### PR TITLE
Fix accidental cffi test deps, refactor cffi skipping

### DIFF
--- a/numba/cuda/tests/cudapy/test_cffi.py
+++ b/numba/cuda/tests/cudapy/test_cffi.py
@@ -1,20 +1,16 @@
 import numpy as np
 
-try:
-    import cffi
-    _have_cffi = True
-except ImportError:
-    _have_cffi = False
-
 from numba import cuda, types
 from numba.cuda.testing import (skip_on_cudasim, test_data_dir, unittest,
                                 CUDATestCase)
+from numba.tests.support import skip_unless_cffi
 
 
-@unittest.skipUnless(_have_cffi, 'Needs CFFI')
+@skip_unless_cffi
 @skip_on_cudasim('Simulator does not support linking')
 class TestCFFI(CUDATestCase):
     def test_from_buffer(self):
+        import cffi
         ffi = cffi.FFI()
 
         link = str(test_data_dir / 'jitlink.ptx')

--- a/numba/cuda/tests/doc_examples/test_ffi.py
+++ b/numba/cuda/tests/doc_examples/test_ffi.py
@@ -3,8 +3,10 @@
 
 import unittest
 from numba.cuda.testing import (CUDATestCase, skip_on_cudasim)
+from numba.tests.support import skip_unless_cffi
 
 
+@skip_unless_cffi
 @skip_on_cudasim("cudasim doesn't support cuda import at non-top-level")
 class TestFFI(CUDATestCase):
     def test_ex_linking_cu(self):

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -32,6 +32,7 @@ import numpy as np
 
 from numba import testing, types
 from numba.core import errors, typing, utils, config, cpu
+from numba.core.typing import cffi_utils
 from numba.core.compiler import (compile_extra, compile_isolated, Flags,
                                  DEFAULT_FLAGS, CompilerBase,
                                  DefaultPassBuilder)
@@ -108,6 +109,8 @@ def expected_failure_py311(fn):
 
 _msg = "SciPy needed for test"
 skip_unless_scipy = unittest.skipIf(scipy is None, _msg)
+
+skip_unless_cffi = unittest.skipUnless(cffi_utils.SUPPORTED, 'requires cffi')
 
 _lnx_reason = 'linux only test'
 linux_only = unittest.skipIf(not sys.platform.startswith('linux'), _lnx_reason)

--- a/numba/tests/test_cffi.py
+++ b/numba/tests/test_cffi.py
@@ -5,7 +5,7 @@ from numba import jit
 import numba.core.typing.cffi_utils as cffi_support
 from numba.core import types, errors
 from numba.core.compiler import compile_isolated, Flags
-from numba.tests.support import TestCase, tag
+from numba.tests.support import TestCase, skip_unless_cffi, tag
 
 import numba.tests.cffi_usecases as mod
 import unittest
@@ -17,8 +17,7 @@ enable_pyobj_flags.enable_pyobject = True
 no_pyobj_flags = Flags()
 
 
-@unittest.skipUnless(cffi_support.SUPPORTED,
-                     "CFFI not supported -- please install the cffi module")
+@skip_unless_cffi
 class TestCFFI(TestCase):
 
     # Need to run the tests serially because of race conditions in

--- a/numba/tests/test_cfunc.py
+++ b/numba/tests/test_cfunc.py
@@ -14,14 +14,10 @@ import numpy as np
 from numba import cfunc, carray, farray, njit
 from numba.core import types, typing, utils
 import numba.core.typing.cffi_utils as cffi_support
-from numba.tests.support import TestCase, tag, captured_stderr
+from numba.tests.support import (TestCase, skip_unless_cffi, tag,
+                                 captured_stderr)
 import unittest
 from numba.np import numpy_support
-
-skip_cffi_unsupported = unittest.skipUnless(
-    cffi_support.SUPPORTED,
-    "CFFI not supported -- please install the cffi module",
-)
 
 
 def add_usecase(a, b):
@@ -130,7 +126,7 @@ class TestCFunc(TestCase):
 
         self.assertPreciseEqual(ct(2.0, 3.5), 5.5)
 
-    @skip_cffi_unsupported
+    @skip_unless_cffi
     def test_cffi(self):
         from numba.tests import cffi_usecases
         ffi, lib = cffi_usecases.load_inline_module()
@@ -304,7 +300,7 @@ class TestCArray(TestCase):
         self.check_numba_carray_farray(farray_usecase, farray_dtype_usecase)
 
 
-@skip_cffi_unsupported
+@skip_unless_cffi
 class TestCffiStruct(TestCase):
     c_source = """
 typedef struct _big_struct {

--- a/numba/tests/test_errorhandling.py
+++ b/numba/tests/test_errorhandling.py
@@ -7,7 +7,6 @@ import os
 
 from numba import jit, njit, typed, int64, types
 from numba.core import errors
-import numba.core.typing.cffi_utils as cffi_support
 from numba.experimental import structref
 from numba.extending import (overload, intrinsic, overload_method,
                              overload_attribute)
@@ -20,7 +19,8 @@ from numba.core.compiler_machinery import PassManager
 from numba.core.types.functions import _err_reasons as error_reasons
 
 from numba.tests.support import (skip_parfors_unsupported, override_config,
-                                 SerialMixin, skip_unless_scipy)
+                                 SerialMixin, skip_unless_cffi,
+                                 skip_unless_scipy)
 import unittest
 
 # used in TestMiscErrorHandling::test_handling_of_write_to_*_global
@@ -393,7 +393,7 @@ class TestErrorMessages(unittest.TestCase):
         excstr = str(raises.exception)
         self.assertIn("Type Restricted Function in function 'unknown'", excstr)
 
-    @unittest.skipUnless(cffi_support.SUPPORTED, "CFFI not supported")
+    @skip_unless_cffi
     def test_cffi_function_pointer_template_source(self):
         from numba.tests import cffi_usecases as mod
         mod.init()

--- a/numba/tests/test_nrt.py
+++ b/numba/tests/test_nrt.py
@@ -20,12 +20,11 @@ from numba.core.typing import signature
 from numba.core.imputils import impl_ret_untracked
 from llvmlite import ir
 import llvmlite.binding as llvm
-import numba.core.typing.cffi_utils as cffi_support
 from numba.core.unsafe.nrt import NRT_get_api
 
 from numba.tests.support import (EnableNRTStatsMixin, TestCase, temp_directory,
                                  import_dynamic, skip_if_32bit,
-                                 run_in_subprocess)
+                                 skip_unless_cffi, run_in_subprocess)
 from numba.core.registry import cpu_target
 import unittest
 
@@ -599,7 +598,7 @@ br i1 %.294, label %B42, label %B160
         self.assertEqual(foo(10), 22) # expect (10 + 1) * 2 = 22
 
 
-@unittest.skipUnless(cffi_support.SUPPORTED, "cffi required")
+@skip_unless_cffi
 class TestNrtExternalCFFI(EnableNRTStatsMixin, TestCase):
     """Testing the use of externally compiled C code that use NRT
     """

--- a/numba/tests/test_typeof.py
+++ b/numba/tests/test_typeof.py
@@ -10,14 +10,13 @@ import typing as py_typing
 import numpy as np
 
 import unittest
-import numba.core.typing.cffi_utils as cffi_support
 from numba.core import types
 from numba.core.errors import NumbaValueError, NumbaTypeError
 from numba.misc.special import typeof
 from numba.core.dispatcher import OmittedArg
 from numba._dispatcher import compute_fingerprint
 
-from numba.tests.support import TestCase, tag
+from numba.tests.support import TestCase, skip_unless_cffi, tag
 from numba.tests.test_numpy_support import ValueTypingTestBase
 from numba.tests.ctypes_usecases import *
 from numba.tests.enum_usecases import *
@@ -282,7 +281,7 @@ class TestTypeof(ValueTypingTestBase, TestCase):
         self.assertNotEqual(ty_cos.get_pointer(c_cos),
                             ty_sin.get_pointer(c_sin))
 
-    @unittest.skipUnless(cffi_support.SUPPORTED, "CFFI not supported")
+    @skip_unless_cffi
     def test_cffi(self):
         from numba.tests import cffi_usecases as mod
         mod.init()


### PR DESCRIPTION
PR #9086 accidentally introduced (or exacerbated) and accidental cffi dependency in the CUDA tests. This commit fixes the issue.

Additionally, there are several ways to skip tests that need cffi when it is not present - we unify them with a new decorator, `skip_unless_cffi`.