### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,6 +15,9 @@
 /numba/cuda/ @gmarkall
 /numba/parfors/ @DrTodd13
 /numba/stencils/ @DrTodd13
+/numba/core/byteflow.py @sklam
+/numba/core/typeinfer.py @sklam
+/numba/core/interpreter.py @sklam
 
 # ------------------------------------------------------------------------------
 # Information for contributors

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,10 +10,6 @@
 # ------------------------------------------------------------------------------
 # Information for github
 # ------------------------------------------------------------------------------
-# These people are the default "owners" for everything in the repo unless a
-# later match is made, they will automatically be requested to review PRs.
-* @sklam @stuartarchibald
-
 # Owners of specific parts of the code, will be requested to review if a PR
 # touches code in the matched pattern
 /numba/cuda/ @gmarkall


### PR DESCRIPTION
- Removing @sklam and @stuartarchibald as default codeowners now that we distributing work via the triage meeting.
- I'm setting ownership on core frontend files.