### PR TITLE
Add CUDA CFG support

### DIFF
--- a/docs/upcoming_changes/9051.cuda.rst
+++ b/docs/upcoming_changes/9051.cuda.rst
@@ -1,0 +1,8 @@
+
+Add CUDA SASS CFG Support
+=========================
+
+This PR This PR adds support for getting the SASS CFG in dot language format. 
+It adds an inspect_sass_cfg method to CUDADispatcher and the -cfg flag to
+the nvdisasm command line tool.
+ 

--- a/docs/upcoming_changes/9051.cuda.rst
+++ b/docs/upcoming_changes/9051.cuda.rst
@@ -2,7 +2,7 @@
 Add CUDA SASS CFG Support
 =========================
 
-This PR This PR adds support for getting the SASS CFG in dot language format. 
-It adds an inspect_sass_cfg method to CUDADispatcher and the -cfg flag to
-the nvdisasm command line tool.
+This PR adds support for getting the SASS CFG in dot language format. 
+It adds an ``inspect_sass_cfg()`` method to CUDADispatcher and the ``-cfg``
+flag to the nvdisasm command line tool.
  

--- a/numba/cuda/codegen.py
+++ b/numba/cuda/codegen.py
@@ -28,8 +28,8 @@ def run_nvdisasm(cubin, flags):
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
         except FileNotFoundError as e:
-            msg = ("nvdisasm has not been found. You may need"
-                   "to install the CUDA toolkit and ensure that"
+            msg = ("nvdisasm has not been found. You may need "
+                   "to install the CUDA toolkit and ensure that "
                    "it is available on your PATH.\n")
             raise RuntimeError(msg) from e
         return cp.stdout.decode('utf-8')

--- a/numba/cuda/codegen.py
+++ b/numba/cuda/codegen.py
@@ -212,7 +212,7 @@ class CUDACodeLibrary(serialize.ReduceMixin, CodeLibrary):
     def get_sass(self, cc=None):
         return disassemble_cubin(self.get_cubin(cc=cc))
 
-    def get_cfg(self, cc=None):
+    def get_sass_cfg(self, cc=None):
         return disassemble_cubin_for_cfg(self.get_cubin(cc=cc))
 
     def add_ir_module(self, mod):

--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -259,7 +259,7 @@ class _Kernel(serialize.ReduceMixin):
 
         Requires nvdisasm to be available on the PATH.
         '''
-        return self._codelibrary.get_cfg()
+        return self._codelibrary.get_sass_cfg()
 
     def inspect_sass(self):
         '''

--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -253,9 +253,9 @@ class _Kernel(serialize.ReduceMixin):
         '''
         return self._codelibrary.get_asm_str(cc=cc)
 
-    def inspect_cfg(self):
+    def inspect_sass_cfg(self):
         '''
-        Returns the CFG for this kernel.
+        Returns the CFG of the SASS for this kernel.
 
         Requires nvdisasm to be available on the PATH.
         '''
@@ -987,16 +987,15 @@ class CUDADispatcher(Dispatcher, serialize.ReduceMixin):
                 return {sig: overload.inspect_asm(cc)
                         for sig, overload in self.overloads.items()}
 
-    def inspect_cfg(self, signature=None):
+    def inspect_sass_cfg(self, signature=None):
         '''
-        Return this kernel's CFG for the device in the
-        current context.
+        Return this kernel's CFG for the device in the current context.
 
         :param signature: A tuple of argument types.
         :return: The CFG for the given signature, or a dict of CFGs
                  for all previously-encountered signatures.
 
-        CFG for the device in the current context is returned.
+        The CFG for the device in the current context is returned.
 
         Requires nvdisasm to be available on the PATH.
         '''
@@ -1004,9 +1003,9 @@ class CUDADispatcher(Dispatcher, serialize.ReduceMixin):
             raise RuntimeError('Cannot get the CFG of a device function')
 
         if signature is not None:
-            return self.overloads[signature].inspect_cfg()
+            return self.overloads[signature].inspect_sass_cfg()
         else:
-            return {sig: defn.inspect_cfg()
+            return {sig: defn.inspect_sass_cfg()
                     for sig, defn in self.overloads.items()}
 
     def inspect_sass(self, signature=None):

--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -253,6 +253,14 @@ class _Kernel(serialize.ReduceMixin):
         '''
         return self._codelibrary.get_asm_str(cc=cc)
 
+    def inspect_cfg(self):
+        '''
+        Returns the CFG for this kernel.
+
+        Requires nvdisasm to be available on the PATH.
+        '''
+        return self._codelibrary.get_cfg()
+
     def inspect_sass(self):
         '''
         Returns the SASS code for this kernel.
@@ -978,6 +986,28 @@ class CUDADispatcher(Dispatcher, serialize.ReduceMixin):
             else:
                 return {sig: overload.inspect_asm(cc)
                         for sig, overload in self.overloads.items()}
+
+    def inspect_cfg(self, signature=None):
+        '''
+        Return this kernel's CFG for the device in the
+        current context.
+
+        :param signature: A tuple of argument types.
+        :return: The CFG for the given signature, or a dict of CFGs
+                 for all previously-encountered signatures.
+
+        CFG for the device in the current context is returned.
+
+        Requires nvdisasm to be available on the PATH.
+        '''
+        if self.targetoptions.get('device'):
+            raise RuntimeError('Cannot get the CFG of a device function')
+
+        if signature is not None:
+            return self.overloads[signature].inspect_cfg()
+        else:
+            return {sig: defn.inspect_cfg()
+                    for sig, defn in self.overloads.items()}
 
     def inspect_sass(self, signature=None):
         '''

--- a/numba/cuda/tests/cudapy/test_inspect.py
+++ b/numba/cuda/tests/cudapy/test_inspect.py
@@ -148,7 +148,7 @@ class TestInspect(CUDATestCase):
 
         self.assertIn('nvdisasm is required', str(raises.exception))
 
-    @skip_without_nvdisasm('nvdisasm needed for inspect_sass()')
+    @skip_without_nvdisasm('nvdisasm needed for inspect_cfg()')
     def test_inspect_cfg(self):
         sig = (float32[::1], int32[::1])
 
@@ -159,7 +159,7 @@ class TestInspect(CUDATestCase):
                 x[i] += y[i]
 
         self.assertRegex(
-            add.inspect_cfg(signature=sig),
+            add.inspect_sass_cfg(signature=sig),
             r'digraph\s*\w\s*{(.|\n)*\n}'
         )
 

--- a/numba/cuda/tests/cudapy/test_inspect.py
+++ b/numba/cuda/tests/cudapy/test_inspect.py
@@ -148,7 +148,7 @@ class TestInspect(CUDATestCase):
 
         self.assertIn('nvdisasm is required', str(raises.exception))
 
-    @skip_without_nvdisasm('nvdisasm needed for inspect_cfg()')
+    @skip_without_nvdisasm('nvdisasm needed for inspect_sass_cfg()')
     def test_inspect_sass_cfg(self):
         sig = (float32[::1], int32[::1])
 

--- a/numba/cuda/tests/cudapy/test_inspect.py
+++ b/numba/cuda/tests/cudapy/test_inspect.py
@@ -149,7 +149,7 @@ class TestInspect(CUDATestCase):
         self.assertIn('nvdisasm is required', str(raises.exception))
 
     @skip_without_nvdisasm('nvdisasm needed for inspect_cfg()')
-    def test_inspect_cfg(self):
+    def test_inspect_sass_cfg(self):
         sig = (float32[::1], int32[::1])
 
         @cuda.jit(sig)

--- a/numba/cuda/tests/cudapy/test_inspect.py
+++ b/numba/cuda/tests/cudapy/test_inspect.py
@@ -148,6 +148,21 @@ class TestInspect(CUDATestCase):
 
         self.assertIn('nvdisasm is required', str(raises.exception))
 
+    @skip_without_nvdisasm('nvdisasm needed for inspect_sass()')
+    def test_inspect_cfg(self):
+        sig = (float32[::1], int32[::1])
+
+        @cuda.jit(sig)
+        def add(x, y):
+            i = cuda.grid(1)
+            if i < len(x):
+                x[i] += y[i]
+
+        self.assertRegex(
+            add.inspect_cfg(signature=sig),
+            r'digraph\s*\w\s*{(.|\n)*\n}'
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/cuda/tests/cudapy/test_inspect.py
+++ b/numba/cuda/tests/cudapy/test_inspect.py
@@ -146,7 +146,7 @@ class TestInspect(CUDATestCase):
         with self.assertRaises(RuntimeError) as raises:
             f.inspect_sass()
 
-        self.assertIn('nvdisasm is required', str(raises.exception))
+        self.assertIn('nvdisasm has not been found', str(raises.exception))
 
     @skip_without_nvdisasm('nvdisasm needed for inspect_sass_cfg()')
     def test_inspect_sass_cfg(self):


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
I'm building some jupyter magic tooling as described in #8960. I need to be able to display the control flow graph for CUDA kernels. This PR adds an `inspect_cfg` method to CUDA kernels that returns the CFG as text in the dot language form. I plan on piping this output to the dot command line tool to display the digraph as an image in Jupyter notebooks. Ex:

```python
from numba import cuda
from numba.types import int32
import numpy as np

sig = (int32[::1], int32[::1])

@cuda.jit(sig)
def add(x, out):
    i = cuda.grid(1)
    if i < len(x):
        out[i] += x[i]
    
a = np.arange(8, dtype=np.float32)
d_a = cuda.to_device(a)
d_out = cuda.device_array_like(d_a)

add[2,4](d_a, d_out)
print(next(iter(add.inspect_cfg().items()))[1])
```

```dot
digraph f {
subgraph "add" {
node [fontname="Courier",fontsize=10,shape=Mrecord];
"add"
[add:\l\ \ MOV\ R1,\ c\[0x0\]\[0x28\]\ ;\l\ \ S2R\ R0,\ SR_TID.X\ ;\l\ \ S2R\ R3,\ SR_CTAID.X\ ;\l\ \ IMAD\ R0,\ R3,\ c\[0x0\]\[0x0\],\ R0\ ;\l\ \ ISETP.GE.U32.AND\ P0,\ PT,\ R0,\ c\[0x0\]\[0x188\],\ PT\ ;\l\ \ SHF.R.S32.HI\ R2,\ RZ,\ 0x1f,\ R0\ ;\l\ \ ISETP.GE.AND.EX\ P0,\ PT,\ R2,\ c\[0x0\]\[0x18c\],\ PT,\ P0\ ;\l|<exit0>\ \ @P0\ EXIT\ ;\l|<exitpost0>\ \ ISETP.GE.AND\ P0,\ PT,\ R0,\ RZ,\ PT\ ;\l\ \ ULDC.64\ UR4,\ c\[0x0\]\[0x118\]\ ;\l\ \ SEL\ R5,\ RZ,\ c\[0x0\]\[0x1c0\],\ P0\ ;\l\ \ SEL\ R3,\ RZ,\ c\[0x0\]\[0x188\],\ P0\ ;\l\ \ IADD3\ R6,\ P1,\ R0.reuse,\ R5,\ RZ\ ;\l\ \ IADD3\ R0,\ P2,\ R0,\ R3,\ RZ\ ;\l\ \ SEL\ R7,\ RZ,\ c\[0x0\]\[0x1c4\],\ P0\ ;\l\ \ SEL\ R3,\ RZ,\ c\[0x0\]\[0x18c\],\ P0\ ;\l\ \ IMAD.X\ R7,\ R2,\ 0x1,\ R7,\ P1\ ;\l\ \ LEA\ R4,\ P1,\ R0,\ c\[0x0\]\[0x180\],\ 0x2\ ;\l\ \ IMAD.X\ R3,\ R2,\ 0x1,\ R3,\ P2\ ;\l\ \ LEA\ R2,\ P0,\ R6,\ c\[0x0\]\[0x1b8\],\ 0x2\ ;\l\ \ LEA.HI.X\ R5,\ R0,\ c\[0x0\]\[0x184\],\ R3,\ 0x2,\ P1\ ;\l\ \ LEA.HI.X\ R3,\ R6,\ c\[0x0\]\[0x1bc\],\ R7,\ 0x2,\ P0\ ;\l\ \ LDG.E\ R4,\ \[R4.64\]\ ;\l\ \ LDG.E\ R7,\ \[R2.64\]\ ;\l\ \ IMAD.IADD\ R7,\ R4,\ 0x1,\ R7\ ;\l\ \ STG.E\ \[R2.64\],\ R7\ ;\l|<exit1>\ \ EXIT\ ;\l}"]
}
}
```