### PR TITLE
Recognize additional functions as being pure or not having side effects.

### DIFF
--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -4,6 +4,7 @@
 #
 
 import numpy
+import math
 
 import types as pytypes
 import collections
@@ -743,7 +744,10 @@ def has_no_side_effect(rhs, lives, call_table):
             call_list == [array_analysis.wrap_index] or
             call_list == [prange] or
             call_list == ['prange', numba] or
-            call_list == [parfor.internal_prange]):
+            call_list == [parfor.internal_prange] or
+            call_list == ['ceil', math] or
+            call_list == [max] or
+            call_list == [int]):
             return True
         elif (isinstance(call_list[0], _Intrinsic) and
               (call_list[0]._name == 'empty_inferred' or
@@ -783,7 +787,10 @@ def is_pure(rhs, lives, call_table):
             call_list = call_table[func_name]
             if (call_list == [slice] or
                 call_list == ['log', numpy] or
-                call_list == ['empty', numpy]):
+                call_list == ['empty', numpy] or
+                call_list == ['ceil', math] or
+                call_list == [max] or
+                call_list == [int]):
                 return True
             for f in is_pure_extensions:
                 if f(rhs, lives, call_list):
@@ -1857,11 +1864,14 @@ def gen_np_call(func_as_str, func, lhs, args, typingctx, typemap, calltypes):
     np_assign = ir.Assign(np_call, lhs, loc)
     return [g_np_assign, attr_assign, np_assign]
 
+def dump_block(label, block):
+    print(label, ":")
+    for stmt in block.body:
+        print("    ", stmt)
+
 def dump_blocks(blocks):
     for label, block in blocks.items():
-        print(label, ":")
-        for stmt in block.body:
-            print("    ", stmt)
+        dump_block(label, block)
 
 def is_operator_or_getitem(expr):
     """true if expr is unary or binary operator or getitem"""

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -4,7 +4,7 @@
 #
 
 
-from math import sqrt
+import math
 import re
 import dis
 import numbers
@@ -460,7 +460,7 @@ def example_kmeans_test(A, numCenter, numIter, init_centroids):
     N, D = A.shape
 
     for l in range(numIter):
-        dist = np.array([[sqrt(np.sum((A[i,:]-centroids[j,:])**2))
+        dist = np.array([[math.sqrt(np.sum((A[i,:]-centroids[j,:])**2))
                                 for j in range(numCenter)] for i in range(N)])
         labels = np.array([dist[i,:].argmin() for i in range(N)])
 
@@ -2284,6 +2284,16 @@ class TestParfors(TestParforsBase):
 
         self.check(test_impl, 15)
         self.assertEqual(countParfors(test_impl, (types.int64, )), 2)
+
+    def test_fusion_no_side_effects(self):
+        def test_impl(a, b):
+            X = np.ones(100)
+            b = math.ceil(b)
+            Y = np.ones(100)
+            c = int(max(a, b))
+            return X + Y + c
+        self.check(test_impl, 3.7, 4.3)
+        self.assertEqual(countParfors(test_impl, (types.float64, types.float64)), 1)
 
 
 @skip_parfors_unsupported


### PR DESCRIPTION
Adds just a few functions to be recognized as pure and not having side effects.

Also split dump_blocks into a dump routine for a single block so that Numba extensions can dump just a single block if it wishes.