### PR TITLE
Add an alternate runtests script for bootstrapping on new Python

### DIFF
--- a/maint/runtest_multiproc.py
+++ b/maint/runtest_multiproc.py
@@ -25,6 +25,10 @@ Example:
     To run 30% of tests chosen randomly from `numba.tests`.
     Use `--` to separate listing arguments from command arguments.
 
+Requires:
+
+    `numba` package to be import-able either by installing `numba` or running
+    this script from the the source root.
 """
 import re
 import sys
@@ -47,7 +51,8 @@ def run_tests(test_args):
     PATH_PASSED.mkdir(parents=True, exist_ok=True)
 
     listing = subp.check_output(
-        "python runtests.py --list".split() + [*test_args], encoding="utf8"
+        "python -m numba.runtests --list".split() + [*test_args],
+        encoding="utf8",
     )
     tests = []
     for line in listing.splitlines():
@@ -65,7 +70,7 @@ def run_tests(test_args):
     def runner(testgroup):
         cmdargs = " ".join(groups[testgroup])
         # Using -m=1 so tests are cancelled if they run too long due to timeout.
-        cmd = f"python runtests.py -m=1 -vb {cmdargs}"
+        cmd = f"python -m numba.runtests -m=1 -vb {cmdargs}"
         print("RUNNING", testgroup)
         try:
             output = subp.check_output(
@@ -77,7 +82,7 @@ def run_tests(test_args):
         else:
             path = PATH_PASSED
 
-        with open(path / "{testgroup}.log", "wb") as fout:
+        with open(path / f"{testgroup}.log", "wb") as fout:
             fout.write(output)
 
         return testgroup

--- a/runtest_multiproc.py
+++ b/runtest_multiproc.py
@@ -1,0 +1,161 @@
+"""runtest_multiproc.py
+
+This is used to run tests in parallel processes using the multiprocessing module
+and be better tolerant to tests that can timeout or segfaulting. This scripts
+gather all the tests and schedule each TestCase class to run in a fresh process.
+Logs from each process are stored under "testlogs" and categorized into "failed"
+or "passed". This scripts is useful for bootstrapping Numba on a new Python
+version or other high impact changes.
+
+Usage:
+    runtest_multiproc.py --run [<args>...]
+    runtest_multiproc.py --count
+
+Options:
+    args: arguments passed to runtests --list
+    --run: Run tests in parallel processes.
+    --count: Print failed tests stats by processing log files.
+
+Example:
+
+    ```
+    runtest_multiproc.py --run -- numba.tests --random=0.3
+    ```
+
+    To run 30% of tests chosen randomly from `numba.tests`.
+    Use `--` to separate listing arguments from command arguments.
+
+"""
+import re
+import sys
+from pathlib import Path
+from pprint import pprint
+import subprocess as subp
+from docopt import docopt
+import multiprocessing as mp
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+
+PATH_LOG = Path("testlogs")
+PATH_FAILED = PATH_LOG / "failed"
+PATH_PASSED = PATH_LOG / "passed"
+
+
+def run_tests(test_args):
+    PATH_FAILED.mkdir(parents=True, exist_ok=True)
+    PATH_PASSED.mkdir(parents=True, exist_ok=True)
+
+    listing = subp.check_output(
+        "python runtests.py --list".split() + [*test_args], encoding="utf8"
+    )
+    tests = []
+    for line in listing.splitlines():
+        if line.startswith("numba."):
+            tests.append(line)
+        else:
+            print(line)
+
+    groups = defaultdict(list)
+    for t in tests:
+        comps = t.split(".")
+        k = ".".join(comps[:4])
+        groups[k].append(t)
+
+    def runner(testgroup):
+        cmdargs = " ".join(groups[testgroup])
+        # Using -m=1 so tests are cancelled if they run too long due to timeout.
+        cmd = f"python runtests.py -m=1 -vb {cmdargs}"
+        print("RUNNING", testgroup)
+        try:
+            output = subp.check_output(
+                cmd.split(), stderr=subp.STDOUT, stdin=subp.DEVNULL
+            )
+        except subp.CalledProcessError as e:
+            output = e.output
+            path = PATH_FAILED
+        else:
+            path = PATH_PASSED
+
+        with open(path / "{testgroup}.log", "wb") as fout:
+            fout.write(output)
+
+        return testgroup
+
+    with ThreadPoolExecutor(max_workers=mp.cpu_count()) as pool:
+        try:
+            futures = [pool.submit(runner, testgroup) for testgroup in groups]
+            for future in as_completed(futures):
+                print("DONE", future.result())
+        except KeyboardInterrupt:
+            pool.shutdown(wait=True, cancel_futures=True)
+    print("END")
+
+
+REGEX_ERROR = re.compile(r"(errors|failures|unexpectedSuccess)=(\d+)")
+
+
+def count_tests():
+    failed = {}
+    timedout = {}
+
+    problems = []
+
+    for file in Path("testlogs/failed").glob("*.log"):
+        with open(file, "r") as fin:
+            body = fin.read().strip()
+        print(file)
+        lines = body.splitlines()
+        cur_timedout = []
+        for ln in reversed(lines):
+            if ln.startswith("- "):
+                cur_timedout.append(ln.strip("- '\""))
+            else:
+                break
+        if cur_timedout:
+            timedout[file] = cur_timedout
+        else:
+            last_line = lines[-1]
+            if last_line.startswith("Parallel: "):
+                last_line = lines[-2]
+            if not last_line.startswith("FAILED"):
+                problems.append(f"ERROR: {file} is malformed")
+            failed[file] = last_line
+
+    print("FAILED".center(80, "-"))
+    pprint(failed)
+    print("TIMEDOUT".center(80, "-"))
+    pprint(timedout)
+
+    stats = {"timedout": sum(len(v) for v in timedout.values())}
+    for _fp, msg in failed.items():
+        _gather_failed_stats(msg, stats)
+
+    pprint(stats)
+
+    for p in problems:
+        print(p)
+
+
+def _gather_failed_stats(line, stats):
+    for fail_type, count in REGEX_ERROR.findall(line):
+        orig = stats.setdefault(fail_type, 0)
+        stats[fail_type] = orig + int(count)
+
+
+if __name__ == "__main__":
+    arguments = docopt(__doc__, version="1.0")
+    action_run = arguments["--run"]
+    test_args = arguments["<args>"]
+    action_count = arguments["--count"]
+
+    if action_count:
+        count_tests()
+    elif action_run:
+        # Strip '--'
+        if test_args and test_args[0] == "--":
+            test_args = test_args[1:]
+        run_tests(test_args)
+    else:
+        print("Please specify either --run or --count")
+        sys.exit(1)


### PR DESCRIPTION
Add scripts to do runtests differently. This one is useful for bootstrapping Numba after high impact changes that can segfault or stall the compiler. See docstring in the added scripts for details.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
