### PR TITLE
Add misc script to find missing towncrier news files

### DIFF
--- a/maint/towncrier_checker.py
+++ b/maint/towncrier_checker.py
@@ -14,6 +14,16 @@ Options:
   --repo=<repo>      Which repository to look at on GitHub
   --token=<token>    The GitHub token to talk to the API
 
+Package requirements:
+
+- pygithub
+- docopt
+- gitpython
+
+Can be installed with:
+
+    pip install pygithub docopt gitpython
+
 """
 
 import re

--- a/maint/towncrier_checker.py
+++ b/maint/towncrier_checker.py
@@ -1,0 +1,78 @@
+"""towncrier_checker.py
+
+Find missing towncrier news fragments.
+
+Usage:
+  towncrier_checker.py (-h | --help)
+  towncrier_checker.py --version
+  towncrier_checker.py  --token=<token> --beginning=<tag> --repo=<repo>
+
+Options:
+  -h --help          Show this screen.
+  --version          Show version.
+  --beginning=<tag>  Where in the History to begin
+  --repo=<repo>      Which repository to look at on GitHub
+  --token=<token>    The GitHub token to talk to the API
+
+"""
+
+import re
+import os.path
+from pathlib import Path
+
+from git import Repo
+from docopt import docopt
+from github import Github
+
+
+if __name__ == "__main__":
+    arguments = docopt(__doc__, version="1.0")
+    beginning = arguments["--beginning"]
+    target_ghrepo = arguments["--repo"]
+    github_token = arguments["--token"]
+    ghrepo = Github(github_token).get_repo(target_ghrepo)
+    repo = Repo(".")
+    all_commits = [x for x in repo.iter_commits(f"{beginning}..HEAD")]
+    merge_commits = [
+        x for x in all_commits if "Merge pull request" in x.message
+    ]
+    prmatch = re.compile(f"^Merge pull request #([0-9]+) from.*")
+    prs = {}
+    authors = set()
+    for x in merge_commits:
+        match = prmatch.match(x.message)
+        if match:
+            issue_id = match.groups()[0]
+            prs[issue_id] = "%s" % (x.message.splitlines()[2])
+
+    # Find towncrier files and remove them from the PR list
+    base = Path("docs/upcoming_changes")
+    for file in base.glob("*.*.rst"):
+        pr = str(file.relative_to(base)).split(".", 1)[0]
+        if pr in prs:
+            del prs[pr]
+        else:
+            print(f"No matching merge commit for {pr}")
+
+    # Find PRs that are mentioned in CHANGE_LOG already
+    # (most likely cherrypicked to previous bugfix releases)
+    with open(Path(os.path.dirname(__file__)) / ".." / "CHANGE_LOG") as fin:
+        # Use regex to find all PR numbers in the file and remove them
+        pr_re = re.compile(r"\#(\d+)")
+        prs_in_changelog = [
+            match.group(1) for match in pr_re.finditer(fin.read())
+        ]
+        to_remove = {pr for pr in prs if pr in prs_in_changelog}
+        for pr in to_remove:
+            print(f"Removing {pr} as already in CHANGELOG")
+            del prs[pr]
+
+    # Print PRs with missing notes
+    if prs:
+        print("PRs that are missing towncrier notes and not skipped")
+        for issue_id in sorted(prs):
+            pr = ghrepo.get_pull(int(issue_id))
+            if any("skip_release_notes" in label.name for label in pr.labels):
+                continue  # skip
+            else:
+                print(issue_id, pr.html_url)


### PR DESCRIPTION
The script finds missing towncrier files by scanning for merge commits that are not already in the CHANGE_LOG or not have the `skip_release_notes` label on github for the PR.
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
