### PR TITLE
Fix old_style error capturing deprecation warnings

### DIFF
--- a/numba/core/errors.py
+++ b/numba/core/errors.py
@@ -457,6 +457,9 @@ class WarningsFixer(object):
     An object "fixing" warnings of a given category caught during
     certain phases.  The warnings can have their filename and lineno fixed,
     and they are deduplicated as well.
+
+    When used as a context manager, any warnings caught by `.catch_warnings()`
+    will be flushed at the exit of the context manager.
     """
 
     def __init__(self, category):
@@ -501,6 +504,12 @@ class WarningsFixer(object):
             for msg in sorted(messages):
                 warnings.warn_explicit(msg, category, filename, lineno)
         self._warnings.clear()
+
+    def __enter__(self):
+        return
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.flush()
 
 
 class NumbaError(Exception):

--- a/numba/core/utils.py
+++ b/numba/core/utils.py
@@ -193,9 +193,10 @@ atexit.register(_at_shutdown)
 
 
 _old_style_deprecation_msg = (
-"Code using Numba extension API maybe depending on 'old_style' error-capturing,"
-" which is deprecated and will be replaced by 'new_style' in a future release."
-" See details at https://numba.readthedocs.io/en/latest/reference/deprecation.html#deprecation-of-old-style-numba-captured-errors" # noqa: E501
+    "Code using Numba extension API maybe depending on 'old_style' "
+    "error-capturing, which is deprecated and will be replaced by 'new_style' "
+    "in a future release. See details at "
+    "https://numba.readthedocs.io/en/latest/reference/deprecation.html#deprecation-of-old-style-numba-captured-errors" # noqa: E501
 )
 
 

--- a/numba/core/utils.py
+++ b/numba/core/utils.py
@@ -195,12 +195,14 @@ atexit.register(_at_shutdown)
 def _warn_old_style():
     from numba.core import errors  # to prevent circular import
 
-    warnings.warn(
-        "The 'old_style' error capturing is deprecated "
-        "and will be replaced by `new_style` in a future release.",
-        errors.NumbaPendingDeprecationWarning,
-        stacklevel=3
-    )
+    exccls, _, _ = sys.exc_info()
+    # Warn only if the active exception is not a NumbaError
+    if exccls is not None and not issubclass(exccls, errors.NumbaError):
+        warnings.warn(
+            "The 'old_style' error capturing is deprecated "
+            "and will be replaced by `new_style` in a future release.",
+            errors.NumbaPendingDeprecationWarning,
+        )
 
 
 def use_new_style_errors():

--- a/numba/core/utils.py
+++ b/numba/core/utils.py
@@ -192,17 +192,21 @@ weakref.finalize(lambda: None, lambda: None)
 atexit.register(_at_shutdown)
 
 
+_old_style_deprecation_msg = (
+"Code using Numba extension API maybe depending on 'old_style' error-capturing,"
+" which is deprecated and will be replaced by 'new_style' in a future release."
+" See details at https://numba.readthedocs.io/en/latest/reference/deprecation.html#deprecation-of-old-style-numba-captured-errors" # noqa: E501
+)
+
+
 def _warn_old_style():
     from numba.core import errors  # to prevent circular import
 
     exccls, _, _ = sys.exc_info()
     # Warn only if the active exception is not a NumbaError
     if exccls is not None and not issubclass(exccls, errors.NumbaError):
-        warnings.warn(
-            "The 'old_style' error capturing is deprecated "
-            "and will be replaced by `new_style` in a future release.",
-            errors.NumbaPendingDeprecationWarning,
-        )
+        warnings.warn(_old_style_deprecation_msg,
+                      errors.NumbaPendingDeprecationWarning)
 
 
 def use_new_style_errors():

--- a/numba/core/utils.py
+++ b/numba/core/utils.py
@@ -205,7 +205,9 @@ def _warn_old_style():
 
     exccls, _, tb = sys.exc_info()
     # Warn only if the active exception is not a NumbaError
-    if exccls is not None and not issubclass(exccls, errors.NumbaError):
+    # and not a NumbaWarning which is raised if -Werror is set.
+    numba_errs = (errors.NumbaError, errors.NumbaWarning)
+    if exccls is not None and not issubclass(exccls, numba_errs):
         tb_last = traceback.format_tb(tb)[-1]
         msg = f"{_old_style_deprecation_msg}\nException origin:\n{tb_last}"
         warnings.warn(msg,

--- a/numba/core/utils.py
+++ b/numba/core/utils.py
@@ -203,10 +203,12 @@ _old_style_deprecation_msg = (
 def _warn_old_style():
     from numba.core import errors  # to prevent circular import
 
-    exccls, _, _ = sys.exc_info()
+    exccls, _, tb = sys.exc_info()
     # Warn only if the active exception is not a NumbaError
     if exccls is not None and not issubclass(exccls, errors.NumbaError):
-        warnings.warn(_old_style_deprecation_msg,
+        tb_last = traceback.format_tb(tb)[-1]
+        msg = f"{_old_style_deprecation_msg}\nException origin:\n{tb_last}"
+        warnings.warn(msg,
                       errors.NumbaPendingDeprecationWarning)
 
 

--- a/numba/tests/test_errorhandling.py
+++ b/numba/tests/test_errorhandling.py
@@ -493,8 +493,11 @@ class TestCapturedErrorHandling(SerialMixin, TestCase):
                 def foo(x):
                     bar(x)
 
-            self.assertIn("The 'old_style' error capturing is deprecated",
-                          str(warns.warnings[0].message))
+            self.assertIn(
+                "Code using Numba extension API maybe depending on 'old_style' "
+                "error-capturing",
+                str(warns.warnings[0].message),
+            )
 
     @TestCase.run_test_in_subprocess(
         envvars={"NUMBA_CAPTURED_ERRORS": "old_style"},


### PR DESCRIPTION
Closes #9151

- da49bf39f31ece669b9d56fde5ab08143db63e20 fixes the invalid raising of deprecation warnings when the active exception is a NumbaError. I also have to fix a problem that warnings were suppressed if an exception is raised at typing.
- 8d04ce893ec0694b2dbbcc0ef0705e1ec9e41a4c clarifies the message.
- The remaining commits fine tunes the warning behavior
    - add origin of the exception to help developers find the source of the problem.
    - avoid showing deprecation warnings on a previous warning that are raised due to `-Werror`