### PR TITLE
CUDA: Allow for debuginfo in nvdisasm output

### DIFF
--- a/numba/cuda/codegen.py
+++ b/numba/cuda/codegen.py
@@ -13,7 +13,7 @@ import tempfile
 CUDA_TRIPLE = 'nvptx64-nvidia-cuda'
 
 
-def disassemble_cubin(cubin, debuginfo=False):
+def disassemble_cubin(cubin):
     # nvdisasm only accepts input from a file, so we need to write out to a
     # temp file and clean up afterwards.
     fd = None
@@ -24,14 +24,9 @@ def disassemble_cubin(cubin, debuginfo=False):
             f.write(cubin)
 
         try:
-            if debuginfo:
-                cp = subprocess.run(['nvdisasm', '-gi', fname], check=True,
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE)
-            else:
-                cp = subprocess.run(['nvdisasm', fname], check=True,
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE)
+            cp = subprocess.run(['nvdisasm', '-gi', fname], check=True,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
         except FileNotFoundError as e:
             msg = ("nvdisasm is required for SASS inspection, and has not "
                    "been found.\n\nYou may need to install the CUDA "
@@ -203,8 +198,8 @@ class CUDACodeLibrary(serialize.ReduceMixin, CodeLibrary):
         except KeyError:
             raise KeyError(f'No linkerinfo for CC {cc}')
 
-    def get_sass(self, cc=None, debuginfo=False):
-        return disassemble_cubin(self.get_cubin(cc=cc), debuginfo=debuginfo)
+    def get_sass(self, cc=None):
+        return disassemble_cubin(self.get_cubin(cc=cc))
 
     def add_ir_module(self, mod):
         self._raise_if_finalized()

--- a/numba/cuda/codegen.py
+++ b/numba/cuda/codegen.py
@@ -24,7 +24,8 @@ def disassemble_cubin(cubin):
             f.write(cubin)
 
         try:
-            cp = subprocess.run(['nvdisasm', '-gi', fname], check=True,
+            lineinfo_flag = '-gi'
+            cp = subprocess.run(['nvdisasm', lineinfo_flag, fname], check=True,
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
         except FileNotFoundError as e:

--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -253,13 +253,13 @@ class _Kernel(serialize.ReduceMixin):
         '''
         return self._codelibrary.get_asm_str(cc=cc)
 
-    def inspect_sass(self, debuginfo=False):
+    def inspect_sass(self):
         '''
         Returns the SASS code for this kernel.
 
         Requires nvdisasm to be available on the PATH.
         '''
-        return self._codelibrary.get_sass(debuginfo=debuginfo)
+        return self._codelibrary.get_sass()
 
     def inspect_types(self, file=None):
         '''
@@ -979,7 +979,7 @@ class CUDADispatcher(Dispatcher, serialize.ReduceMixin):
                 return {sig: overload.inspect_asm(cc)
                         for sig, overload in self.overloads.items()}
 
-    def inspect_sass(self, signature=None, debuginfo=False):
+    def inspect_sass(self, signature=None):
         '''
         Return this kernel's SASS assembly code for for the device in the
         current context.
@@ -996,9 +996,9 @@ class CUDADispatcher(Dispatcher, serialize.ReduceMixin):
             raise RuntimeError('Cannot inspect SASS of a device function')
 
         if signature is not None:
-            return self.overloads[signature].inspect_sass(debuginfo=debuginfo)
+            return self.overloads[signature].inspect_sass()
         else:
-            return {sig: defn.inspect_sass(debuginfo=debuginfo)
+            return {sig: defn.inspect_sass()
                     for sig, defn in self.overloads.items()}
 
     def inspect_types(self, file=None):

--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -253,13 +253,13 @@ class _Kernel(serialize.ReduceMixin):
         '''
         return self._codelibrary.get_asm_str(cc=cc)
 
-    def inspect_sass(self):
+    def inspect_sass(self, debuginfo=False):
         '''
         Returns the SASS code for this kernel.
 
         Requires nvdisasm to be available on the PATH.
         '''
-        return self._codelibrary.get_sass()
+        return self._codelibrary.get_sass(debuginfo=debuginfo)
 
     def inspect_types(self, file=None):
         '''
@@ -979,7 +979,7 @@ class CUDADispatcher(Dispatcher, serialize.ReduceMixin):
                 return {sig: overload.inspect_asm(cc)
                         for sig, overload in self.overloads.items()}
 
-    def inspect_sass(self, signature=None):
+    def inspect_sass(self, signature=None, debuginfo=False):
         '''
         Return this kernel's SASS assembly code for for the device in the
         current context.
@@ -996,9 +996,9 @@ class CUDADispatcher(Dispatcher, serialize.ReduceMixin):
             raise RuntimeError('Cannot inspect SASS of a device function')
 
         if signature is not None:
-            return self.overloads[signature].inspect_sass()
+            return self.overloads[signature].inspect_sass(debuginfo=debuginfo)
         else:
-            return {sig: defn.inspect_sass()
+            return {sig: defn.inspect_sass(debuginfo=debuginfo)
                     for sig, defn in self.overloads.items()}
 
     def inspect_types(self, file=None):

--- a/numba/cuda/tests/cudapy/test_inspect.py
+++ b/numba/cuda/tests/cudapy/test_inspect.py
@@ -98,6 +98,9 @@ class TestInspect(CUDATestCase):
                 seen_function = True
         self.assertTrue(seen_function)
 
+        seen_lineinfo = 'line' in sass and 'inlined' in sass
+        self.assertTrue(seen_lineinfo)
+
         # Some instructions common to all supported architectures that should
         # appear in the output
         self.assertIn('S2R', sass)   # Special register to register
@@ -108,7 +111,7 @@ class TestInspect(CUDATestCase):
     def test_inspect_sass_eager(self):
         sig = (float32[::1], int32[::1])
 
-        @cuda.jit(sig)
+        @cuda.jit(sig, lineinfo=True)
         def add(x, y):
             i = cuda.grid(1)
             if i < len(x):
@@ -118,7 +121,7 @@ class TestInspect(CUDATestCase):
 
     @skip_without_nvdisasm('nvdisasm needed for inspect_sass()')
     def test_inspect_sass_lazy(self):
-        @cuda.jit
+        @cuda.jit(lineinfo=True)
         def add(x, y):
             i = cuda.grid(1)
             if i < len(x):

--- a/numba/cuda/tests/cudapy/test_inspect.py
+++ b/numba/cuda/tests/cudapy/test_inspect.py
@@ -98,8 +98,7 @@ class TestInspect(CUDATestCase):
                 seen_function = True
         self.assertTrue(seen_function)
 
-        seen_lineinfo = 'line' in sass and 'inlined' in sass
-        self.assertTrue(seen_lineinfo)
+        self.assertRegex(sass, r'//## File ".*/test_inspect.py", line [0-9]')
 
         # Some instructions common to all supported architectures that should
         # appear in the output

--- a/numba/cuda/tests/cudapy/test_inspect.py
+++ b/numba/cuda/tests/cudapy/test_inspect.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from io import StringIO
 from numba import cuda, float32, float64, int32, intp
+from numba.cuda.cudadrv.nvvm import NVVM
 from numba.cuda.testing import unittest, CUDATestCase
 from numba.cuda.testing import (skip_on_cudasim, skip_with_nvdisasm,
                                 skip_without_nvdisasm)
@@ -91,6 +92,8 @@ class TestInspect(CUDATestCase):
         self.assertIn("foo", asmdict[float64, float64])
 
     def _test_inspect_sass(self, kernel, name, sass):
+        if not NVVM().is_nvvm70:
+            self.skipTest("lineinfo not generated for NVVM 3.4")
         # Ensure function appears in output
         seen_function = False
         for line in sass.split():


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
I'm building some jupyter magic tooling as described in #8960.  I need to be able to map the SASS to original source lines. This PR adds debug info flag `-gi` to the `nvdisasm` command to get line information. For example output, see below:

```python
from numba import cuda
import numpy as np
@cuda.jit(lineinfo=True)
def gpu_add_one_kernel(x, out, N):
    i = cuda.grid(1)
    if i<N:
        out[i] = x[i] + 1

a = np.arange(4096,dtype=np.int32)
d_a = cuda.to_device(a)
d_out = cuda.device_array_like(d_a)
blocks_per_grid = 32*2
threads_per_block = 128
gpu_add_one_kernel[blocks_per_grid, threads_per_block](d_a, d_out, len(d_a))
cuda.synchronize()
print(next(iter(gpu_add_one_kernel.inspect_sass(debuginfo=True).items()))[1])
```

```asm
...
	//## File "/tmp/ipykernel_2373722/1083830147.py", line 3
        /*0000*/                   MOV R1, c[0x0][0x28] ;
	//## File "/tmp/ipykernel_2373722/1083830147.py", line 5 inlined at "/tmp/ipykernel_2373722/1083830147.py", line 3
	//## File "/tmp/ipykernel_2373722/1083830147.py", line 3
        /*0010*/                   S2R R0, SR_CTAID.X ;
        /*0020*/                   S2R R3, SR_TID.X ;
        /*0030*/                   IMAD R0, R0, c[0x0][0x0], R3 ;
	//## File "/tmp/ipykernel_2373722/1083830147.py", line 6 inlined at "/tmp/ipykernel_2373722/1083830147.py", line 3
	//## File "/tmp/ipykernel_2373722/1083830147.py", line 3
        /*0040*/                   ISETP.GE.U32.AND P0, PT, R0, c[0x0][0x1d0], PT ;
        /*0050*/                   SHF.R.S32.HI R4, RZ, 0x1f, R0 ;
        /*0060*/                   ISETP.GE.AND.EX P0, PT, R4, c[0x0][0x1d4], PT, P0 ;
        /*0070*/               @P0 EXIT ;
	//## File "/tmp/ipykernel_2373722/1083830147.py", line 7 inlined at "/tmp/ipykernel_2373722/1083830147.py", line 3
	//## File "/tmp/ipykernel_2373722/1083830147.py", line 3
        /*0080*/                   ISETP.GE.AND P0, PT, R0, RZ, PT ;
        /*0090*/                   ULDC.64 UR4, c[0x0][0x118] ;
        /*00a0*/                   SEL R3, RZ, c[0x0][0x188], P0 ;
        /*00b0*/                   SEL R5, RZ, c[0x0][0x18c], P0 ;
        /*00c0*/                   IADD3 R3, P1, R0, R3, RZ ;
        /*00d0*/                   IMAD.X R6, R4, 0x1, R5, P1 ;
        /*00e0*/                   LEA R2, P1, R3, c[0x0][0x180], 0x2 ;
        /*00f0*/                   LEA.HI.X R3, R3, c[0x0][0x184], R6, 0x2, P1 ;
        /*0100*/                   LDG.E R2, [R2.64] ;
        /*0110*/                   SEL R5, RZ, c[0x0][0x1c0], P0 ;
        /*0120*/                   SEL R7, RZ, c[0x0][0x1c4], P0 ;
        /*0130*/                   IADD3 R0, P0, R0, R5, RZ ;
        /*0140*/                   IMAD.X R5, R4, 0x1, R7, P0 ;
        /*0150*/                   LEA R4, P0, R0, c[0x0][0x1b8], 0x2 ;
        /*0160*/                   LEA.HI.X R5, R0, c[0x0][0x1bc], R5, 0x2, P0 ;
        /*0170*/                   IADD3 R7, R2, 0x1, RZ ;
        /*0180*/                   STG.E [R4.64], R7 ;
	//## File "/tmp/ipykernel_2373722/1083830147.py", line 3
        /*0190*/                   EXIT ;
...
```