### PR TITLE
Fix: Issue 9063 - CUDA atomics tests failing with CUDA 12.2

### DIFF
--- a/docs/upcoming_changes/9088.cuda.rst
+++ b/docs/upcoming_changes/9088.cuda.rst
@@ -1,0 +1,5 @@
+Fix CUDA atomics tests with toolkit 12.2
+========================================
+
+CUDA 12.2 generates slightly different PTX for some atomics, so the relevant
+tests are updated to look for the correct instructions when 12.2 is used.

--- a/numba/cuda/nvvmutils.py
+++ b/numba/cuda/nvvmutils.py
@@ -1,8 +1,7 @@
 import itertools
 from llvmlite import ir
-from numba.core import cgutils
+from numba.core import cgutils, targetconfig
 from .cudadrv import nvvm
-from .api import current_context
 
 
 def declare_atomic_cas_int(lmod, isize):
@@ -31,7 +30,8 @@ def declare_atomic_add_float32(lmod):
 
 
 def declare_atomic_add_float64(lmod):
-    if current_context().device.compute_capability >= (6, 0):
+    flags = targetconfig.ConfigStack().top()
+    if flags.compute_capability >= (6, 0):
         fname = 'llvm.nvvm.atomic.load.add.f64.p0f64'
     else:
         fname = '___numba_atomic_double_add'

--- a/numba/cuda/tests/cudapy/test_atomics.py
+++ b/numba/cuda/tests/cudapy/test_atomics.py
@@ -2,8 +2,7 @@ import numpy as np
 from textwrap import dedent
 
 from numba import cuda, uint32, uint64, float32, float64
-from numba.cuda.testing import (unittest, CUDATestCase, skip_unless_cc_50,
-                                cc_X_or_above)
+from numba.cuda.testing import unittest, CUDATestCase, cc_X_or_above
 from numba.core import config
 
 
@@ -559,17 +558,24 @@ class TestCudaAtomics(CUDATestCase):
         # Use the first (and only) definition
         asm = next(iter(kernel.inspect_asm().values()))
         if cc_X_or_above(6, 0):
-            if shared:
-                self.assertIn('atom.shared.add.f64', asm)
+            if cuda.runtime.get_version() > (12, 1):
+                # CUDA 12.2 and above generate a more optimized reduction
+                # instruction, because the result does not need to be
+                # placed in a register.
+                inst = 'red'
             else:
-                self.assertIn('atom.add.f64', asm)
+                inst = 'atom'
+
+            if shared:
+                inst = f'{inst}.shared'
+
+            self.assertIn(f'{inst}.add.f64', asm)
         else:
             if shared:
                 self.assertIn('atom.shared.cas.b64', asm)
             else:
                 self.assertIn('atom.cas.b64', asm)
 
-    @skip_unless_cc_50
     def test_atomic_add_double(self):
         idx = np.random.randint(0, 32, size=32, dtype=np.int64)
         ary = np.zeros(32, np.float64)
@@ -615,7 +621,6 @@ class TestCudaAtomics(CUDATestCase):
         np.testing.assert_equal(ary, orig + 1)
         self.assertCorrectFloat64Atomics(cuda_func)
 
-    @skip_unless_cc_50
     def test_atomic_add_double_global(self):
         idx = np.random.randint(0, 32, size=32, dtype=np.int64)
         ary = np.zeros(32, np.float64)


### PR DESCRIPTION
CUDA 12.2 uses the `red` instruction instead of the `atom` instruction, because this saves a register (the original value is not required to be stored in a register for the test code). This updates the test accordingly.

Since we only have CUDA 11.x for CI, I have tested this manually.

I noticed during testing (using the `NUMBA_FORCE_CUDA_CC` environment variable) that `declare_atomic_add_float64()` assumes it can choose which implementation to use based on the device in the current context - this is not the case, and will have been a long-standing issue (e.g. it could cause issues with `compile_ptx()`). It should use the CC stored in the flags instead.

Fixes #9063.