### PR TITLE
Make all parameter names in `@overload`s match the API being overloaded.

### DIFF
--- a/docs/upcoming_changes/9059.bug_fix.rst
+++ b/docs/upcoming_changes/9059.bug_fix.rst
@@ -1,0 +1,7 @@
+
+Fix parameter names for ``random`` functions
+============================================
+
+This corrects a bunch of parameter names that did not match the names in
+``random`` and ``numpy.random`` so that using name parameters will work
+properly for these functions. Positional parameters worked correctly.

--- a/docs/upcoming_changes/9059.bug_fix.rst
+++ b/docs/upcoming_changes/9059.bug_fix.rst
@@ -1,7 +1,0 @@
-
-Fix parameter names for ``random`` functions
-============================================
-
-This corrects a bunch of parameter names that did not match the names in
-``random`` and ``numpy.random`` so that using name parameters will work
-properly for these functions. Positional parameters worked correctly.

--- a/docs/upcoming_changes/9099.bug_fix.rst
+++ b/docs/upcoming_changes/9099.bug_fix.rst
@@ -1,0 +1,69 @@
+Fix all ``@overload``s to use parameter names that match public APIs.
+=====================================================================
+
+Some of the Numba ``@overload``s for functions in NumPy and Python's built-ins
+were written using parameter names that did not match those used in API they
+were overloading. The result of this being that calling a function with such a
+mismatch using the parameter names as key-word arguments at the call site would
+result in a compilation error. This has now been universally fixed throughout
+the code base and a unit test is running with a best-effort attempt to prevent
+reintroduction of similar mistakes in the future. Fixed functions include:
+
+From Python built-ins:
+
+* ``complex``
+
+From the Python ``random`` module:
+
+* ``random.seed``
+* ``random.gauss``
+* ``random.normalvariate``
+* ``random.randrange``
+* ``random.randint``
+* ``random.uniform``
+* ``random.shuffle``
+
+From the ``numpy`` module:
+
+* ``numpy.argmin``
+* ``numpy.argmax``
+* ``numpy.array_equal``
+* ``numpy.average``
+* ``numpy.count_nonzero``
+* ``numpy.flip``
+* ``numpy.fliplr``
+* ``numpy.flipud``
+* ``numpy.iinfo``
+* ``numpy.isscalar``
+* ``numpy.imag``
+* ``numpy.real``
+* ``numpy.reshape``
+* ``numpy.rot90``
+* ``numpy.swapaxes``
+* ``numpy.union1d``
+* ``numpy.unique``
+
+From the ``numpy.linalg`` module:
+
+* ``numpy.linalg.norm``
+* ``numpy.linalg.cond``
+* ``numpy.linalg.matrix_rank``
+
+From the ``numpy.random`` module:
+
+* ``numpy.random.beta``
+* ``numpy.random.chisquare``
+* ``numpy.random.f``
+* ``numpy.random.gamma``
+* ``numpy.random.hypergeometric``
+* ``numpy.random.lognormal``
+* ``numpy.random.pareto``
+* ``numpy.random.randint``
+* ``numpy.random.random_sample``
+* ``numpy.random.ranf``
+* ``numpy.random.rayleigh``
+* ``numpy.random.sample``
+* ``numpy.random.shuffle``
+* ``numpy.random.standard_gamma``
+* ``numpy.random.triangular``
+* ``numpy.random.weibull``

--- a/numba/cpython/randomimpl.py
+++ b/numba/cpython/randomimpl.py
@@ -736,8 +736,9 @@ def triangular_impl_3(left, mode, right):
 @overload(np.random.triangular)
 def triangular_impl(left, mode, right, size=None):
     if is_nonelike(size):
-        return lambda left, mode, right, size: np.random.triangular(left, mode,
-                                                                    right)
+        return lambda left, mode, right, size=None: np.random.triangular(left,
+                                                                         mode,
+                                                                         right)
     if (isinstance(size, types.Integer) or (isinstance(size, types.UniTuple) and
                                             isinstance(size.dtype,
                                                        types.Integer))):

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1908,26 +1908,26 @@ def numpy_logspace(start, stop, num=50):
 
 
 @overload(np.rot90)
-def numpy_rot90(arr, k=1):
+def numpy_rot90(m, k=1):
     # supporting axes argument it needs to be included in np.flip
     if not isinstance(k, (int, types.Integer)):
         raise errors.TypingError('The second argument "k" must be an integer')
-    if not isinstance(arr, types.Array):
-        raise errors.TypingError('The first argument "arr" must be an array')
+    if not isinstance(m, types.Array):
+        raise errors.TypingError('The first argument "m" must be an array')
 
-    if arr.ndim < 2:
+    if m.ndim < 2:
         raise errors.NumbaValueError('Input must be >= 2-d.')
 
-    def impl(arr, k=1):
+    def impl(m, k=1):
         k = k % 4
         if k == 0:
-            return arr[:]
+            return m[:]
         elif k == 1:
-            return np.swapaxes(np.fliplr(arr), 0, 1)
+            return np.swapaxes(np.fliplr(m), 0, 1)
         elif k == 2:
-            return np.flipud(np.fliplr(arr))
+            return np.flipud(np.fliplr(m))
         elif k == 3:
-            return np.fliplr(np.swapaxes(arr, 0, 1))
+            return np.fliplr(np.swapaxes(m, 0, 1))
         else:
             raise AssertionError  # unreachable
 
@@ -2072,9 +2072,9 @@ def array_reshape_vararg(context, builder, sig, args):
 
 
 @overload(np.reshape)
-def np_reshape(a, shape):
-    def np_reshape_impl(a, shape):
-        return a.reshape(shape)
+def np_reshape(a, newshape):
+    def np_reshape_impl(a, newshape):
+        return a.reshape(newshape)
     return np_reshape_impl
 
 
@@ -2440,9 +2440,9 @@ def np_shape(a):
 
 
 @overload(np.unique)
-def np_unique(a):
-    def np_unique_impl(a):
-        b = np.sort(a.ravel())
+def np_unique(ar):
+    def np_unique_impl(ar):
+        b = np.sort(ar.ravel())
         head = list(b[:1])
         tail = [x for i, x in enumerate(b[1:]) if b[i] != x]
         return np.array(head + tail)
@@ -5935,13 +5935,13 @@ def array_dot(arr, other):
 
 
 @overload(np.fliplr)
-def np_flip_lr(a):
+def np_flip_lr(m):
 
-    if not type_can_asarray(a):
-        raise errors.TypingError("Cannot np.fliplr on %s type" % a)
+    if not type_can_asarray(m):
+        raise errors.TypingError("Cannot np.fliplr on %s type" % m)
 
-    def impl(a):
-        A = np.asarray(a)
+    def impl(m):
+        A = np.asarray(m)
         # this handling is superfluous/dead as < 2d array cannot be indexed as
         # present below and so typing fails. If the typing doesn't fail due to
         # some future change, this will catch it.
@@ -5952,13 +5952,13 @@ def np_flip_lr(a):
 
 
 @overload(np.flipud)
-def np_flip_ud(a):
+def np_flip_ud(m):
 
-    if not type_can_asarray(a):
-        raise errors.TypingError("Cannot np.flipud on %s type" % a)
+    if not type_can_asarray(m):
+        raise errors.TypingError("Cannot np.flipud on %s type" % m)
 
-    def impl(a):
-        A = np.asarray(a)
+    def impl(m):
+        A = np.asarray(m)
         # this handling is superfluous/dead as a 0d array cannot be indexed as
         # present below and so typing fails. If the typing doesn't fail due to
         # some future change, this will catch it.
@@ -5999,15 +5999,15 @@ def _build_flip_slice_tuple(tyctx, sz):
 
 
 @overload(np.flip)
-def np_flip(a):
+def np_flip(m):
     # a constant value is needed for the tuple slice, types.Array.ndim can
     # provide this and so at presnet only type.Array is support
-    if not isinstance(a, types.Array):
-        raise errors.TypingError("Cannot np.flip on %s type" % a)
+    if not isinstance(m, types.Array):
+        raise errors.TypingError("Cannot np.flip on %s type" % m)
 
-    def impl(a):
-        sl = _build_flip_slice_tuple(a.ndim)
-        return a[sl]
+    def impl(m):
+        sl = _build_flip_slice_tuple(m.ndim)
+        return m[sl]
 
     return impl
 
@@ -6409,21 +6409,21 @@ def ol_bool(arr):
 
 
 @overload(np.swapaxes)
-def numpy_swapaxes(arr, axis1, axis2):
+def numpy_swapaxes(a, axis1, axis2):
     if not isinstance(axis1, (int, types.Integer)):
         raise errors.TypingError('The second argument "axis1" must be an '
                                  'integer')
     if not isinstance(axis2, (int, types.Integer)):
         raise errors.TypingError('The third argument "axis2" must be an '
                                  'integer')
-    if not isinstance(arr, types.Array):
-        raise errors.TypingError('The first argument "arr" must be an array')
+    if not isinstance(a, types.Array):
+        raise errors.TypingError('The first argument "a" must be an array')
 
     # create tuple list for transpose
-    ndim = arr.ndim
+    ndim = a.ndim
     axes_list = tuple(range(ndim))
 
-    def impl(arr, axis1, axis2):
+    def impl(a, axis1, axis2):
         axis1 = normalize_axis("np.swapaxes", "axis1", ndim, axis1)
         axis2 = normalize_axis("np.swapaxes", "axis2", ndim, axis2)
 
@@ -6435,7 +6435,7 @@ def numpy_swapaxes(arr, axis1, axis2):
 
         axes_tuple = tuple_setitem(axes_list, axis1, axis2)
         axes_tuple = tuple_setitem(axes_tuple, axis2, axis1)
-        return np.transpose(arr, axes_tuple)
+        return np.transpose(a, axes_tuple)
 
     return impl
 

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -1,3 +1,4 @@
+import inspect
 import math
 import operator
 import sys
@@ -9,6 +10,7 @@ import re
 
 import numpy as np
 
+import numba
 from numba import njit, jit, vectorize, guvectorize, objmode
 from numba.core import types, errors, typing, compiler, cgutils
 from numba.core.typed_passes import type_inference_stage
@@ -2065,6 +2067,139 @@ class TestOverloadPreferLiteral(TestCase):
         self.assertEqual(a, 100)
         self.assertEqual(b, 200)
         self.assertEqual(c, 300)
+
+
+class TestNumbaInternalOverloads(TestCase):
+
+    def test_signatures_match_overloaded_api(self):
+        # This is a "best-effort" test to try and ensure that Numba's internal
+        # overload declarations have signatures with argument names that match
+        # the API they are overloading. The purpose of ensuring there is a
+        # match is so that users can use call-by-name for positional arguments.
+
+        # Set this to:
+        # 0 to make violations raise a ValueError (default).
+        # 1 to get violations reported to STDOUT
+        # 2 to get a verbose output of everything that was checked and its state
+        #   reported to STDOUT.
+        DEBUG = 0
+
+        # np.random.* does not have a signature exposed to `inspect`... so
+        # custom parse the docstrings.
+        def sig_from_np_random(x):
+            if not x.startswith('_'):
+                thing = getattr(np.random, x)
+                if inspect.isbuiltin(thing):
+                    docstr = thing.__doc__.splitlines()
+                    for l in docstr:
+                        if l:
+                            sl = l.strip()
+                            if sl.startswith(x): # its the signature
+                                # special case np.random.seed, it has `self` in
+                                # the signature whereas all the other functions
+                                # do not!?
+                                if x == "seed":
+                                    sl = "seed(seed)"
+
+                                fake_impl = f"def {sl}:\n\tpass"
+                                l = {}
+                                try:
+                                    exec(fake_impl, {}, l)
+                                except SyntaxError:
+                                    # likely elipsis, e.g. rand(d0, d1, ..., dn)
+                                    if DEBUG == 2:
+                                        print("... skipped as cannot parse "
+                                              "signature")
+                                    return None
+                                else:
+                                    fn = l.get(x)
+                                    return inspect.signature(fn)
+
+        def checker(func, overload_func):
+            if DEBUG == 2:
+                print(f"Checking: {func}")
+
+            def create_message(func, overload_func, func_sig, ol_sig):
+                msg = []
+                s = (f"{func} from module '{getattr(func, '__module__')}' "
+                     "has mismatched sig.")
+                msg.append(s)
+                msg.append(f"    - expected: {func_sig}")
+                msg.append(f"    -      got: {ol_sig}")
+                lineno = inspect.getsourcelines(overload_func)[1]
+                tmpsrcfile = inspect.getfile(overload_func)
+                srcfile = tmpsrcfile.replace(numba.__path__[0], '')
+                msg.append(f"from {srcfile}:{lineno}")
+                msgstr = '\n' + '\n'.join(msg)
+                return msgstr
+
+            func_sig = None
+            try:
+                func_sig = inspect.signature(func)
+            except ValueError:
+                # probably a built-in/C code, see if it's a np.random function
+                if fname := getattr(func, '__name__', False):
+                    if maybe_func := getattr(np.random, fname, False):
+                        if maybe_func == func:
+                            # it's a built-in from np.random
+                            func_sig = sig_from_np_random(fname)
+
+            if func_sig is not None:
+                ol_sig = inspect.signature(overload_func)
+                x = list(func_sig.parameters.keys())
+                y = list(ol_sig.parameters.keys())
+                for a, b in zip(x[:len(y)], y):
+                    if a != b:
+                        p = func_sig.parameters[a]
+                        if p.kind == p.POSITIONAL_ONLY:
+                            # probably a built-in/C code
+                            if DEBUG == 2:
+                                print("... skipped as positional only "
+                                      "arguments found")
+                            break
+                        elif '*' in str(p): # probably *args or similar
+                            if DEBUG == 2:
+                                print("... skipped as contains *args")
+                            break
+                        else:
+                            # Only error/report on functions that have a module
+                            # or are from somewhere other than Numba.
+                            if (not func.__module__ or
+                                    not func.__module__.startswith("numba")):
+                                msgstr = create_message(func, overload_func,
+                                                        func_sig, ol_sig)
+                                if DEBUG != 0:
+                                    if DEBUG == 2:
+                                        print("... INVALID")
+                                    if msgstr:
+                                        print(msgstr)
+                                    break
+                                else:
+                                    raise ValueError(msgstr)
+                            else:
+                                if DEBUG == 2:
+                                    if not func.__module__:
+                                        print("... skipped as no __module__ "
+                                              "present")
+                                    else:
+                                        print("... skipped as Numba internal")
+                                break
+                else:
+                    if DEBUG == 2:
+                        print("... OK")
+
+        # Compile something to make sure that the typing context registries
+        # are populated with everything from the CPU target.
+        njit(lambda : None).compile(())
+        tyctx = numba.core.typing.context.Context()
+        tyctx.refresh()
+
+        # Walk the registries and check each function that is an overload
+        regs = tyctx._registries
+        for k, v in regs.items():
+            for item in k.functions:
+                if getattr(item, '_overload_func', False):
+                    checker(item.key, item._overload_func)
 
 
 if __name__ == "__main__":

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -3072,7 +3072,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         with self.assertRaises(TypingError) as raises:
             cfunc("abc")
 
-        self.assertIn('The first argument "arr" must be an array',
+        self.assertIn('The first argument "m" must be an array',
                       str(raises.exception))
 
         with self.assertRaises(TypingError) as raises:
@@ -5146,7 +5146,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         with self.assertRaises(TypingError) as raises:
             cfunc('abc', 0, 0)
 
-        self.assertIn('The first argument "arr" must be an array',
+        self.assertIn('The first argument "a" must be an array',
                       str(raises.exception))
 
         with self.assertRaises(TypingError) as raises:


### PR DESCRIPTION
This is a continuation of #9059, with thanks to @apmasell for this patch, authorship is preserved.

What this PR is about: Some of the Numba ``@overload``s for functions in NumPy and Python's built-ins were written using parameter names that did not match those used in API they were overloading. The result of this being that calling a function with such a mismatch using the parameter names as key-word arguments at the call site would result in a compilation error. This has now been universally fixed throughout the code base and a unit test is running with a best-effort attempt to prevent reintroduction of similar mistakes in the future.

Review order suggestion:
* Look at the combined diff of the original 5bcbb3a, cf75079 (adding test) and 587b15b (fixing further issues and de-duplicating code) to see that #9053 is addressed.
* Look solely at 86bf5cf next, this patch adds a function that scans all `@overload` API use and validates the function parameters. If you are happy with what this function does and the unit test that uses it, then the subsequent patches are just fixing the things it highlights as somewhat "mechanical" changes, each patch is isolated to a single module as per the commit message title.
* Look at 1bd2c6d which is a change log update.

Fixes #9053
Closes #9073