### PR TITLE
Fix issue with incompatible multiprocessing context in test.

### DIFF
--- a/numba/tests/test_parallel_backend.py
+++ b/numba/tests/test_parallel_backend.py
@@ -819,13 +819,13 @@ class TestForkSafetyIssues(ThreadLayerTestHelper):
         body = """if 1:
             X = np.arange(1000000.)
             Y = np.arange(1000000.)
-            q = multiprocessing.Queue()
+            ctx = multiprocessing.get_context('fork')
+            q = ctx.Queue()
 
             # Start OpenMP runtime on parent via parallel function
             Z = busy_func(X, Y, q)
 
             # fork() underneath with no exec, will abort
-            ctx = multiprocessing.get_context('fork')
             proc = ctx.Process(target = busy_func, args=(X, Y, q))
             proc.start()
             proc.join()
@@ -851,12 +851,12 @@ class TestForkSafetyIssues(ThreadLayerTestHelper):
         body = """if 1:
             X = np.arange(1000000.)
             Y = np.arange(1000000.)
-            q = multiprocessing.Queue()
+            ctx = multiprocessing.get_context('spawn')
+            q = ctx.Queue()
 
             # Start OpenMP runtime and run on parent via parallel function
             Z = busy_func(X, Y, q)
             procs = []
-            ctx = multiprocessing.get_context('spawn')
             for x in range(20): # start a lot to try and get overlap
                 ## fork() + exec() to run some OpenMP on children
                 proc = ctx.Process(target = busy_func, args=(X, Y, q))
@@ -937,11 +937,11 @@ class TestForkSafetyIssues(ThreadLayerTestHelper):
         body = """if 1:
             X = np.arange(1000000.)
             Y = np.arange(1000000.)
-            q = multiprocessing.Queue()
+            ctx = multiprocessing.get_context('fork')
+            q = ctx.Queue()
 
             # this is ok
             procs = []
-            ctx = multiprocessing.get_context('fork')
             for x in range(10):
                 # fork() underneath with but no OpenMP in parent, this is ok
                 proc = ctx.Process(target = busy_func, args=(X, Y, q))


### PR DESCRIPTION
This fixes an issue highlighted by a patch added to Python 3.11.5 which identifies if a semaphore created via one multiprocessing context is in use by another (doing this is essentially a bug).

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
