### PR TITLE
Update conda-recipe for numba-rvsdg

### DIFF
--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -63,6 +63,8 @@ requirements:
     - scipy >=1.0
     # CUDA Python 11.6 or later
     - cuda-python >=11.6
+    # numba-rvsdg
+    - numba-rvsdg ==0.0.2      # [py==311]
 
 test:
   requires:

--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -64,7 +64,7 @@ requirements:
     # CUDA Python 11.6 or later
     - cuda-python >=11.6
     # numba-rvsdg
-    - numba-rvsdg ==0.0.2      # [py==311]
+    - numba-rvsdg 0.0.*      # [py==311]
 
 test:
   requires:

--- a/numba/core/rvsdg_frontend/__init__.py
+++ b/numba/core/rvsdg_frontend/__init__.py
@@ -1,0 +1,17 @@
+from numba.core.utils import PYVERSION
+
+def _ensure_rvsdg_supported():
+    """Check that rvsdg_frontend is usable
+    """
+    # Only support Python 3.11.
+    if PYVERSION != (3, 11):
+        raise ImportError("rvsdg_frontend is only supported on python 3.11")
+    # Require that numba_rvsdg to be installed.
+    try:
+        import numba_rvsdg
+    except ImportError:
+        raise ImportError("Failed to import numba_rvsdg package, "
+                          "which is required for the rvsdg_frontend.")
+
+
+_ensure_rvsdg_supported()


### PR DESCRIPTION
Base on #9012.
Depends on https://github.com/numba/numba-rvsdg/pull/91.

- https://github.com/numba/numba/pull/9120/commits/80eb15079f6e2b8f1fac69e9cf82febd4fca25d6 adds runtime constraints for numba-rvsdg.
- https://github.com/numba/numba/pull/9120/commits/1b19c223f2a5317015faf824feba9eee5c3f26f2 adds import guard and direct user to install numba-rvsdg when the rvsdg-frontend subpackage is used.

