### PR TITLE
Replace use of imp module removed in 3.12

### DIFF
--- a/numba/tests/test_llvm_version_check.py
+++ b/numba/tests/test_llvm_version_check.py
@@ -1,4 +1,4 @@
-import imp
+import importlib
 import sys
 
 import unittest
@@ -29,13 +29,13 @@ class TestLlvmVersion(unittest.TestCase):
         ver_fail = (version_fail, git_version_fail)
         for v in ver_pass:
             llvmlite.__version__ = v
-            imp.reload(numba)
+            importlib.reload(numba)
             self.assertTrue(numba.__version__)
 
         for v in ver_fail:
             with self.assertRaises(ImportError):
                 llvmlite.__version__ = v
-                imp.reload(numba)
+                importlib.reload(numba)
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_pycc.py
+++ b/numba/tests/test_pycc.py
@@ -1,5 +1,5 @@
 import contextlib
-import imp
+import importlib
 import os
 import shutil
 import subprocess
@@ -94,7 +94,7 @@ class TestCC(BasePYCCTest):
         self.skip_if_no_external_compiler() # external compiler needed
         from numba.tests import compile_with_pycc
         self._test_module = compile_with_pycc
-        imp.reload(self._test_module)
+        importlib.reload(self._test_module)
 
     @contextlib.contextmanager
     def check_cc_compiled(self, cc):


### PR DESCRIPTION
Fixes #8933

This is exactly the same:
https://github.com/python/cpython/blob/3.11/Lib/imp.py#L315