### PR TITLE
fix numpy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ except ImportError:
 min_python_version = "3.8"
 max_python_version = "3.12"  # exclusive
 min_numpy_build_version = "1.11"
-min_numpy_run_version = "1.21"
+min_numpy_run_version = "1.22"
 min_llvmlite_version = "0.42.0dev0"
 max_llvmlite_version = "0.43"
 


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
For some reason numpy version for numba installation is not fixated for >=1.22. Thus, you can install Numba==0.58 and numpy<1.22. Which after `import numba` results in exception https://github.com/numba/numba/blob/main/numba/__init__.py#L37

installation
```shell
pip install numba "numpy<1.22"
```

exception
```python
import numba
```
