### PR TITLE
Fix error when literal is wrongly propagated in a PHI node

### DIFF
--- a/docs/upcoming_changes/9126.bug_fix.rst
+++ b/docs/upcoming_changes/9126.bug_fix.rst
@@ -1,0 +1,5 @@
+Fix propagation of literal values in PHI nodes.
+"""""""""""""""""""""""""""""""""""""""""""""""
+
+Fixed a bug in the literal propagation pass where a PHI node could be wrongly
+replaced by a constant.

--- a/numba/core/untyped_passes.py
+++ b/numba/core/untyped_passes.py
@@ -1577,8 +1577,10 @@ class PropagateLiterals(FunctionPass):
                 # Only propagate a PHI node if all arguments are the same
                 # constant
                 if isinstance(value, ir.Expr) and value.op == 'phi':
+                    # typemap will return None in case `inc.name` not in typemap
                     v = [typemap.get(inc.name) for inc in value.incoming_values]
-                    if any([v[0] != vi for vi in v]):
+                    # stop if the elements in `v` do not hold the same value
+                    if v[0] is not None and any([v[0] != vi for vi in v]):
                         continue
 
                 lit = typemap.get(target.name, None)

--- a/numba/core/untyped_passes.py
+++ b/numba/core/untyped_passes.py
@@ -1574,6 +1574,13 @@ class PropagateLiterals(FunctionPass):
                                    'due to a branch.')
                             raise errors.NumbaTypeError(msg, loc=assign.loc)
 
+                # Only propagate a PHI node if all arguments are the same
+                # constant
+                if isinstance(value, ir.Expr) and value.op == 'phi':
+                    v = [typemap.get(inc.name) for inc in value.incoming_values]
+                    if any([v[0] != vi for vi in v]):
+                        continue
+
                 lit = typemap.get(target.name, None)
                 if lit and isinstance(lit, types.Literal):
                     # replace assign instruction by ir.Const(lit) iff

--- a/numba/tests/test_builtins.py
+++ b/numba/tests/test_builtins.py
@@ -309,6 +309,17 @@ def invalid_isinstance_usecase_phi_nopropagate(x):
         return False
 
 
+def invalid_isinstance_usecase_phi_nopropagate2(a):
+    # Numba issue #9125
+    x = 0
+    if isinstance(a, int):
+        a = (a, a)
+
+    for i in range(len(a)):
+        x += i
+    return x
+
+
 def invalid_isinstance_optional_usecase(x):
     if x > 4:
         z = 10
@@ -1245,6 +1256,11 @@ class TestIsinstanceBuiltin(TestCase):
         pyfunc = isinstance_dict
         cfunc = jit(nopython=True)(pyfunc)
         self.assertEqual(pyfunc(), cfunc())
+
+    def test_isinstance_issue9125(self):
+        pyfunc = invalid_isinstance_usecase_phi_nopropagate2
+        cfunc = jit(nopython=True)(pyfunc)
+        self.assertEqual(pyfunc(3), cfunc(3))
 
     def test_isinstance_numba_types(self):
         # This makes use of type aliasing between python scalars and NumPy


### PR DESCRIPTION
Fix numba issue #9125 - Don't propagate literal if node is a PHI node.

Reproducer:

```python
from numba import njit

@njit
def foo(a):
    x = 0
    if isinstance(a, int):
        # renaming variable fixes the issue: "b = (a, a)"
        a = (a, a)

    for i in range(len(a)):
        x += i
    return x

a = 3
print(foo(a))  # 0
print(foo.py_func(a))  # 1
```

Closes #9125