### PR TITLE
Change a bunch of var names created during lowering to start with a period.

### DIFF
--- a/numba/core/pythonapi.py
+++ b/numba/core/pythonapi.py
@@ -827,11 +827,11 @@ class PythonAPI(object):
     def set_iterate(self, set):
         builder = self.builder
 
-        hashptr = cgutils.alloca_once(builder, self.py_hash_t, name="hashptr")
-        keyptr = cgutils.alloca_once(builder, self.pyobj, name="keyptr")
+        hashptr = cgutils.alloca_once(builder, self.py_hash_t, name=".hashptr")
+        keyptr = cgutils.alloca_once(builder, self.pyobj, name=".keyptr")
         posptr = cgutils.alloca_once_value(builder,
                                            Constant(self.py_ssize_t, 0),
-                                           name="posptr")
+                                           name=".posptr")
 
         bb_body = builder.append_basic_block("bb_body")
         bb_end = builder.append_basic_block("bb_end")

--- a/numba/cpython/mathimpl.py
+++ b/numba/cpython/mathimpl.py
@@ -261,7 +261,7 @@ def frexp_impl(context, builder, sig, args):
     val, = args
     fltty = context.get_data_type(sig.args[0])
     intty = context.get_data_type(sig.return_type[1])
-    expptr = cgutils.alloca_once(builder, intty, name='exp')
+    expptr = cgutils.alloca_once(builder, intty, name='.exp')
     fnty = llvmlite.ir.FunctionType(fltty, (fltty, llvmlite.ir.PointerType(intty)))
     fname = {
         "float": "numba_frexpf",

--- a/numba/cpython/numbers.py
+++ b/numba/cpython/numbers.py
@@ -135,8 +135,8 @@ def _int_divmod_impl(context, builder, sig, args, zerodiv_message):
         ty = ty.dtype
     a = context.cast(builder, va, ta, ty)
     b = context.cast(builder, vb, tb, ty)
-    quot = cgutils.alloca_once(builder, a.type, name="quot")
-    rem = cgutils.alloca_once(builder, a.type, name="rem")
+    quot = cgutils.alloca_once(builder, a.type, name=".quot")
+    rem = cgutils.alloca_once(builder, a.type, name=".rem")
 
     with builder.if_else(cgutils.is_scalar_zero(builder, b), likely=False
                          ) as (if_zero, if_non_zero):
@@ -734,8 +734,8 @@ def real_divmod_func_body(context, builder, vx, wx):
 @lower_builtin(divmod, types.Float, types.Float)
 def real_divmod_impl(context, builder, sig, args, loc=None):
     x, y = args
-    quot = cgutils.alloca_once(builder, x.type, name="quot")
-    rem = cgutils.alloca_once(builder, x.type, name="rem")
+    quot = cgutils.alloca_once(builder, x.type, name=".quot")
+    rem = cgutils.alloca_once(builder, x.type, name=".rem")
 
     with builder.if_else(cgutils.is_scalar_zero(builder, y), likely=False
                          ) as (if_zero, if_non_zero):

--- a/numba/cpython/randomimpl.py
+++ b/numba/cpython/randomimpl.py
@@ -371,7 +371,7 @@ def _gauss_impl(state, loc_preprocessor, scale_preprocessor):
 
         state_ptr = get_state_ptr(context, builder, state)
 
-        ret = cgutils.alloca_once(builder, llty, name="result")
+        ret = cgutils.alloca_once(builder, llty, name=".result")
 
         gauss_ptr = get_gauss_ptr(builder, state_ptr)
         has_gauss_ptr = get_has_gauss_ptr(builder, state_ptr)
@@ -443,7 +443,7 @@ def _randrange_impl(context, builder, start, stop, step, ty, signed, state):
     state_ptr = get_state_ptr(context, builder, state)
     zero = ir.Constant(ty, 0)
     one = ir.Constant(ty, 1)
-    nptr = cgutils.alloca_once(builder, ty, name="n")
+    nptr = cgutils.alloca_once(builder, ty, name=".n")
 
     # n = stop - start
     builder.store(builder.sub(stop, start), nptr)
@@ -480,7 +480,7 @@ def _randrange_impl(context, builder, start, stop, step, ty, signed, state):
     nbits = builder.trunc(builder.call(fn, [nm1, cgutils.true_bit]), int32_t)
     nbits = builder.sub(ir.Constant(int32_t, ty.width), nbits)
 
-    rptr = cgutils.alloca_once(builder, ty, name="r")
+    rptr = cgutils.alloca_once(builder, ty, name=".r")
 
     def get_num():
         bbwhile = builder.append_basic_block("while")
@@ -1568,7 +1568,7 @@ def poisson_impl1(lam):
             def codegen(context, builder, sig, args):
                 state_ptr = get_np_state_ptr(context, builder)
 
-                retptr = cgutils.alloca_once(builder, int64_t, name="ret")
+                retptr = cgutils.alloca_once(builder, int64_t, name=".ret")
                 bbcont = builder.append_basic_block("bbcont")
                 bbend = builder.append_basic_block("bbend")
 

--- a/numba/cpython/unicode_support.py
+++ b/numba/cpython/unicode_support.py
@@ -108,12 +108,12 @@ def _gettyperecord_impl(typingctx, codepoint):
         fn = cgutils.get_or_insert_function(
             builder.module,
             fnty, name="numba_gettyperecord")
-        upper = cgutils.alloca_once(builder, ll_intc, name='upper')
-        lower = cgutils.alloca_once(builder, ll_intc, name='lower')
-        title = cgutils.alloca_once(builder, ll_intc, name='title')
-        decimal = cgutils.alloca_once(builder, ll_uchar, name='decimal')
-        digit = cgutils.alloca_once(builder, ll_uchar, name='digit')
-        flags = cgutils.alloca_once(builder, ll_ushort, name='flags')
+        upper = cgutils.alloca_once(builder, ll_intc, name='.upper')
+        lower = cgutils.alloca_once(builder, ll_intc, name='.lower')
+        title = cgutils.alloca_once(builder, ll_intc, name='.title')
+        decimal = cgutils.alloca_once(builder, ll_uchar, name='.decimal')
+        digit = cgutils.alloca_once(builder, ll_uchar, name='.digit')
+        flags = cgutils.alloca_once(builder, ll_ushort, name='.flags')
 
         byref = [ upper, lower, title, decimal, digit, flags]
         builder.call(fn, [args[0]] + byref)

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -114,7 +114,7 @@ def cuda_shared_array_integer(context, builder, sig, args):
     length = sig.args[0].literal_value
     dtype = parse_dtype(sig.args[1])
     return _generic_array(context, builder, shape=(length,), dtype=dtype,
-                          symbol_name=_get_unique_smem_id('_cudapy_smem'),
+                          symbol_name=_get_unique_smem_id('._cudapy_smem'),
                           addrspace=nvvm.ADDRSPACE_SHARED,
                           can_dynsized=True)
 
@@ -125,7 +125,7 @@ def cuda_shared_array_tuple(context, builder, sig, args):
     shape = [ s.literal_value for s in sig.args[0] ]
     dtype = parse_dtype(sig.args[1])
     return _generic_array(context, builder, shape=shape, dtype=dtype,
-                          symbol_name=_get_unique_smem_id('_cudapy_smem'),
+                          symbol_name=_get_unique_smem_id('._cudapy_smem'),
                           addrspace=nvvm.ADDRSPACE_SHARED,
                           can_dynsized=True)
 
@@ -135,7 +135,7 @@ def cuda_local_array_integer(context, builder, sig, args):
     length = sig.args[0].literal_value
     dtype = parse_dtype(sig.args[1])
     return _generic_array(context, builder, shape=(length,), dtype=dtype,
-                          symbol_name='_cudapy_lmem',
+                          symbol_name='._cudapy_lmem',
                           addrspace=nvvm.ADDRSPACE_LOCAL,
                           can_dynsized=False)
 
@@ -146,7 +146,7 @@ def ptx_lmem_alloc_array(context, builder, sig, args):
     shape = [ s.literal_value for s in sig.args[0] ]
     dtype = parse_dtype(sig.args[1])
     return _generic_array(context, builder, shape=shape, dtype=dtype,
-                          symbol_name='_cudapy_lmem',
+                          symbol_name='._cudapy_lmem',
                           addrspace=nvvm.ADDRSPACE_LOCAL,
                           can_dynsized=False)
 

--- a/numba/np/npdatetime.py
+++ b/numba/np/npdatetime.py
@@ -76,7 +76,7 @@ def normalize_timedeltas(context, builder, left, right, leftty, rightty):
     raise RuntimeError("cannot normalize %r and %r" % (leftty, rightty))
 
 
-def alloc_timedelta_result(builder, name='ret'):
+def alloc_timedelta_result(builder, name='.ret'):
     """
     Allocate a NaT-initialized datetime64 (or timedelta64) result slot.
     """
@@ -85,7 +85,7 @@ def alloc_timedelta_result(builder, name='ret'):
     return ret
 
 
-def alloc_boolean_result(builder, name='ret'):
+def alloc_boolean_result(builder, name='.ret'):
     """
     Allocate an uninitialized boolean result slot.
     """
@@ -285,7 +285,7 @@ def timedelta_over_timedelta(context, builder, sig, args):
     [ta, tb] = sig.args
     not_nan = are_not_nat(builder, [va, vb])
     ll_ret_type = context.get_value_type(sig.return_type)
-    ret = cgutils.alloca_once(builder, ll_ret_type, name='ret')
+    ret = cgutils.alloca_once(builder, ll_ret_type, name='.ret')
     builder.store(Constant(ll_ret_type, float('nan')), ret)
     with cgutils.if_likely(builder, not_nan):
         va, vb = normalize_timedeltas(context, builder, va, vb, ta, tb)
@@ -302,7 +302,7 @@ def timedelta_floor_div_timedelta(context, builder, sig, args):
     [ta, tb] = sig.args
     ll_ret_type = context.get_value_type(sig.return_type)
     not_nan = are_not_nat(builder, [va, vb])
-    ret = cgutils.alloca_once(builder, ll_ret_type, name='ret')
+    ret = cgutils.alloca_once(builder, ll_ret_type, name='.ret')
     zero = Constant(ll_ret_type, 0)
     one = Constant(ll_ret_type, 1)
     builder.store(zero, ret)

--- a/numba/np/ufunc/wrappers.py
+++ b/numba/np/ufunc/wrappers.py
@@ -531,7 +531,7 @@ def _prepare_call_to_object_mode(context, builder, pyapi, func,
                                                   "numba_ndarray_new")
 
     # Convert each llarray into pyobject
-    error_pointer = cgutils.alloca_once(builder, ir.IntType(1), name='error')
+    error_pointer = cgutils.alloca_once(builder, ir.IntType(1), name='.error')
     builder.store(cgutils.true_bit, error_pointer)
 
     # The PyObject* arguments to the kernel function

--- a/numba/parfors/parfor_lowering.py
+++ b/numba/parfors/parfor_lowering.py
@@ -1691,10 +1691,10 @@ def call_parallel_gufunc(lowerer, cres, gu_signature, outer_sig, expr_args, expr
     # Call do_scheduling with appropriate arguments
     dim_starts = cgutils.alloca_once(
         builder, sched_type, size=context.get_constant(
-            types.uintp, num_dim), name="dim_starts")
+            types.uintp, num_dim), name=".dim_starts")
     dim_stops = cgutils.alloca_once(
         builder, sched_type, size=context.get_constant(
-            types.uintp, num_dim), name="dim_stops")
+            types.uintp, num_dim), name=".dim_stops")
     for i in range(num_dim):
         start, stop, step = loop_ranges[i]
         if start.type != one_type:
@@ -1807,7 +1807,7 @@ def call_parallel_gufunc(lowerer, cres, gu_signature, outer_sig, expr_args, expr
         size=context.get_constant(
             types.intp,
             1 + num_args),
-        name="pargs")
+        name=".pargs")
     array_strides = []
     # sched goes first
     builder.store(builder.bitcast(sched, byte_ptr_t), args)
@@ -1906,7 +1906,7 @@ def call_parallel_gufunc(lowerer, cres, gu_signature, outer_sig, expr_args, expr
     # Prepare shapes, which is a single number (outer loop size), followed by
     # the size of individual shape variables.
     nshapes = len(sig_dim_dict) + 1
-    shapes = cgutils.alloca_once(builder, intp_t, size=nshapes, name="pshape")
+    shapes = cgutils.alloca_once(builder, intp_t, size=nshapes, name=".pshape")
     # For now, outer loop size is the same as number of threads
     builder.store(num_divisions, shapes)
     # Individual shape variables go next
@@ -1927,7 +1927,7 @@ def call_parallel_gufunc(lowerer, cres, gu_signature, outer_sig, expr_args, expr
     num_steps = num_args + 1 + len(array_strides)
     steps = cgutils.alloca_once(
         builder, intp_t, size=context.get_constant(
-            types.intp, num_steps), name="psteps")
+            types.intp, num_steps), name=".psteps")
     # First goes the step size for sched, which is 2 * num_dim
     builder.store(context.get_constant(types.intp, 2 * num_dim * sizeof_intp),
                   steps)


### PR DESCRIPTION
Numba is supposed to use a convention that vars introduced during Numba passes start with $ and LLVM vars introduced during lowering start with a period.  There were a bunch of cases where vars introduced during lowering don't start with a period.  PyOMP relies on this convention.