### PR TITLE
CUDA libs test: Report the absolute path of the loaded libcuda.so on Linux, + other improvements

### DIFF
--- a/docs/upcoming_changes/9034.cuda.rst
+++ b/docs/upcoming_changes/9034.cuda.rst
@@ -1,6 +1,6 @@
 Report absolute path of libcuda.so on Linux
 ===========================================
 
-`numba -s` now reported the absolute path to libcuda.so on Linux, to aid
+``numba -s`` now reports the absolute path to ``libcuda.so`` on Linux, to aid
 troubleshooting driver issues, particularly on WSL2 where a Linux driver can
 incorrectly be installed in the environment.

--- a/docs/upcoming_changes/9034.cuda.rst
+++ b/docs/upcoming_changes/9034.cuda.rst
@@ -1,0 +1,6 @@
+Report absolute path of libcuda.so on Linux
+===========================================
+
+`numba -s` now reported the absolute path to libcuda.so on Linux, to aid
+troubleshooting driver issues, particularly on WSL2 where a Linux driver can
+incorrectly be installed in the environment.

--- a/numba/cuda/cudadrv/libs.py
+++ b/numba/cuda/cudadrv/libs.py
@@ -107,7 +107,7 @@ def test():
     # look up whether the driver was intended for "native" Linux.
     if sys.platform == 'linux' and not failed:
         pid = os.getpid()
-        mapsfile = f'/proc/{pid}/maps'
+        mapsfile = os.path.join('proc', f'{pid}', 'maps')
         try:
             with open(mapsfile) as f:
                 maps = f.read()

--- a/numba/cuda/cudadrv/libs.py
+++ b/numba/cuda/cudadrv/libs.py
@@ -41,7 +41,7 @@ def open_libdevice():
         return bcfile.read()
 
 
-def get_cudalib(lib, platform=None, static=False):
+def get_cudalib(lib, static=False):
     """
     Find the path of a CUDA library based on a search of known locations. If
     the search fails, return a generic filename for the library (e.g.
@@ -54,7 +54,7 @@ def get_cudalib(lib, platform=None, static=False):
         dir_type = 'static_cudalib_dir' if static else 'cudalib_dir'
         libdir = get_cuda_paths()[dir_type].info
 
-    candidates = find_lib(lib, libdir, platform=platform, static=static)
+    candidates = find_lib(lib, libdir, static=static)
     namepattern = _staticnamepattern if static else _dllnamepattern
     return max(candidates) if candidates else namepattern % lib
 
@@ -80,7 +80,7 @@ def _get_source_variable(lib, static=False):
         return get_cuda_paths()[dir_type].by
 
 
-def test(_platform=None, print_paths=True):
+def test():
     """Test library lookup.  Path info is printed to stdout.
     """
     failed = False
@@ -101,31 +101,24 @@ def test(_platform=None, print_paths=True):
     # Checks for dynamic libraries
     libs = 'nvvm cudart'.split()
     for lib in libs:
-        path = get_cudalib(lib, _platform)
+        path = get_cudalib(lib)
         print('Finding {} from {}'.format(lib, _get_source_variable(lib)))
-        if print_paths:
-            print('\tlocated at', path)
-        else:
-            print('\tnamed ', os.path.basename(path))
+        print('\tlocated at', path)
 
-        if _platform in (None, sys.platform):
-            try:
-                print('\ttrying to open library', end='...')
-                open_cudalib(lib)
-                print('\tok')
-            except OSError as e:
-                print('\tERROR: failed to open %s:\n%s' % (lib, e))
-                failed = True
+        try:
+            print('\ttrying to open library', end='...')
+            open_cudalib(lib)
+            print('\tok')
+        except OSError as e:
+            print('\tERROR: failed to open %s:\n%s' % (lib, e))
+            failed = True
 
     # Check for cudadevrt (the only static library)
     lib = 'cudadevrt'
-    path = get_cudalib(lib, _platform, static=True)
+    path = get_cudalib(lib, static=True)
     print('Finding {} from {}'.format(lib, _get_source_variable(lib,
                                                                 static=True)))
-    if print_paths:
-        print('\tlocated at', path)
-    else:
-        print('\tnamed ', os.path.basename(path))
+    print('\tlocated at', path)
 
     try:
         check_static_lib(lib)

--- a/numba/cuda/cudadrv/libs.py
+++ b/numba/cuda/cudadrv/libs.py
@@ -107,7 +107,7 @@ def test():
     # look up whether the driver was intended for "native" Linux.
     if sys.platform == 'linux' and not failed:
         pid = os.getpid()
-        mapsfile = os.path.join('proc', f'{pid}', 'maps')
+        mapsfile = os.path.join(os.path.sep, 'proc', f'{pid}', 'maps')
         try:
             with open(mapsfile) as f:
                 maps = f.read()

--- a/numba/misc/numba_sysinfo.py
+++ b/numba/misc/numba_sysinfo.py
@@ -370,7 +370,7 @@ def get_sysinfo():
 
             output = StringIO()
             with redirect_stdout(output):
-                cudadrv.libs.test(sys.platform, print_paths=False)
+                cudadrv.libs.test()
             sys_info[_cu_lib_test] = output.getvalue()
             output.close()
 


### PR DESCRIPTION
This PR improves the CUDA library test function. The most important change is to report the absolute path of the loaded `libcuda.so` on Linux. 

This motivation is as follows: various driver-related issues have been reported by WSL2 users (see e.g. #9032, #7104, https://github.com/rapidsai/cudf/issues/13388, other questions on Gitter, Slacks, Discourse, etc.) and it is almost always due to a Linux (i.e. not- WSL2) driver being installed in a WSL2 system. Printing the absolute path gives the version number of the driver, which can be looked up to determine whether it was a version intended for "native" Linux, or the correct WSL2 driver.

There are also some minor changes to the tests and output to improve consistency and readability - see individual commit messages for details. 

With these changes, the output of the test function (identically reported by the Numba sysinfo tool, `numba -s`) is, for example:

```
$ python -c "from numba import cuda; cuda.cudadrv.libs.test()"
Finding driver from candidates:
	libcuda.so
	libcuda.so.1
	/usr/lib/libcuda.so
	/usr/lib/libcuda.so.1
	/usr/lib64/libcuda.so
	/usr/lib64/libcuda.so.1
Using loader <class 'ctypes.CDLL'>
	Trying to load driver...	ok
		Loaded from libcuda.so
	Mapped libcuda.so paths:
		/usr/lib/x86_64-linux-gnu/libcuda.so.530.30.02
Finding nvvm from Conda environment
	Located at /home/gmarkall/mambaforge/envs/numbadev/lib/libnvvm.so.4.0.0
	Trying to open library...	ok
Finding cudart from Conda environment
	Located at /home/gmarkall/mambaforge/envs/numbadev/lib/libcudart.so.11.8.89
	Trying to open library...	ok
Finding cudadevrt from Conda environment
	Located at /home/gmarkall/mambaforge/envs/numbadev/lib/libcudadevrt.a
	Checking library...	ok
Finding libdevice from Conda environment
	Located at /home/gmarkall/mambaforge/envs/numbadev/lib/libdevice.10.bc
	Checking library...	ok
```

I would suggest that each commit can be reviewed individually - the changes in each are independent, and commit messages contain further details.
