### PR TITLE
Fix: Issue #8923 - avoid spurious device-to-host transfers in CUDA ufuncs

### DIFF
--- a/numba/cuda/tests/cudapy/test_vectorize.py
+++ b/numba/cuda/tests/cudapy/test_vectorize.py
@@ -229,12 +229,18 @@ class TestCUDAVectorize(CUDATestCase):
         self.assertEqual(bar.__name__, 'bar')
 
     def test_no_transfer_for_device_data(self):
+        # Initialize test data on the device prior to banning host <-> device
+        # transfer
+
         noise = np.random.randn(1, 3, 64, 64).astype(np.float32)
         noise = cuda.to_device(noise)
 
         # A mock of a CUDA function that always raises a CudaAPIError
+
         def raising_transfer(*args, **kwargs):
             raise CudaAPIError(999, 'Transfer not allowed')
+
+        # Use the mock for transfers between the host and device
 
         old_HtoD = getattr(driver, 'cuMemcpyHtoD', None)
         old_DtoH = getattr(driver, 'cuMemcpyDtoH', None)
@@ -242,21 +248,35 @@ class TestCUDAVectorize(CUDATestCase):
         setattr(driver, 'cuMemcpyHtoD', raising_transfer)
         setattr(driver, 'cuMemcpyDtoH', raising_transfer)
 
+        # Ensure that the mock functions are working as expected
+
+        with self.assertRaisesRegex(CudaAPIError, "Transfer not allowed"):
+            noise.copy_to_host()
+
+        with self.assertRaisesRegex(CudaAPIError, "Transfer not allowed"):
+            cuda.to_device([1])
+
         try:
+            # Check that defining and calling a ufunc with data on the device
+            # induces no transfers
+
             @vectorize(['float32(float32)'], target='cuda')
             def func(noise):
                 return noise + 1.0
 
             func(noise)
         finally:
+            # Replace our mocks with the original implementations. If there was
+            # no original implementation, simply remove ours.
+
             if old_HtoD is not None:
                 setattr(driver, 'cuMemcpyHtoD', old_HtoD)
             else:
-                del driver.cuMemcpyHtoD_v2
+                del driver.cuMemcpyHtoD
             if old_DtoH is not None:
                 setattr(driver, 'cuMemcpyDtoH', old_DtoH)
             else:
-                del driver.cuMemcpyDtoH_v2
+                del driver.cuMemcpyDtoH
 
 
 if __name__ == '__main__':

--- a/numba/np/ufunc/deviceufunc.py
+++ b/numba/np/ufunc/deviceufunc.py
@@ -105,7 +105,10 @@ class UFuncMechanism(object):
         """
         for i, ary in enumerate(self.arrays):
             if ary is not None:
-                self.argtypes[i] = np.asarray(ary).dtype
+                dtype = getattr(ary, 'dtype')
+                if dtype is None:
+                    dtype = np.asarray(ary).dtype
+                self.argtypes[i] = dtype
 
     def _resolve_signature(self):
         """Resolve signature.


### PR DESCRIPTION
Only convert an object to a NumPy array when we can't work out the dtype, so that we don't end up converting all arguments to NumPy arrays on the host.

Fixes Issue https://github.com/numba/numba/issues/8923.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
