### PR TITLE
Add towncrier news snippets for PRs that are missing them.

### DIFF
--- a/docs/upcoming_changes/7262.bug_fix.rst
+++ b/docs/upcoming_changes/7262.bug_fix.rst
@@ -1,0 +1,5 @@
+Handling of different sized unsigned integer indexes are fixed in ``numba.typed.List``.
+=======================================================================================
+
+An issue with the order of truncation/extension and casting of unsigned integer
+indexes in ``numba.typed.List`` has been fixed.

--- a/docs/upcoming_changes/7543.np_support.rst
+++ b/docs/upcoming_changes/7543.np_support.rst
@@ -1,0 +1,5 @@
+All modes are supported in ``numpy.correlate`` and ``numpy.convolve``.
+======================================================================
+
+All values for the ``mode`` argument to ``numpy.correlate`` and
+``numpy.convolve`` are now supported.

--- a/docs/upcoming_changes/8462.improvement.rst
+++ b/docs/upcoming_changes/8462.improvement.rst
@@ -1,0 +1,6 @@
+Updates to ``numba.core.pythonapi``.
+====================================
+
+Support for Python C-API functions ``PyBytes_AsString`` and
+``PyBytes_AsStringAndSize`` is added to ``numba.core.pythonapi.PythonAPI`` as
+``bytes_as_string`` and ``bytes_as_string_and_size`` methods respectively.

--- a/docs/upcoming_changes/8736.np_support.rst
+++ b/docs/upcoming_changes/8736.np_support.rst
@@ -1,0 +1,5 @@
+Support is added for ``numpy.lib.stride_tricks.sliding_window_view``.
+=====================================================================
+
+Support is added for ``numpy.lib.stride_tricks.sliding_window_view`` with
+arguments ``window_size`` and ``axis``.

--- a/docs/upcoming_changes/8885.bug_fix.rst
+++ b/docs/upcoming_changes/8885.bug_fix.rst
@@ -1,0 +1,5 @@
+The ``numpy.allclose`` implementation now correctly handles default arguments.
+==============================================================================
+
+The implementation of ``numpy.allclose`` is corrected to use ``TypingError`` to
+report typing errors.

--- a/docs/upcoming_changes/8892.new_feature.rst
+++ b/docs/upcoming_changes/8892.new_feature.rst
@@ -1,0 +1,8 @@
+``numba.experimental.jitclass`` gains support for ``__*matmul__`` methods.
+==========================================================================
+
+``numba.experimental.jitclass`` now has support for the following methods:
+
+* ``__matmul__``
+* ``__imatmul__``
+* ``__rmatmul__``

--- a/docs/upcoming_changes/8906.new_feature.rst
+++ b/docs/upcoming_changes/8906.new_feature.rst
@@ -1,0 +1,17 @@
+``numba.experimental.jitclass`` gains support for reflected "dunder" methods.
+=============================================================================
+
+``numba.experimental.jitclass`` now has support for the following methods:
+
+* ``__radd__``
+* ``__rand_``
+* ``__rfloordiv__``
+* ``__rlshift__``
+* ``__ror_``
+* ``__rmod_``
+* ``__rmul_``
+* ``__rpow_``
+* ``__rrshift_``
+* ``__rsub_``
+* ``__rtruediv_``
+* ``__rxor_``

--- a/docs/upcoming_changes/8911.improvement.rst
+++ b/docs/upcoming_changes/8911.improvement.rst
@@ -1,0 +1,5 @@
+Support for ``isinstance`` is now non-experimental.
+===================================================
+
+Support for the ``isinstance`` built-in function has moved from being considered
+an experimental feature to a fully supported feature.

--- a/docs/upcoming_changes/8916.change.rst
+++ b/docs/upcoming_changes/8916.change.rst
@@ -1,0 +1,4 @@
+The minimum ``llvmlite`` version is now 0.41.0.
+===============================================
+
+The minimum required version of ``llvmlite`` is now version 0.41.0.

--- a/docs/upcoming_changes/8944.bug_fix.rst
+++ b/docs/upcoming_changes/8944.bug_fix.rst
@@ -1,0 +1,4 @@
+Add type validation to ``numpy.isclose``.
+=========================================
+
+Type validation is added to the implementation of ``numpy.isclose``.

--- a/docs/upcoming_changes/8974.cuda.rst
+++ b/docs/upcoming_changes/8974.cuda.rst
@@ -1,0 +1,13 @@
+Bitwise operation ``ufunc`` support for the CUDA target.
+========================================================
+
+Support is added for some ``ufunc``s associated with bitwise operation on the
+CUDA target. Namely:
+
+* ``numpy.bitwise_and``
+* ``numpy.bitwise_or``
+* ``numpy.bitwise_not``
+* ``numpy.bitwise_xor``
+* ``numpy.invert``
+* ``numpy.left_shift``
+* ``numpy.right_shift``

--- a/docs/upcoming_changes/8988.cuda.rst
+++ b/docs/upcoming_changes/8988.cuda.rst
@@ -1,0 +1,4 @@
+Add support for the latest CUDA driver codes.
+=============================================
+
+Support is added for the latest set of CUDA driver codes.

--- a/docs/upcoming_changes/8995.np_support.rst
+++ b/docs/upcoming_changes/8995.np_support.rst
@@ -1,0 +1,7 @@
+``@vectorize`` accommodates arguments implementing ``__array_ufunc__``.
+=======================================================================
+
+Universal functions (``ufunc``s) created with ``numba.vectorize`` will now
+respect arguments implementing ``__array_ufunc__`` (NEP-13) to allow pre- and
+post-processing of arguments and return values when the ufunc is called from the
+interpreter.

--- a/docs/upcoming_changes/9035.cuda.rst
+++ b/docs/upcoming_changes/9035.cuda.rst
@@ -1,0 +1,6 @@
+Add debuginfo support to nvdisasm output.
+=========================================
+
+Support is added for debuginfo (source line and inlining information) in
+functions that make calls through ``nvdisasm``. For example the CUDA dispatcher
+``.inspect_sass`` method output is now augmented with this information.


### PR DESCRIPTION
This adds news snippets for PRs that are scheduled for Numba 0.58 but were merged prior to towncrier being enabled and a news snippet being a requirement.

Closes #9070

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
