### PR TITLE
Fix uncaught exception in `find_file()`

### DIFF
--- a/numba/misc/findlib.py
+++ b/numba/misc/findlib.py
@@ -53,7 +53,10 @@ def find_file(pat, libdir=None):
         libdirs = list(libdir)
     files = []
     for ldir in libdirs:
-        entries = os.listdir(ldir)
+        try:
+            entries = os.listdir(ldir)
+        except FileNotFoundError:
+            continue
         candidates = [os.path.join(ldir, ent)
                       for ent in entries if pat.match(ent)]
         files.extend([c for c in candidates if os.path.isfile(c)])

--- a/numba/tests/test_findlib.py
+++ b/numba/tests/test_findlib.py
@@ -1,0 +1,12 @@
+from numba.tests.support import TestCase, unittest
+from numba.misc import findlib
+
+
+class TestFindlib(TestCase):
+    def test_find_file_nonexistent_path(self):
+        candidates = findlib.find_file('libirrelevant.so', 'NONEXISTENT')
+        self.assertEqual(candidates, [])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
(As discussed in the triage meeting on Tuesday)

`find_file()` assumed that all folders it was asked to search actually exist - this may not be the case, and is exposed now that we search more locations for CUDA packages. To prevent uncaught exceptions propagating outward (and thereby crashing `numba -s`, `cuda.cudadrv.libs.test()`, etc.), we catch `FileNotFoundError` when listing directories, and continue with the next dir when this occurs.

There didn't seem to be any tests of `findlib`, so I've added a new test file / class with this particular regression.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
