### PR TITLE
Remove extra decrefs in RNG

### DIFF
--- a/numba/core/boxing.py
+++ b/numba/core/boxing.py
@@ -1230,11 +1230,9 @@ def unbox_numpy_random_bitgenerator(typ, obj, c):
 
             # Want to do ctypes.cast(CFunctionType, ctypes.c_void_p), create an
             # args tuple for that.
-            extra_refs.append(ct_voidptr_ty)
             args = c.pyapi.tuple_pack([interface_next_fn, ct_voidptr_ty])
             with cgutils.early_exit_if_null(c.builder, stack, args):
                 handle_failure()
-            extra_refs.append(ct_voidptr_ty)
 
             # Call ctypes.cast()
             interface_next_fn_casted = c.pyapi.call(ct_cast, args)


### PR DESCRIPTION
Fix #9143. The fix requires a Python debug build to confirm. `ct_voidptr_ty` is already added to `extra_refs` inside `object_getattr_safetly()`.

I used 
```
python                    3.11.4          hffe3a8e_0_debug_cpython    conda-forge/label/python_debug
```
for testing.