### PR TITLE
Align `searchsorted` behaviour with numpy

### DIFF
--- a/docs/upcoming_changes/9189.bug_fix.rst
+++ b/docs/upcoming_changes/9189.bug_fix.rst
@@ -1,0 +1,5 @@
+The ``numpy.searchsorted`` behaviour aligned with numpy
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+The implementation of ``numpy.searchsorted`` is updated to behave precisely
+like numpy for a wider set of uses cases.

--- a/docs/upcoming_changes/9189.bug_fix.rst
+++ b/docs/upcoming_changes/9189.bug_fix.rst
@@ -1,5 +1,15 @@
-The ``numpy.searchsorted`` behaviour aligned with numpy
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""
+``numpy.searchsorted`` and ``numpy.sort`` behaviour updates
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+* ``numpy.searchsorted`` implementation updated to produce
+  identical outputs to numpy for a wider set of use cases,
+  including where the provided array `a` is in fact not
+  properly sorted.
 
-The implementation of ``numpy.searchsorted`` is updated to behave precisely
-like numpy for a wider set of uses cases.
+* ``numpy.searchsorted`` implementation bugfix for the case where
+  side='right' and the provided array `a` contains NaN(s).
+
+* ``numpy.searchsorted`` implementation extended to support complex
+  inputs.
+
+* ``numpy.sort`` (and ``array.sort``) implementation extended to
+  support sorting of complex data.

--- a/numba/cpython/builtins.py
+++ b/numba/cpython/builtins.py
@@ -762,7 +762,7 @@ def ol_isinstance(var, typs):
 
     # NOTE: The current implementation of `isinstance` restricts the type of the
     # instance variable to types that are well known and in common use. The
-    # danger of unrestricted tyoe comparison is that a "default" of `False` is
+    # danger of unrestricted type comparison is that a "default" of `False` is
     # required and this means that if there is a bug in the logic of the
     # comparison tree `isinstance` returns False! It's therefore safer to just
     # reject the compilation as untypable!
@@ -770,7 +770,9 @@ def ol_isinstance(var, typs):
                         types.DictType, types.LiteralStrKeyDict, types.List,
                         types.ListType, types.Tuple, types.UniTuple, types.Set,
                         types.Function, types.ClassType, types.UnicodeType,
-                        types.ClassInstanceType, types.NoneType, types.Array)
+                        types.ClassInstanceType, types.NoneType, types.Array,
+                        types.Boolean, types.Float, types.UnicodeCharSeq,
+                        types.Complex)
     if not isinstance(var_ty, supported_var_ty):
         msg = f'isinstance() does not support variables of type "{var_ty}".'
         raise NumbaTypeError(msg)

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -3749,7 +3749,8 @@ def searchsorted(a, v, side='left'):
     if side_val == 'left':
         _impl = _searchsorted_left
     elif side_val == 'right':
-        # change in behaviour introduced by https://github.com/numpy/numpy/pull/21867
+        # change in behaviour introduced by
+        # https://github.com/numpy/numpy/pull/21867
         if numpy_version >= (1, 23):
             _impl = _searchsorted_right_np123_on
         else:

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -3731,9 +3731,15 @@ def _searchsorted(func_1, func_2):
     return impl
 
 
-_searchsorted_left = register_jitable(_searchsorted(custom_lt, custom_lt))
-_searchsorted_right_pre_np123 = register_jitable(_searchsorted(custom_lt, custom_le))
-_searchsorted_right_np123_on = register_jitable(_searchsorted(custom_le, custom_le))
+_searchsorted_left = register_jitable(
+    _searchsorted(custom_lt, custom_lt)
+)
+_searchsorted_right_pre_np123 = register_jitable(
+    _searchsorted(custom_lt, custom_le)
+)
+_searchsorted_right_np123_on = register_jitable(
+    _searchsorted(custom_le, custom_le)
+)
 
 
 @overload(np.searchsorted)

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -3698,9 +3698,6 @@ def _searchsorted(func_1, func_2):
 
         out = np.empty(v.size, np.intp)
 
-        if v.size == 0:
-            return out
-
         last_key_val = v.flat[0]
 
         for i in range(v.size):

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -3813,7 +3813,9 @@ def choose_searchsorted_implementation(np_dtype, side):
             _impl = _searchsorted(less_than_or_equal, less_than_or_equal)
 
     else:
-        raise ValueError(f'No implementation for numpy dtype: {np_dtype}')
+        raise ValueError(
+            f'No searchsorted implementation for numpy dtype: {np_dtype}'
+        )
 
     return register_jitable(_impl)
 

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -3689,14 +3689,17 @@ def custom_le(a, b):
 
 
 def _searchsorted(func_1, func_2):
+    # a facsimile of:
+    # https://github.com/numpy/numpy/blob/4f84d719657eb455a35fcdf9e75b83eb1f97024a/numpy/core/src/npysort/binsearch.cpp#L61  # noqa: E501
+
     def impl(a, v):
         min_idx = 0
         max_idx = len(a)
 
-        if v.size == 0:
-            return
-
         out = np.empty(v.size, np.intp)
+
+        if v.size == 0:
+            return out
 
         last_key_val = v.flat[0]
 
@@ -3715,6 +3718,7 @@ def _searchsorted(func_1, func_2):
             last_key_val = key_val
 
             while min_idx < max_idx:
+                # to avoid overflow
                 mid_idx = min_idx + ((max_idx - min_idx) >> 1)
 
                 mid_val = a[mid_idx]

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -15,7 +15,7 @@ from numba.core import types, cgutils
 from numba.core.extending import overload, overload_method, register_jitable
 from numba.np.numpy_support import (as_dtype, type_can_asarray, type_is_scalar,
                                     numpy_version, is_nonelike,
-                                    check_is_integer, lt_complex, lt_floats)
+                                    check_is_integer, lt_inexact)
 from numba.core.imputils import (lower_builtin, impl_ret_borrowed,
                                  impl_ret_new_ref, impl_ret_untracked)
 from numba.np.arrayobj import (make_array, load_item, store_item,
@@ -3674,12 +3674,11 @@ def np_bincount(a, weights=None, minlength=0):
     return bincount_impl
 
 
-less_than_float = register_jitable(lt_floats)
-less_than_complex = register_jitable(lt_complex)
+less_than_inexact = register_jitable(lt_inexact)
 
 
 @register_jitable
-def less_than_or_equal_complex(a, b):
+def less_than_or_equal_inexact(a, b):
     if np.isnan(a.real):
         if np.isnan(b.real):
             if np.isnan(a.imag):
@@ -3713,24 +3712,17 @@ def less_than_or_equal_complex(a, b):
 
 
 @register_jitable
-def less_than_or_equal(a, b):
-    if isinstance(a, complex) or isinstance(b, complex):
-        return less_than_or_equal_complex(a, b)
-
-    if isinstance(b, float):
-        if np.isnan(b):
-            return True
+def _less_than_or_equal(a, b):
+    if isinstance(a, (float, complex)) or isinstance(b, (float, complex)):
+        return less_than_or_equal_inexact(a, b)
 
     return a <= b
 
 
 @register_jitable
-def less_than_generic(a, b):
-    if isinstance(a, complex) or isinstance(b, complex):
-        return less_than_complex(a, b)
-
-    if isinstance(b, float):
-        return lt_floats(a, b)
+def _less_than(a, b):
+    if isinstance(a, (float, complex)) or isinstance(b, (float, complex)):
+        return less_than_inexact(a, b)
 
     return a < b
 
@@ -3785,8 +3777,8 @@ VALID_SEARCHSORTED_SIDES = frozenset({'left', 'right'})
 def make_searchsorted_implementation(np_dtype, side):
     assert side in VALID_SEARCHSORTED_SIDES
 
-    lt = less_than_generic
-    le = less_than_or_equal
+    lt = _less_than
+    le = _less_than_or_equal
 
     if side == 'left':
         _impl = _searchsorted(lt, lt)

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -3688,11 +3688,6 @@ def custom_le(a, b):
     return a <= b
 
 
-@register_jitable
-def less_than_or_equal(a, b):
-    return a <= b
-
-
 def _searchsorted(func_1, func_2):
     # a facsimile of:
     # https://github.com/numpy/numpy/blob/4f84d719657eb455a35fcdf9e75b83eb1f97024a/numpy/core/src/npysort/binsearch.cpp#L61  # noqa: E501
@@ -3737,7 +3732,6 @@ def _searchsorted(func_1, func_2):
     return impl
 
 
-# inexact dtypes
 _searchsorted_left = register_jitable(
     _searchsorted(custom_lt, custom_lt)
 )
@@ -3748,60 +3742,22 @@ _searchsorted_right_np123_on = register_jitable(
     _searchsorted(custom_le, custom_le)
 )
 
-# exact dtypes
-_searchsorted_left_exact = register_jitable(
-    _searchsorted(less_than, less_than)
-)
-_searchsorted_right_pre_np123_exact = register_jitable(
-    _searchsorted(less_than, less_than_or_equal)
-)
-_searchsorted_right_np123_on_exact = register_jitable(
-    _searchsorted(less_than_or_equal, less_than_or_equal)
-)
-
 
 @overload(np.searchsorted)
 def searchsorted(a, v, side='left'):
     side_val = getattr(side, 'literal_value', side)
 
-    if side_val not in ['left', 'right']:
-        raise NumbaValueError(f"Invalid value given for 'side': {side_val}")
-
-    a_dt = as_dtype(a.dtype)
-
-    if isinstance(v, (types.Number, types.Boolean)):
-        v_dt = as_dtype(v)
-    else:
-        v_dt = as_dtype(v.dtype)
-
-    dt = np.promote_types(a_dt, v_dt)
-    exact = False
-
-    if np.issubdtype(dt, np.integer):
-        exact = True
-
-    if 'unichr' in a.dtype.name and 'unichr' in v.dtype.name:
-        exact = True
-
     if side_val == 'left':
-        if exact:
-            _impl = _searchsorted_left_exact
-        else:
-            _impl = _searchsorted_left
-
+        _impl = _searchsorted_left
     elif side_val == 'right':
         # change in behaviour introduced by
         # https://github.com/numpy/numpy/pull/21867
         if numpy_version >= (1, 23):
-            if exact:
-                _impl = _searchsorted_right_np123_on_exact
-            else:
-                _impl = _searchsorted_right_np123_on
+            _impl = _searchsorted_right_np123_on
         else:
-            if exact:
-                _impl = _searchsorted_right_pre_np123_exact
-            else:
-                _impl = _searchsorted_right_pre_np123
+            _impl = _searchsorted_right_pre_np123
+    else:
+        raise NumbaValueError(f"Invalid value given for 'side': {side_val}")
 
     if isinstance(v, types.Array):
         def impl(a, v, side='left'):

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -17,7 +17,7 @@ from numba.core import types, typing, errors, cgutils, extending
 from numba.np.numpy_support import (as_dtype, from_dtype, carray, farray,
                                     is_contiguous, is_fortran,
                                     check_is_integer, type_is_scalar,
-                                    lt_complex, lt_floats)
+                                    lt_inexact)
 from numba.np.numpy_support import type_can_asarray, is_nonelike, numpy_version
 from numba.core.imputils import (lower_builtin, lower_getattr,
                                  lower_getattr_generic,
@@ -6347,10 +6347,8 @@ def get_sort_func(kind, lt_impl, is_argsort=False):
 
 
 def lt_implementation(dtype):
-    if isinstance(dtype, types.Float):
-        return lt_floats
-    elif isinstance(dtype, types.Complex):
-        return lt_complex
+    if isinstance(dtype, (types.Float, types.Complex)):
+        return lt_inexact
     else:
         return default_lt
 

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -17,7 +17,7 @@ from numba.core import types, typing, errors, cgutils, extending
 from numba.np.numpy_support import (as_dtype, from_dtype, carray, farray,
                                     is_contiguous, is_fortran,
                                     check_is_integer, type_is_scalar,
-                                    lt_complex)
+                                    lt_complex, lt_floats)
 from numba.np.numpy_support import type_can_asarray, is_nonelike, numpy_version
 from numba.core.imputils import (lower_builtin, lower_getattr,
                                  lower_getattr_generic,
@@ -6320,14 +6320,6 @@ def default_lt(a, b):
     Trivial comparison function between two keys.
     """
     return a < b
-
-
-def lt_floats(a, b):
-    # Adapted from NumPy commit 717c7acf which introduced the behavior of
-    # putting NaNs at the end.
-    # The code is later moved to numpy/core/src/npysort/npysort_common.h
-    # This info is gathered as of NumPy commit d8c09c50
-    return a < b or (np.isnan(b) and not np.isnan(a))
 
 
 def get_sort_func(kind, lt_impl, is_argsort=False):

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -17,7 +17,7 @@ from numba.core import types, typing, errors, cgutils, extending
 from numba.np.numpy_support import (as_dtype, from_dtype, carray, farray,
                                     is_contiguous, is_fortran,
                                     check_is_integer, type_is_scalar,
-                                    lt_inexact)
+                                    lt_complex, lt_floats)
 from numba.np.numpy_support import type_can_asarray, is_nonelike, numpy_version
 from numba.core.imputils import (lower_builtin, lower_getattr,
                                  lower_getattr_generic,
@@ -6347,8 +6347,10 @@ def get_sort_func(kind, lt_impl, is_argsort=False):
 
 
 def lt_implementation(dtype):
-    if isinstance(dtype, (types.Float, types.Complex)):
-        return lt_inexact
+    if isinstance(dtype, types.Float):
+        return lt_floats
+    elif isinstance(dtype, types.Complex):
+        return lt_complex
     else:
         return default_lt
 

--- a/numba/np/numpy_support.py
+++ b/numba/np/numpy_support.py
@@ -729,3 +729,36 @@ def check_is_integer(v, name):
     """Raises TypingError if the value is not an integer."""
     if not isinstance(v, (int, types.Integer)):
         raise TypingError('{} must be an integer'.format(name))
+
+
+def lt_complex(a, b):
+    if np.isnan(a.real):
+        if np.isnan(b.real):
+            if np.isnan(a.imag):
+                return False
+            else:
+                if np.isnan(b.imag):
+                    return True
+                else:
+                    return a.imag < b.imag
+        else:
+            return False
+
+    else:
+        if np.isnan(b.real):
+            return True
+        else:
+            if np.isnan(a.imag):
+                if np.isnan(b.imag):
+                    return a.real < b.real
+                else:
+                    return False
+            else:
+                if np.isnan(b.imag):
+                    return True
+                else:
+                    if a.real < b.real:
+                        return True
+                    elif a.real == b.real:
+                        return a.imag < b.imag
+                    return False

--- a/numba/np/numpy_support.py
+++ b/numba/np/numpy_support.py
@@ -731,6 +731,14 @@ def check_is_integer(v, name):
         raise TypingError('{} must be an integer'.format(name))
 
 
+def lt_floats(a, b):
+    # Adapted from NumPy commit 717c7acf which introduced the behavior of
+    # putting NaNs at the end.
+    # The code is later moved to numpy/core/src/npysort/npysort_common.h
+    # This info is gathered as of NumPy commit d8c09c50
+    return a < b or (np.isnan(b) and not np.isnan(a))
+
+
 def lt_complex(a, b):
     if np.isnan(a.real):
         if np.isnan(b.real):

--- a/numba/np/numpy_support.py
+++ b/numba/np/numpy_support.py
@@ -731,15 +731,11 @@ def check_is_integer(v, name):
         raise TypingError('{} must be an integer'.format(name))
 
 
-def lt_floats(a, b):
+def lt_inexact(a, b):
     # Adapted from NumPy commit 717c7acf which introduced the behavior of
     # putting NaNs at the end.
     # The code is later moved to numpy/core/src/npysort/npysort_common.h
     # This info is gathered as of NumPy commit d8c09c50
-    return a < b or (np.isnan(b) and not np.isnan(a))
-
-
-def lt_complex(a, b):
     if np.isnan(a.real):
         if np.isnan(b.real):
             if np.isnan(a.imag):

--- a/numba/np/numpy_support.py
+++ b/numba/np/numpy_support.py
@@ -731,11 +731,15 @@ def check_is_integer(v, name):
         raise TypingError('{} must be an integer'.format(name))
 
 
-def lt_inexact(a, b):
+def lt_floats(a, b):
     # Adapted from NumPy commit 717c7acf which introduced the behavior of
     # putting NaNs at the end.
     # The code is later moved to numpy/core/src/npysort/npysort_common.h
     # This info is gathered as of NumPy commit d8c09c50
+    return a < b or (np.isnan(b) and not np.isnan(a))
+
+
+def lt_complex(a, b):
     if np.isnan(a.real):
         if np.isnan(b.real):
             if np.isnan(a.imag):

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -1388,6 +1388,11 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         v = True
         check(a, v)
 
+        # `a` and `v` arrays of strings
+        a = np.array(['1', '2', '3'])
+        v = np.array(['2', '4'])
+        check(a, v)
+
     def test_searchsorted_complex(self):
         pyfunc = searchsorted
         cfunc = jit(nopython=True)(pyfunc)

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -1364,18 +1364,33 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             check(a, v)
             check(np.sort(a), v)
 
-        # corner case: `a` and / or `v` full of the same value
-        x = np.ones(5)
-        check(x, x)
-        for fill_value in np.nan, -np.inf, np.inf:
-            y = np.full(len(x), fill_value=fill_value)
-            check(x, y)
-            check(y, x)
-            check(y, y)
+        ones = np.ones(5)
+        nans = np.full(len(ones), fill_value=np.nan)
+        check(ones, ones)
+
+        # corner case: `a` and / or `v` full of nans
+        check(ones, nans)
+        check(nans, ones)
+        check(nans, nans)
 
         # corner case: `v` is zero size
         a = np.arange(1)
         v = np.arange(0)
+        check(a, v)
+
+        # corner case: `a` and `v` booleans
+        a = np.array([False, False, True, True])
+        v = np.array([False, True])
+        check(a, v)
+
+        # corner case: `a` and `v` are not numeric
+        a = np.array(['a', 'aa', 'b', 'c', 'd01', 'd03', 'da', 'e', 'f'])
+        v = np.array(['d', 'e', 'd02'])
+        check(a, v)
+
+        # corner case: `v` is a scalar boolean
+        a = [1, 2, 3]
+        v = True
         check(a, v)
 
     def test_digitize(self):

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -1327,14 +1327,6 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         )
         check(a, v)
 
-        a = np.array([9])
-        v = np.array([9])
-        check(a, v)
-
-        a = np.array([np.nan])
-        v = np.array([np.nan])
-        check(a, v)
-
     def test_searchsorted_supplemental(self):
         pyfunc = searchsorted
         cfunc = jit(nopython=True)(pyfunc)

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -1383,11 +1383,6 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         v = np.array([False, True])
         check(a, v)
 
-        # corner case: `a` and `v` are not numeric
-        a = np.array(['a', 'aa', 'b', 'c', 'd01', 'd03', 'da', 'e', 'f'])
-        v = np.array(['d', 'e', 'd02'])
-        check(a, v)
-
         # corner case: `v` is a scalar boolean
         a = [1, 2, 3]
         v = True

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -1365,27 +1365,28 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             sample_size = self.rnd.choice([5, 10, 25])
             a = self.rnd.choice(x_pool, sample_size)
             v = a[:-1]
+            self.rnd.shuffle(v)
+            v[2] += 0.1  # a non-bin edge
             check(a, v)
 
-            v[3] = np.nan
-            check(a, v)
-
+            # contiguous run of nans
             v[2:4] = np.nan
             check(a, v)
 
+            # contiguous run of nans at start
             v[:4] = np.nan
             check(a, v)
 
+            # contiguous run of nans at end
             v[:4] = -200
             v[-3:] = np.nan
             check(a, v)
 
-            v = v[::-1]
-            check(a, v)
-
+            # all nan
             v = np.full_like(v, fill_value=np.nan)
             check(a, v)
 
+            # all inf
             v = np.full_like(v, fill_value=np.inf)
             check(a, v)
 

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -1356,7 +1356,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         for i in range(1000):
             sample_size = self.rnd.choice([5, 10, 25])
 
-            # `a` an `v` not sorted and may have repeating values
+            # `a` and `v` not sorted; either may have repeating values
             a = self.rnd.choice(element_pool, sample_size)
             v = self.rnd.choice(element_pool, sample_size + (i % 3 - 1))
 
@@ -1368,22 +1368,22 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         nans = np.full(len(ones), fill_value=np.nan)
         check(ones, ones)
 
-        # corner case: `a` and / or `v` full of nans
+        # `a` and / or `v` full of nans
         check(ones, nans)
         check(nans, ones)
         check(nans, nans)
 
-        # corner case: `v` is zero size
+        # `v` is zero size
         a = np.arange(1)
         v = np.arange(0)
         check(a, v)
 
-        # corner case: `a` and `v` booleans
+        # `a` and `v` booleans
         a = np.array([False, False, True, True])
         v = np.array([False, True])
         check(a, v)
 
-        # corner case: `v` is a scalar boolean
+        # `v` is a (scalar) boolean
         a = [1, 2, 3]
         v = True
         check(a, v)

--- a/numba/tests/test_sort.py
+++ b/numba/tests/test_sort.py
@@ -889,6 +889,16 @@ class TestNumpySort(TestCase):
         for orig in self.float_arrays():
             self.check_sort_inplace(pyfunc, cfunc, orig)
 
+    def test_array_sort_complex(self):
+        pyfunc = sort_usecase
+        cfunc = jit(nopython=True)(pyfunc)
+
+        for real in self.float_arrays():
+            imag = real[::]
+            np.random.shuffle(imag)
+            orig = np.array([complex(*x) for x in zip(real, imag)])
+            self.check_sort_inplace(pyfunc, cfunc, orig)
+
     def test_np_sort_int(self):
         pyfunc = np_sort_usecase
         cfunc = jit(nopython=True)(pyfunc)
@@ -903,6 +913,18 @@ class TestNumpySort(TestCase):
         for size in (5, 20, 50, 500):
             orig = np.random.random(size=size) * 100
             orig[np.random.random(size=size) < 0.1] = float('nan')
+            self.check_sort_copy(pyfunc, cfunc, orig)
+
+    def test_np_sort_complex(self):
+        pyfunc = np_sort_usecase
+        cfunc = jit(nopython=True)(pyfunc)
+
+        for size in (5, 20, 50, 500):
+            real = np.random.random(size=size) * 100
+            imag = np.random.random(size=size) * 100
+            real[np.random.random(size=size) < 0.1] = float('nan')
+            imag[np.random.random(size=size) < 0.1] = float('nan')
+            orig = np.array([complex(*x) for x in zip(real, imag)])
             self.check_sort_copy(pyfunc, cfunc, orig)
 
     def test_argsort_int(self):
@@ -935,10 +957,37 @@ class TestNumpySort(TestCase):
         check(argsort_usecase)
         check(np_argsort_usecase)
 
-    def test_argsort_float(self):
+    def test_argsort_float_supplemental(self):
         def check(pyfunc, is_stable):
             cfunc = jit(nopython=True)(pyfunc)
             for orig in self.float_arrays():
+                self.check_argsort(pyfunc, cfunc, orig,
+                                   dict(is_stable=is_stable))
+
+        check(argsort_kind_usecase, is_stable=True)
+        check(np_argsort_kind_usecase, is_stable=True)
+        check(argsort_kind_usecase, is_stable=False)
+        check(np_argsort_kind_usecase, is_stable=False)
+
+    def test_argsort_complex(self):
+        def check(pyfunc):
+            cfunc = jit(nopython=True)(pyfunc)
+            for real in self.float_arrays():
+                imag = real[::]
+                np.random.shuffle(imag)
+                orig = np.array([complex(*x) for x in zip(real, imag)])
+                self.check_argsort(pyfunc, cfunc, orig)
+
+        check(argsort_usecase)
+        check(np_argsort_usecase)
+
+    def test_argsort_complex_supplemental(self):
+        def check(pyfunc, is_stable):
+            cfunc = jit(nopython=True)(pyfunc)
+            for real in self.float_arrays():
+                imag = real[::]
+                np.random.shuffle(imag)
+                orig = np.array([complex(*x) for x in zip(real, imag)])
                 self.check_argsort(pyfunc, cfunc, orig,
                                    dict(is_stable=is_stable))
 


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

This MR attempts to align `searchsorted` behaviour with numpy for a wider set of use cases, particularly where (i) the input array `a` is not properly sorted or (ii) the input array `a` is properly sorted but contains NaN and side='right'.

This PR was motivated by https://github.com/numba/numba/pull/9169 - the hypothesis being that if we could align `searchsorted` behaviour with numpy closely (including for weird inputs) then updating `digitize` should be trivial, since its implementation could in fact just hand off to `searchsorted` (in the same way that numpy does). 

(The aspiration to cope with improperly sorted inputs comes in part from the foreknowledge that `digitize` attempts to determine if the provided bins are monotonic increasing or decreasing before calling into `searchsorted`, and  can make seemingly incorrect inference in the presence of NaNs.)

I have added thousands of tests to assert behavioural similarity (happy to tone this down) and have run hours of randomised tests on GCP. 

It could be that there are some outstanding edge cases where the behaviour continues to be misaligned; the implementation choices I made are difficult to justify / rationalise, and there's an unfortunate / unexpected change in behaviour pre- and post- numpy 1.22, which appears to be an unintended consequence of some bugfix (as noted in the comments).

Interested in your thoughts.


