### PR TITLE
Add noalias option to jit decorator.

### DIFF
--- a/numba/core/compiler.py
+++ b/numba/core/compiler.py
@@ -334,7 +334,7 @@ def run_frontend(func, inline_closures=False, emit_dels=False):
     if inline_closures:
         from numba.core.inline_closurecall import InlineClosureCallPass
         inline_pass = InlineClosureCallPass(func_ir, cpu.ParallelOptions(False),
-                                            {}, False)
+                                            Flags(), {}, False)
         inline_pass.run()
     post_proc = postproc.PostProcessor(func_ir)
     post_proc.run(emit_dels)

--- a/numba/core/cpu.py
+++ b/numba/core/cpu.py
@@ -282,6 +282,7 @@ _options_mixin = include_default_options(
     "error_model",
     "inline",
     "forceinline",
+    "noalias",
     # Add "target_backend" as a accepted option for the CPU in @jit(...)
     "target_backend",
     "_dbg_extend_lifetimes",
@@ -328,3 +329,5 @@ class CPUTargetOptions(_options_mixin, TargetOptions):
         if flags.forceinline:
             # forceinline turns off optnone, just like clang.
             flags.optnone = False
+
+        flags.inherit_if_not_set("noalias")

--- a/numba/core/inline_closurecall.py
+++ b/numba/core/inline_closurecall.py
@@ -70,7 +70,12 @@ class InlineClosureCallPass(object):
     closures, and inlines the body of the closure function to the call site.
     """
 
-    def __init__(self, func_ir, parallel_options, flags, swapped={}, typed=False):
+    def __init__(self,
+                 func_ir,
+                 parallel_options,
+                 flags,
+                 swapped={},
+                 typed=False):
         self.func_ir = func_ir
         self.parallel_options = parallel_options
         self.swapped = swapped

--- a/numba/core/inline_closurecall.py
+++ b/numba/core/inline_closurecall.py
@@ -70,12 +70,13 @@ class InlineClosureCallPass(object):
     closures, and inlines the body of the closure function to the call site.
     """
 
-    def __init__(self, func_ir, parallel_options, swapped={}, typed=False):
+    def __init__(self, func_ir, parallel_options, flags, swapped={}, typed=False):
         self.func_ir = func_ir
         self.parallel_options = parallel_options
         self.swapped = swapped
         self._processed_stencils = []
         self.typed = typed
+        self.flags = flags
 
     def run(self):
         """Run inline closure call pass.
@@ -143,7 +144,7 @@ class InlineClosureCallPass(object):
                 del self.func_ir.blocks[dead]
 
             # run dead code elimination
-            dead_code_elimination(self.func_ir)
+            dead_code_elimination(self.func_ir, self.flags)
             # do label renaming
             self.func_ir.blocks = rename_labels(self.func_ir.blocks)
 

--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -642,14 +642,14 @@ def remove_dead_block(block, lives, call_table, arg_aliases, alias_map,
     new_body = [block.terminator]
     # for each statement in reverse order, excluding terminator
     for stmt in reversed(block.body[:-1]):
-        if config.DEBUG_ARRAY_OPT >= 2:
-            print("remove_dead_block", stmt)
         # aliases of lives are also live
         alias_lives = set()
         init_alias_lives = lives & alias_set
         for v in init_alias_lives:
             alias_lives |= alias_map[v]
         lives_n_aliases = lives | alias_lives | arg_aliases
+        if config.DEBUG_ARRAY_OPT >= 2:
+            print("remove_dead_block", stmt, lives, alias_lives, arg_aliases)
 
         # let external calls handle stmt if type matches
         if type(stmt) in remove_dead_extensions:
@@ -658,7 +658,7 @@ def remove_dead_block(block, lives, call_table, arg_aliases, alias_map,
                      typemap, flags)
             if stmt is None:
                 if config.DEBUG_ARRAY_OPT >= 2:
-                    print("Statement was removed.")
+                    print("Statement was removed 1.")
                 removed = True
                 continue
 
@@ -669,12 +669,12 @@ def remove_dead_block(block, lives, call_table, arg_aliases, alias_map,
             if lhs.name not in lives and has_no_side_effect(
                     rhs, lives_n_aliases, call_table):
                 if config.DEBUG_ARRAY_OPT >= 2:
-                    print("Statement was removed.")
+                    print("Statement was removed 2.")
                 removed = True
                 continue
             if isinstance(rhs, ir.Var) and lhs.name == rhs.name:
                 if config.DEBUG_ARRAY_OPT >= 2:
-                    print("Statement was removed.")
+                    print("Statement was removed 3.")
                 removed = True
                 continue
             # TODO: remove other nodes like SetItem etc.
@@ -682,7 +682,7 @@ def remove_dead_block(block, lives, call_table, arg_aliases, alias_map,
         if isinstance(stmt, ir.Del):
             if stmt.value not in lives:
                 if config.DEBUG_ARRAY_OPT >= 2:
-                    print("Statement was removed.")
+                    print("Statement was removed 4.")
                 removed = True
                 continue
 
@@ -690,7 +690,7 @@ def remove_dead_block(block, lives, call_table, arg_aliases, alias_map,
             name = stmt.target.name
             if name not in lives_n_aliases:
                 if config.DEBUG_ARRAY_OPT >= 2:
-                    print("Statement was removed.")
+                    print("Statement was removed 5.")
                 continue
 
         if type(stmt) in analysis.ir_extension_usedefs:

--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -18,6 +18,7 @@ from numba.core.analysis import (compute_live_map, compute_use_defs,
 from numba.core.errors import (TypingError, UnsupportedError,
                                NumbaPendingDeprecationWarning,
                                CompilerError)
+from numba.core.compiler import Flags
 
 import copy
 
@@ -1781,13 +1782,14 @@ def get_ir_of_code(glbls, fcode):
             self.state.typemap = None
             self.state.return_type = None
             self.state.calltypes = None
+            self.state.flags = Flags()
     state = DummyPipeline(ir).state
     rewrites.rewrite_registry.apply('before-inference', state)
     # call inline pass to handle cases like stencils and comprehensions
     swapped = {} # TODO: get this from diagnostics store
     import numba.core.inline_closurecall
     inline_pass = numba.core.inline_closurecall.InlineClosureCallPass(
-        ir, numba.core.cpu.ParallelOptions(False), swapped)
+        ir, numba.core.cpu.ParallelOptions(False), state.flags, swapped)
     inline_pass.run()
 
     # TODO: DO NOT ADD MORE THINGS HERE!

--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -617,6 +617,7 @@ def remove_dead(blocks, args, func_ir, flags, *, typemap=None, alias_map=None, a
             if config.DEBUG_ARRAY_OPT >= 2:
                 print("succ live_map", out_blk, live_map[out_blk])
             lives |= live_map[out_blk]
+        lives |= set(args)
         removed |= remove_dead_block(block, lives, call_table, arg_aliases,
                                      alias_map, alias_set, func_ir, typemap, flags)
 

--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -597,12 +597,12 @@ def remove_dead(blocks, args, func_ir, typemap=None, alias_map=None, arg_aliases
         alias_map, arg_aliases = find_potential_aliases(blocks, args, typemap,
                                                         func_ir)
     if config.DEBUG_ARRAY_OPT >= 1:
-        print("args:", args)
-        print("alias map:", alias_map)
-        print("arg_aliases:", arg_aliases)
-        print("live_map:", live_map)
-        print("usemap:", usedefs.usemap)
-        print("defmap:", usedefs.defmap)
+        print("remove dead args:", args)
+        print("remove dead alias map:", alias_map)
+        print("remove dead arg_aliases:", arg_aliases)
+        print("remove dead live_map:", live_map)
+        print("remove dead usemap:", usedefs.usemap)
+        print("remove dead defmap:", usedefs.defmap)
     # keep set for easier search
     alias_set = set(alias_map.keys())
 
@@ -812,13 +812,18 @@ def get_canonical_alias(v, alias_map):
     v_aliases = sorted(list(alias_map[v]))
     return v_aliases[0]
 
-def find_potential_aliases(blocks, args, typemap, func_ir, alias_map=None,
-                                                           arg_aliases=None):
+def find_potential_aliases(blocks, args, typemap, func_ir, flags,
+                           alias_map=None, arg_aliases=None):
     "find all array aliases and argument aliases to avoid remove as dead"
     if alias_map is None:
         alias_map = {}
     if arg_aliases is None:
-        arg_aliases = set(a for a in args if not is_immutable_type(a, typemap))
+        if flags.noalias:
+            arg_aliases = {}
+        else:
+            arg_aliases = set(a for a in args if not is_immutable_type(a, typemap))
+    if config.DEBUG_ARRAY_OPT >= 1:
+        print("find_potential_aliases", args, alias_map, arg_aliases)
 
     # update definitions since they are not guaranteed to be up-to-date
     # FIXME keep definitions up-to-date to avoid the need for rebuilding

--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -18,7 +18,6 @@ from numba.core.analysis import (compute_live_map, compute_use_defs,
 from numba.core.errors import (TypingError, UnsupportedError,
                                NumbaPendingDeprecationWarning,
                                CompilerError)
-from numba.core.compiler import Flags
 
 import copy
 
@@ -1782,7 +1781,7 @@ def get_ir_of_code(glbls, fcode):
             self.state.typemap = None
             self.state.return_type = None
             self.state.calltypes = None
-            self.state.flags = Flags()
+            self.state.flags = compiler.Flags()
     state = DummyPipeline(ir).state
     rewrites.rewrite_registry.apply('before-inference', state)
     # call inline pass to handle cases like stencils and comprehensions

--- a/numba/core/options.py
+++ b/numba/core/options.py
@@ -90,6 +90,7 @@ class DefaultOptions:
     error_model = _mapping("error_model")
     inline = _mapping("inline")
     forceinline = _mapping("forceinline")
+    noalias = _mapping("noalias")
 
     target_backend = _mapping("target_backend")
 

--- a/numba/core/typed_passes.py
+++ b/numba/core/typed_passes.py
@@ -660,7 +660,7 @@ class InlineOverloads(FunctionPass):
             for dead in cfg.dead_nodes():
                 del state.func_ir.blocks[dead]
             # clean up blocks
-            dead_code_elimination(state.func_ir,
+            dead_code_elimination(state.func_ir, state.flags,
                                   typemap=state.typemap)
             # clean up unconditional branches that appear due to inlined
             # functions introducing blocks
@@ -860,7 +860,7 @@ class DeadCodeElimination(FunctionPass):
         FunctionPass.__init__(self)
 
     def run_pass(self, state):
-        dead_code_elimination(state.func_ir, state.typemap)
+        dead_code_elimination(state.func_ir, state.flags, typemap=state.typemap)
         return True
 
 

--- a/numba/core/untyped_passes.py
+++ b/numba/core/untyped_passes.py
@@ -201,6 +201,7 @@ class InlineClosureLikes(FunctionPass):
         inline_pass = InlineClosureCallPass(
             state.func_ir,
             state.flags.auto_parallel,
+            state.flags,
             state.parfor_diagnostics.replaced_fns,
             typed_pass)
         inline_pass.run()

--- a/numba/parfors/array_analysis.py
+++ b/numba/parfors/array_analysis.py
@@ -1083,11 +1083,12 @@ class ArrayAnalysis(object):
     parfor optimizations.
     """
 
-    def __init__(self, context, func_ir, typemap, calltypes):
+    def __init__(self, context, func_ir, typemap, calltypes, flags):
         self.context = context
         self.func_ir = func_ir
         self.typemap = typemap
         self.calltypes = calltypes
+        self.flags = flags
 
         # EquivSet of variables, indexed by block number
         self.equiv_sets = {}
@@ -1135,7 +1136,8 @@ class ArrayAnalysis(object):
             blocks,
             self.func_ir.arg_names,
             self.typemap,
-            self.func_ir
+            self.func_ir,
+            self.flags
         )
 
         aa_count_save = ArrayAnalysis.aa_count

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -3015,10 +3015,14 @@ class ParforFusionPass(ParforPassStates):
 
     def fuse_recursive_parfor(self, parfor, equiv_set, func_ir, typemap):
         blocks = wrap_parfor_blocks(parfor)
-        maximize_fusion(self.func_ir, blocks, self.typemap, self.flags)
+        maximize_fusion(self.func_ir, blocks, self.typemap, self.flags,
+                        self.alias_map, self.arg_aliases)
         dprint_func_ir(self.func_ir, "after recursive maximize fusion down", blocks)
-        arr_analysis = array_analysis.ArrayAnalysis(self.typingctx, self.func_ir,
-                                                self.typemap, self.calltypes)
+        arr_analysis = array_analysis.ArrayAnalysis(self.typingctx,
+                                                    self.func_ir,
+                                                    self.typemap,
+                                                    self.calltypes,
+                                                    self.flags)
         arr_analysis.run(blocks, equiv_set)
         self.fuse_parfors(arr_analysis, blocks, func_ir, typemap)
         unwrap_parfor_blocks(parfor)

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -3995,6 +3995,7 @@ def maximize_fusion(func_ir, blocks, typemap, flags, alias_map, arg_aliases,
                                 up_direction
                             )
 
+
 def maximize_fusion_inner(func_ir, block, call_table, alias_map,
                           arg_aliases, up_direction=True):
     order_changed = False

--- a/numba/parfors/parfor_lowering.py
+++ b/numba/parfors/parfor_lowering.py
@@ -110,10 +110,12 @@ def _lower_parfor_parallel_std(lowerer, parfor):
             rv = ir.Var(scope, racevar, loc)
             lowerer._alloca_var(rv.name, rvtyp)
 
-    alias_map = {}
-    arg_aliases = {}
-    numba.parfors.parfor.find_potential_aliases_parfor(parfor, parfor.params, typemap,
-                                        lowerer.func_ir, alias_map, arg_aliases)
+    #alias_map = {}
+    #arg_aliases = {}
+    alias_map, arg_aliases = numba.parfors.parfor.find_potential_aliases_parfor(
+                                 parfor, parfor.params, typemap,
+                                 lowerer.func_ir, parfor.flags)
+                                 #lowerer.func_ir, False, alias_map, arg_aliases)
     if config.DEBUG_ARRAY_OPT:
         print("alias_map", alias_map)
         print("arg_aliases", arg_aliases)
@@ -1041,7 +1043,7 @@ def _create_gufunc_for_parfor_body(
     for the parfor body inserted.
     '''
     if config.DEBUG_ARRAY_OPT >= 1:
-        print("starting _create_gufunc_for_parfor_body")
+        print("starting _create_gufunc_for_parfor_body", has_aliases)
 
     loc = parfor.init_block.loc
 

--- a/numba/stencils/stencilparfor.py
+++ b/numba/stencils/stencilparfor.py
@@ -155,7 +155,7 @@ class StencilPass(object):
             print("stencil_blocks after copy_propagate")
             ir_utils.dump_blocks(stencil_blocks)
         ir_utils.remove_dead(stencil_blocks, self.func_ir.arg_names, stencil_ir,
-                             self.typemap)
+                             self.flags, typemap=self.typemap)
         if config.DEBUG_ARRAY_OPT >= 1:
             print("stencil_blocks after removing dead code")
             ir_utils.dump_blocks(stencil_blocks)

--- a/numba/tests/test_analysis.py
+++ b/numba/tests/test_analysis.py
@@ -74,7 +74,8 @@ class TestBranchPruneBase(MemoryLeakMixin, TestCase):
 
         # run closure inlining to ensure that nonlocals in closures are visible
         inline_pass = InlineClosureCallPass(func_ir,
-                                            cpu.ParallelOptions(False),)
+                                            cpu.ParallelOptions(False),
+                                            Flags())
         inline_pass.run()
 
         # Remove all Dels, and re-run postproc

--- a/numba/tests/test_array_analysis.py
+++ b/numba/tests/test_array_analysis.py
@@ -98,7 +98,8 @@ class ArrayAnalysisPass(FunctionPass):
 
     def run_pass(self, state):
         state.array_analysis = ArrayAnalysis(state.typingctx, state.func_ir,
-                                             state.typemap, state.calltypes)
+                                             state.typemap, state.calltypes,
+                                             state.flags)
         state.array_analysis.run(state.func_ir.blocks)
         post_proc = postproc.PostProcessor(state.func_ir)
         post_proc.run()

--- a/numba/tests/test_array_analysis.py
+++ b/numba/tests/test_array_analysis.py
@@ -175,7 +175,7 @@ class TestArrayAnalysis(TestCase):
     def compare_ir(self, ir_list):
         outputs = []
         for func_ir in ir_list:
-            remove_dead(func_ir.blocks, func_ir.arg_names, func_ir)
+            remove_dead(func_ir.blocks, func_ir.arg_names, func_ir, Flags())
             output = StringIO()
             func_ir.dump(file=output)
             outputs.append(output.getvalue())

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -671,6 +671,7 @@ class TestPipeline(object):
         self.state.return_type = None
         self.state.calltypes = None
         self.state.metadata = {}
+        self.state.flags = compiler.DEFAULT_FLAGS
 
 
 @skip_parfors_unsupported

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -486,6 +486,7 @@ def get_optimized_numba_ir(test_func, args, **kws):
 
         inline_pass = inline_closurecall.InlineClosureCallPass(tp.state.func_ir,
                                                                options,
+                                                               tp.state.flags,
                                                                typed=True)
         inline_pass.run()
 

--- a/numba/tests/test_parfors_passes.py
+++ b/numba/tests/test_parfors_passes.py
@@ -35,6 +35,7 @@ class MyPipeline(object):
         self.state.return_type = None
         self.state.calltypes = None
         self.state.metadata = {}
+        self.state.flags = compiler.DEFAULT_FLAGS
 
 
 class BaseTest(TestCase):

--- a/numba/tests/test_parfors_passes.py
+++ b/numba/tests/test_parfors_passes.py
@@ -54,7 +54,7 @@ class BaseTest(TestCase):
             targetctx.refresh()
 
             inline_pass = inline_closurecall.InlineClosureCallPass(
-                tp.state.func_ir, options, typed=True
+                tp.state.func_ir, options, tp.state.flags, typed=True
             )
             inline_pass.run()
 

--- a/numba/tests/test_remove_dead.py
+++ b/numba/tests/test_remove_dead.py
@@ -81,7 +81,7 @@ class TestRemoveDead(unittest.TestCase):
             in_cps, out_cps = copy_propagate(test_ir.blocks, typemap)
             apply_copy_propagate(test_ir.blocks, in_cps, get_name_var_table(test_ir.blocks), typemap, calltypes)
 
-            remove_dead(test_ir.blocks, test_ir.arg_names, test_ir)
+            remove_dead(test_ir.blocks, test_ir.arg_names, test_ir, Flags())
             self.assertFalse(findLhsAssign(test_ir, "x"))
 
     def test2(self):
@@ -98,7 +98,7 @@ class TestRemoveDead(unittest.TestCase):
             return False
 
         test_ir = compiler.run_frontend(call_np_random_seed)
-        remove_dead(test_ir.blocks, test_ir.arg_names, test_ir)
+        remove_dead(test_ir.blocks, test_ir.arg_names, test_ir, Flags())
         self.assertTrue(seed_call_exists(test_ir))
 
     def run_array_index_test(self, func):
@@ -261,7 +261,9 @@ class TestRemoveDead(unittest.TestCase):
                 remove_dead(state.func_ir.blocks,
                             state.func_ir.arg_names,
                             state.func_ir,
-                            state.typemap)
+                            state.flags,
+                            typemap=state.typemap,
+)
                 numba.parfors.parfor.get_parfor_params(state.func_ir.blocks,
                                                 parfor_pass.options.fusion,
                                                 parfor_pass.nested_fusion_info)


### PR DESCRIPTION
Adds noalias option to jit decorator which the programmer can use to assert that none of the arguments to the function can share memory.  Ultimately, this will cause all the pointers in the memory models for the argument to have the noalias LLVM qualifier set when the Numba IR is lowered to LLVM.  This will enable more code to vectorize since the possibility of aliasing will frequently cause the LLVM vectorizer to give up.

Previously, parallel=True would try to do an analysis to see whether it can add the noalias flag to the arguments passed to the parallel region gufunc.  This PR improves that process and uses the aliasing information from the outer function better and so if noalias is given for the outer function it will often enable parallel=True to add the noalias flag to the outlined gufunc as well.