### PR TITLE
Allow libraries that implement __array_ufunc__ to override DUFunc.__c…

### DIFF
--- a/docs/source/reference/jit-compilation.rst
+++ b/docs/source/reference/jit-compilation.rst
@@ -346,6 +346,13 @@ Vectorized functions (ufuncs and DUFuncs)
    It is enabled by setting *cache* to True. Only the "cpu" and "parallel"
    targets support caching.
 
+   The ufuncs created by this function respect `NEP-13 <https://numpy.org/neps/nep-0013-ufunc-overrides.html>`_,
+   NumPy's mechanism for overriding ufuncs. If any of the arguments of the
+   ufunc's ``__call__`` have a ``__array_ufunc__`` method, that method will
+   be called (in Python, not the compiled context), which may pre-process
+   and/or post-process the arguments and return value of the compiled ufunc
+   (or might not even call it).
+
 
 .. decorator:: numba.guvectorize(signatures, layout, *, identity=None, nopython=True, target='cpu', forceobj=False, cache=False, locals={})
 

--- a/numba/np/ufunc/dufunc.py
+++ b/numba/np/ufunc/dufunc.py
@@ -174,6 +174,21 @@ class DUFunc(serialize.ReduceMixin, _internal._DUFunc):
         args, return_type = sigutils.normalize_signature(sig)
         return self._compile_for_argtys(args, return_type)
 
+    def __call__(self, *args, **kws):
+        """
+        Allow any argument that has overridden __array_ufunc__ (NEP-18)
+        to take control of DUFunc.__call__.
+        """
+        default = numpy_support.np.ndarray.__array_ufunc__
+
+        for arg in args + tuple(kws.values()):
+            if getattr(type(arg), "__array_ufunc__", default) is not default:
+                output = arg.__array_ufunc__(self, "__call__", *args, **kws)
+                if output is not NotImplemented:
+                    return output
+        else:
+            return super().__call__(*args, **kws)
+
     def _compile_for_args(self, *args, **kws):
         nin = self.ufunc.nin
         if kws:

--- a/numba/tests/npyufunc/test_ufuncbuilding.py
+++ b/numba/tests/npyufunc/test_ufuncbuilding.py
@@ -355,6 +355,75 @@ class TestVectorizeDecor(TestCase):
         # (error message depends on Numpy version)
 
 
+class TestNEP13WithoutSignature(TestCase):
+
+    def test_all(self):
+
+        # note: no signatures specified
+        @vectorize(nopython=True)
+        def new_ufunc(hundreds, tens, ones):
+            return 100*hundreds + 10*tens + ones
+
+        # https://numpy.org/neps/nep-0013-ufunc-overrides.html
+        class NEP13Array:
+            def __init__(self, array):
+                self.array = array
+
+            def __array__(self):
+                return self.array
+
+            def tolist(self):
+                return self.array.tolist()
+
+            def __array_ufunc__(self, ufunc, method, *args, **kwargs):
+                if method != "__call__":
+                    return NotImplemented
+
+                return NEP13Array(ufunc(*[np.asarray(x) for x in args], **kwargs))
+
+        # give it integers
+        a = np.array([1, 2, 3], dtype=np.int64)
+        b = np.array([4, 5, 6], dtype=np.int64)
+        c = np.array([7, 8, 9], dtype=np.int64)
+
+        all_np = new_ufunc(a, b, c)
+        assert isinstance(all_np, np.ndarray)
+        assert all_np.tolist() == [147, 258, 369]
+
+        nep13_1 = new_ufunc(NEP13Array(a), b, c)
+        assert isinstance(nep13_1, NEP13Array)
+        assert nep13_1.tolist() == [147, 258, 369]
+
+        nep13_2 = new_ufunc(a, NEP13Array(b), c)
+        assert isinstance(nep13_2, NEP13Array)
+        assert nep13_2.tolist() == [147, 258, 369]
+
+        nep13_3 = new_ufunc(a, b, NEP13Array(c))
+        assert isinstance(nep13_3, NEP13Array)
+        assert nep13_3.tolist() == [147, 258, 369]
+
+        # give it floats
+        a = np.array([1.1, 2.2, 3.3], dtype=np.float64)
+        b = np.array([4.4, 5.5, 6.6], dtype=np.float64)
+        c = np.array([7.7, 8.8, 9.9], dtype=np.float64)
+
+        all_np = new_ufunc(a, b, c)
+        assert isinstance(all_np, np.ndarray)
+        assert all_np.tolist() == [161.7, 283.8, 405.9]
+
+        nep13_1 = new_ufunc(NEP13Array(a), b, c)
+        assert isinstance(nep13_1, NEP13Array)
+        assert nep13_1.tolist() == [161.7, 283.8, 405.9]
+
+        nep13_2 = new_ufunc(a, NEP13Array(b), c)
+        assert isinstance(nep13_2, NEP13Array)
+        assert nep13_2.tolist() == [161.7, 283.8, 405.9]
+
+        nep13_3 = new_ufunc(a, b, NEP13Array(c))
+        assert isinstance(nep13_3, NEP13Array)
+        assert nep13_3.tolist() == [161.7, 283.8, 405.9]
+
+
 class TestVectorizeDecorJitDisabled(TestVectorizeDecor):
 
     def setUp(self):

--- a/numba/tests/npyufunc/test_ufuncbuilding.py
+++ b/numba/tests/npyufunc/test_ufuncbuilding.py
@@ -387,20 +387,20 @@ class TestNEP13WithoutSignature(TestCase):
         c = np.array([7, 8, 9], dtype=np.int64)
 
         all_np = new_ufunc(a, b, c)
-        assert isinstance(all_np, np.ndarray)
-        assert all_np.tolist() == [147, 258, 369]
+        self.assertIsInstance(all_np, np.ndarray)
+        self.assertEqual(all_np.tolist(), [147, 258, 369])
 
         nep13_1 = new_ufunc(NEP13Array(a), b, c)
-        assert isinstance(nep13_1, NEP13Array)
-        assert nep13_1.tolist() == [147, 258, 369]
+        self.assertIsInstance(nep13_1, NEP13Array)
+        self.assertEqual(nep13_1.tolist(), [147, 258, 369])
 
         nep13_2 = new_ufunc(a, NEP13Array(b), c)
-        assert isinstance(nep13_2, NEP13Array)
-        assert nep13_2.tolist() == [147, 258, 369]
+        self.assertIsInstance(nep13_2, NEP13Array)
+        self.assertEqual(nep13_2.tolist(), [147, 258, 369])
 
         nep13_3 = new_ufunc(a, b, NEP13Array(c))
-        assert isinstance(nep13_3, NEP13Array)
-        assert nep13_3.tolist() == [147, 258, 369]
+        self.assertIsInstance(nep13_3, NEP13Array)
+        self.assertEqual(nep13_3.tolist(), [147, 258, 369])
 
         # give it floats
         a = np.array([1.1, 2.2, 3.3], dtype=np.float64)
@@ -408,20 +408,20 @@ class TestNEP13WithoutSignature(TestCase):
         c = np.array([7.7, 8.8, 9.9], dtype=np.float64)
 
         all_np = new_ufunc(a, b, c)
-        assert isinstance(all_np, np.ndarray)
-        assert all_np.tolist() == [161.7, 283.8, 405.9]
+        self.assertIsInstance(all_np, np.ndarray)
+        self.assertEqual(all_np.tolist(), [161.7, 283.8, 405.9])
 
         nep13_1 = new_ufunc(NEP13Array(a), b, c)
-        assert isinstance(nep13_1, NEP13Array)
-        assert nep13_1.tolist() == [161.7, 283.8, 405.9]
+        self.assertIsInstance(nep13_1, NEP13Array)
+        self.assertEqual(nep13_1.tolist(), [161.7, 283.8, 405.9])
 
         nep13_2 = new_ufunc(a, NEP13Array(b), c)
-        assert isinstance(nep13_2, NEP13Array)
-        assert nep13_2.tolist() == [161.7, 283.8, 405.9]
+        self.assertIsInstance(nep13_2, NEP13Array)
+        self.assertEqual(nep13_2.tolist(), [161.7, 283.8, 405.9])
 
         nep13_3 = new_ufunc(a, b, NEP13Array(c))
-        assert isinstance(nep13_3, NEP13Array)
-        assert nep13_3.tolist() == [161.7, 283.8, 405.9]
+        self.assertIsInstance(nep13_3, NEP13Array)
+        self.assertEqual(nep13_3.tolist(), [161.7, 283.8, 405.9])
 
 
 class TestVectorizeDecorJitDisabled(TestVectorizeDecor):


### PR DESCRIPTION
This PR addresses a long-standing issue in which array-like objects that define an `__array_ufunc__` method ([NEP-18](https://numpy.org/neps/nep-0013-ufunc-overrides.html)) can't be used with ufuncs created by `np.vectorize` unless a signature is provided. (I should have done this years ago!)

For instance, in Awkward Array,

```python
>>> import awkward as ak
>>> import numba as nb

>>> nb.vectorize([nb.float64(nb.float64)])(lambda x: x + 1)(ak.Array([[1.1, 2.2, 3.3], [], [4.4, 5.5]]))
<Array [[2.1, 3.2, 4.3], [], [5.4, 6.5]] type='3 * var * float64'>
```

but

```python
>>> nb.vectorize()(lambda x: x + 1)(ak.Array([[1.1, 2.2, 3.3], [], [4.4, 5.5]]))
<stdin>:1: NumbaWarning: 
Compilation is falling back to object mode WITHOUT looplifting enabled because Function "<lambda>" failed type inference due to: non-precise type pyobject
During: typing of argument at <stdin> (1)

File "<stdin>", line 1:
<source missing, REPL/exec in use?>

/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/core/object_mode_passes.py:151: NumbaWarning: Function "<lambda>" was compiled in object mode without forceobj=True.

File "<stdin>", line 1:
<source missing, REPL/exec in use?>

  warnings.warn(errors.NumbaWarning(warn_msg,
/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/core/object_mode_passes.py:161: NumbaDeprecationWarning: 
Fall-back from the nopython compilation path to the object mode compilation path has been detected. This is deprecated behaviour that will be removed in Numba 0.59.0.

For more information visit https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-object-mode-fall-back-behaviour-when-using-jit

File "<stdin>", line 1:
<source missing, REPL/exec in use?>

  warnings.warn(errors.NumbaDeprecationWarning(msg,
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/np/ufunc/dufunc.py", line 206, in _compile_for_args
    return self._compile_for_argtys(tuple(argtys))
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/np/ufunc/dufunc.py", line 225, in _compile_for_argtys
    actual_sig = ufuncbuilder._finalize_ufunc_signature(
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/np/ufunc/ufuncbuilder.py", line 189, in _finalize_ufunc_signature
    raise TypeError("return type must be specified for object mode")
TypeError: return type must be specified for object mode
```

and even if we pass `nopython=True`,

```python
>>> nb.vectorize(nopython=True)(lambda x: x + 1)(ak.Array([[1.1, 2.2, 3.3], [], [4.4, 5.5]]))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/np/ufunc/dufunc.py", line 206, in _compile_for_args
    return self._compile_for_argtys(tuple(argtys))
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/np/ufunc/dufunc.py", line 223, in _compile_for_argtys
    cres, argtys, return_type = ufuncbuilder._compile_element_wise_function(
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/np/ufunc/ufuncbuilder.py", line 176, in _compile_element_wise_function
    cres = nb_func.compile(sig, **targetoptions)
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/np/ufunc/ufuncbuilder.py", line 124, in compile
    return self._compile_core(sig, flags, locals)
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/np/ufunc/ufuncbuilder.py", line 157, in _compile_core
    cres = compiler.compile_extra(typingctx, targetctx,
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/core/compiler.py", line 742, in compile_extra
    return pipeline.compile_extra(func)
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/core/compiler.py", line 460, in compile_extra
    return self._compile_bytecode()
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/core/compiler.py", line 528, in _compile_bytecode
    return self._compile_core()
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/core/compiler.py", line 507, in _compile_core
    raise e
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/core/compiler.py", line 494, in _compile_core
    pm.run(self.state)
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/core/compiler_machinery.py", line 368, in run
    raise patched_exception
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/core/compiler_machinery.py", line 356, in run
    self._runPass(idx, pass_inst, state)
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/core/compiler_lock.py", line 35, in _acquire_compile_lock
    return func(*args, **kwargs)
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/core/compiler_machinery.py", line 311, in _runPass
    mutated |= check(pss.run_pass, internal_state)
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/core/compiler_machinery.py", line 273, in check
    mangled = func(compiler_state)
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/core/typed_passes.py", line 110, in run_pass
    typemap, return_type, calltypes, errs = type_inference_stage(
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/core/typed_passes.py", line 88, in type_inference_stage
    errs = infer.propagate(raise_errors=raise_errors)
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/core/typeinfer.py", line 1086, in propagate
    raise errors[0]
numba.core.errors.TypingError: Failed in nopython mode pipeline (step: nopython frontend)
non-precise type pyobject
During: typing of argument at <stdin> (1)

File "<stdin>", line 1:
<source missing, REPL/exec in use?>
```

Similarly, with the Sparse library,

```python
>>> import numpy as np
>>> import sparse
>>> x = np.random.random((100, 100, 100))
>>> x[x < 0.9] = 0
>>> s = sparse.COO(x)

>>> nb.vectorize([nb.float64(nb.float64)], nopython=True)(lambda x: x + 100)(s)
<COO: shape=(100, 100, 100), dtype=float64, nnz=99450, fill_value=100.0>

>>> nb.vectorize([nb.float64(nb.float64)], nopython=True)(lambda x: x + 100)(s)[:2, :5, :8].todense()
array([[[100.        , 100.        , 100.        , 100.        ,
         100.        , 100.        , 100.        , 100.        ],
        [100.        , 100.        , 100.        , 100.        ,
         100.        , 100.        , 100.        , 100.        ],
        [100.        , 100.        , 100.        , 100.        ,
         100.        , 100.        , 100.        , 100.98842074],
        [100.        , 100.        , 100.        , 100.        ,
         100.        , 100.        , 100.        , 100.        ],
        [100.        , 100.        , 100.        , 100.        ,
         100.        , 100.99039874, 100.        , 100.        ]],

       [[100.        , 100.        , 100.        , 100.        ,
         100.        , 100.        , 100.        , 100.        ],
        [100.        , 100.        , 100.        , 100.        ,
         100.        , 100.        , 100.        , 100.        ],
        [100.        , 100.        , 100.        , 100.        ,
         100.        , 100.        , 100.99464796, 100.        ],
        [100.        , 100.        , 100.        , 100.        ,
         100.        , 100.        , 100.        , 100.        ],
        [100.        , 100.        , 100.        , 100.        ,
         100.        , 100.        , 100.95169938, 100.        ]]])
```

but

```python
>>> nb.vectorize()(lambda x: x + 100)(s)
<stdin>:1: NumbaWarning: 
Compilation is falling back to object mode WITHOUT looplifting enabled because Function "<lambda>" failed type inference due to: non-precise type pyobject
During: typing of argument at <stdin> (1)

File "<stdin>", line 1:
<source missing, REPL/exec in use?>

/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/core/object_mode_passes.py:151: NumbaWarning: Function "<lambda>" was compiled in object mode without forceobj=True.

File "<stdin>", line 1:
<source missing, REPL/exec in use?>

  warnings.warn(errors.NumbaWarning(warn_msg,
/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/core/object_mode_passes.py:161: NumbaDeprecationWarning: 
Fall-back from the nopython compilation path to the object mode compilation path has been detected. This is deprecated behaviour that will be removed in Numba 0.59.0.

For more information visit https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-object-mode-fall-back-behaviour-when-using-jit

File "<stdin>", line 1:
<source missing, REPL/exec in use?>

  warnings.warn(errors.NumbaDeprecationWarning(msg,
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/np/ufunc/dufunc.py", line 206, in _compile_for_args
    return self._compile_for_argtys(tuple(argtys))
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/np/ufunc/dufunc.py", line 225, in _compile_for_argtys
    actual_sig = ufuncbuilder._finalize_ufunc_signature(
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/np/ufunc/ufuncbuilder.py", line 189, in _finalize_ufunc_signature
    raise TypeError("return type must be specified for object mode")
TypeError: return type must be specified for object mode
```

and

```python
>>> nb.vectorize(nopython=True)(lambda x: x + 100)(s)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/np/ufunc/dufunc.py", line 206, in _compile_for_args
    return self._compile_for_argtys(tuple(argtys))
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/np/ufunc/dufunc.py", line 223, in _compile_for_argtys
    cres, argtys, return_type = ufuncbuilder._compile_element_wise_function(
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/np/ufunc/ufuncbuilder.py", line 176, in _compile_element_wise_function
    cres = nb_func.compile(sig, **targetoptions)
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/np/ufunc/ufuncbuilder.py", line 124, in compile
    return self._compile_core(sig, flags, locals)
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/np/ufunc/ufuncbuilder.py", line 157, in _compile_core
    cres = compiler.compile_extra(typingctx, targetctx,
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/core/compiler.py", line 742, in compile_extra
    return pipeline.compile_extra(func)
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/core/compiler.py", line 460, in compile_extra
    return self._compile_bytecode()
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/core/compiler.py", line 528, in _compile_bytecode
    return self._compile_core()
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/core/compiler.py", line 507, in _compile_core
    raise e
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/core/compiler.py", line 494, in _compile_core
    pm.run(self.state)
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/core/compiler_machinery.py", line 368, in run
    raise patched_exception
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/core/compiler_machinery.py", line 356, in run
    self._runPass(idx, pass_inst, state)
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/core/compiler_lock.py", line 35, in _acquire_compile_lock
    return func(*args, **kwargs)
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/core/compiler_machinery.py", line 311, in _runPass
    mutated |= check(pss.run_pass, internal_state)
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/core/compiler_machinery.py", line 273, in check
    mangled = func(compiler_state)
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/core/typed_passes.py", line 110, in run_pass
    typemap, return_type, calltypes, errs = type_inference_stage(
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/core/typed_passes.py", line 88, in type_inference_stage
    errs = infer.propagate(raise_errors=raise_errors)
  File "/home/jpivarski/mambaforge/lib/python3.9/site-packages/numba/core/typeinfer.py", line 1086, in propagate
    raise errors[0]
numba.core.errors.TypingError: Failed in nopython mode pipeline (step: nopython frontend)
non-precise type pyobject
During: typing of argument at <stdin> (1)

File "<stdin>", line 1:
<source missing, REPL/exec in use?>
```

However, with this PR, ufuncs created with `@nb.vectorize` and no type signature are recognized by Awkward Array:

```python
>>> nb.vectorize()(lambda x: x + 1)(ak.Array([[1.1, 2.2, 3.3], [], [4.4, 5.5]]))
<Array [[2.1, 3.2, 4.3], [], [5.4, 6.5]] type='3 * var * float64'>

>>> nb.vectorize(nopython=True)(lambda x: x + 1)(ak.Array([[1.1, 2.2, 3.3], [], [4.4, 5.5]]))
<Array [[2.1, 3.2, 4.3], [], [5.4, 6.5]] type='3 * var * float64'>
```

and Sparse:

```python
>>> nb.vectorize()(lambda x: x + 100)(s)
<COO: shape=(100, 100, 100), dtype=float64, nnz=100594, fill_value=100.0>

>>> nb.vectorize()(lambda x: x + 100)(s)[:2, :5, :8].todense()
array([[[100.        , 100.        , 100.        , 100.        ,
         100.        , 100.        , 100.        , 100.        ],
        [100.        , 100.        , 100.        , 100.        ,
         100.        , 100.        , 100.        , 100.96245334],
        [100.        , 100.        , 100.        , 100.        ,
         100.        , 100.        , 100.        , 100.        ],
        [100.        , 100.        , 100.        , 100.        ,
         100.        , 100.        , 100.        , 100.        ],
        [100.        , 100.        , 100.        , 100.        ,
         100.        , 100.        , 100.        , 100.        ]],

       [[100.        , 100.        , 100.        , 100.        ,
         100.        , 100.99515858, 100.        , 100.        ],
        [100.        , 100.        , 100.        , 100.        ,
         100.        , 100.        , 100.        , 100.        ],
        [100.        , 100.        , 100.95034604, 100.        ,
         100.        , 100.        , 100.        , 100.        ],
        [100.        , 100.96199577, 100.        , 100.        ,
         100.        , 100.        , 100.        , 100.        ],
        [100.        , 100.        , 100.        , 100.        ,
         100.        , 100.        , 100.        , 100.        ]]])
```

It's because `__array_ufunc__` methods are usually implemented by pre- and post-processing the result of applying the ufunc to some underlying NumPy array. If an `__array_ufunc__` method is implemented some other way, without Numba-compatible objects at any level, then `@nb.vectorize`-decorated functions wouldn't work with it, anyway.

This is a draft PR because:

> 1. Please ensure that you have written units tests for the changes made/features added.

Some thought will be needed to know what kinds of tests would be appropriate. This mostly affects libraries that use Numba. Maybe a little class that implements `__array_ufunc__`?

> 2. If you are closing an issue please use one of the automatic closing words as noted here: https://help.github.com/articles/closing-issues-using-keywords/

It could be related to #6678, #4625, and/or #2979. For completeness, the PR in its current state only addresses ufunc's `__call__` method; perhaps we want `accumulate`, `at`, `outer`, `reduce`, and `reduceat` as well. Also, it only addresses `np.vectorize`; maybe something similar is needed for `np.guvectorize`.

I'm leaving it in this simple state so that I can get feedback about whether this is the right direction before proceeding to generalize it. (Also, which generalizations are important?)