### PR TITLE
allow casting `optional` type to numba concrete types

### DIFF
--- a/numba/core/typing/builtins.py
+++ b/numba/core/typing/builtins.py
@@ -825,7 +825,10 @@ class NumberClassAttribute(AttributeTemplate):
                 sig = fnty.get_call_type(self.context, (val, types.DType(ty)),
                                          {})
                 return sig.return_type
-            elif isinstance(val, (types.Number, types.Boolean, types.IntEnumMember)):
+            elif isinstance(val, (types.Number,
+                                  types.Boolean,
+                                  types.IntEnumMember,
+                                  types.Optional)):
                  # Scalar constructor, e.g. np.int32(42)
                  return ty
             elif isinstance(val, (types.NPDatetime, types.NPTimedelta)):

--- a/numba/tests/test_optional.py
+++ b/numba/tests/test_optional.py
@@ -259,6 +259,20 @@ class TestOptional(TestCase):
         # incref being made on the returned None.
         work()
 
+    def test_optional_to_int(self):
+        @njit
+        def foo(key):
+            d = {1:1}
+            value = d.get(key)
+            if value is None:
+                return None
+            else:
+                # allow using types.int64 as int for optional type
+                return types.int64(value)
+
+        for key in [1, 2]:
+            self.assertEqual(foo.py_func(key), foo(key))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
You can see the added test case.
Without this patch, the test will fail. With this patch, we allow this kind of casting from optional to concrete_type, e.g., `types.int64(optional_instance)`.