### PR TITLE
Remove an undefined name

### DIFF
--- a/numba/pycc/compiler.py
+++ b/numba/pycc/compiler.py
@@ -19,7 +19,7 @@ from numba.core import cgutils
 
 logger = logging.getLogger(__name__)
 
-__all__ = ['Compiler']
+__all__ = []
 
 NULL = ir.Constant(lt._void_star, None)
 ZERO = ir.Constant(lt._int32, 0)


### PR DESCRIPTION
In file: compiler.py, the list named `__all__` contains an undefined name which can result in errors  when this module is imported. I removed the undefined name from the list. For more information regarding `__all__`, please read about [importing fields from a package](https://docs.python.org/3/tutorial/modules.html#importing-from-a-package).  

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the Open Source Security Foundation (OpenSSF)(https://openssf.org/): Project Alpha-Omega(https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.