### PR TITLE
Split find_top_level_loops into two functions.

### DIFF
--- a/numba/core/analysis.py
+++ b/numba/core/analysis.py
@@ -247,20 +247,25 @@ def compute_cfg_from_blocks(blocks):
     return cfg
 
 
-def find_top_level_loops(cfg):
-    """
-    A generator that yields toplevel loops given a control-flow-graph
-    """
+def filter_nested_loops(cfg, loops):
     blocks_in_loop = set()
     # get loop bodies
-    for loop in cfg.loops().values():
+    for loop in loops.values():
         insiders = set(loop.body) | set(loop.entries) | set(loop.exits)
         insiders.discard(loop.header)
         blocks_in_loop |= insiders
     # find loop that is not part of other loops
-    for loop in cfg.loops().values():
+    for loop in loops.values():
         if loop.header not in blocks_in_loop:
             yield _fix_loop_exit(cfg, loop)
+
+
+def find_top_level_loops(cfg, loops=None):
+    """
+    A generator that yields toplevel loops given a control-flow-graph
+    """
+    loops = cfg.loops()
+    filter_nested_loops(cfg, loops)
 
 
 def _fix_loop_exit(cfg, loop):


### PR DESCRIPTION
The current function gets all the loops in the cfg and then filter the nested ones.  In pyomp, we have the need to filter top level loops but not from all the loops in the function but a certain set.  So, to act better as a compiler toolkit, I propose splitting this function as in the PR.  Since this is just a refactor I didn't add any tests.