### PR TITLE
Support passing arbitrary flags to NVVM

### DIFF
--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -231,72 +231,45 @@ class CompilationUnit(object):
         self.driver.check_error(err, 'Failed to add module')
 
     def compile(self, **options):
-        """Perform Compilation
+        """Perform Compilation.
 
-        The valid compiler options are
+        Compilation options are accepted as keyword arguments, with the
+        following considerations:
 
-         *   - -opt=
-         *     - 0 (disable optimizations)
-         *     - 3 (default, enable optimizations)
-         *   - -arch=
-         *     - compute_XX where XX is in (35, 37, 50, 52, 53, 60, 61, 62, 70,
-         *                                  72, 75, 80, 86, 89, 90).
-         *       The default is compute_52.
-         *   - -ftz=
-         *     - 0 (default, preserve denormal values, when performing
-         *          single-precision floating-point operations)
-         *     - 1 (flush denormal values to zero, when performing
-         *          single-precision floating-point operations)
-         *   - -prec-sqrt=
-         *     - 0 (use a faster approximation for single-precision
-         *          floating-point square root)
-         *     - 1 (default, use IEEE round-to-nearest mode for
-         *          single-precision floating-point square root)
-         *   - -prec-div=
-         *     - 0 (use a faster approximation for single-precision
-         *          floating-point division and reciprocals)
-         *     - 1 (default, use IEEE round-to-nearest mode for
-         *          single-precision floating-point division and reciprocals)
-         *   - -fma=
-         *     - 0 (disable FMA contraction)
-         *     - 1 (default, enable FMA contraction)
-         *
-         """
+        - Underscores (`_`_ in option names are converted to dashes (`-`), to
+          match NVVM's option name format.
+        - Options that take a value will be emitted in the form
+          "-<name>=<value>".
+        - Options which take no value (such as `-gen-lto`) should have a value
+          of `None` passed in and will be emitted in the form "-<name>".
 
-        # stringify options
-        opts = []
+        For documentation on NVVM compilation options, see the CUDA Toolkit
+        Documentation:
 
-        if 'opt' in options:
-            opts.append('-opt=%d' % options.pop('opt'))
+        https://docs.nvidia.com/cuda/libnvvm-api/index.html#_CPPv418nvvmCompileProgram11nvvmProgramiPPKc
+        """
 
-        if options.get('arch'):
-            opts.append('-arch=%s' % options.pop('arch'))
+        def stringify_option(k, v):
+            k = k.replace('_', '-')
 
-        other_options = (
-            'ftz',
-            'prec_sqrt',
-            'prec_div',
-            'fma',
-        )
+            if v is None:
+                return f'-{k}'
 
-        for k in other_options:
-            if k in options:
-                v = int(bool(options.pop(k)))
-                opts.append('-%s=%d' % (k.replace('_', '-'), v))
+            if isinstance(v, bool):
+                v = int(v)
 
-        # If there are any option left
-        if options:
-            optstr = ', '.join(map(repr, options.keys()))
-            raise NvvmError("unsupported option {0}".format(optstr))
+            return f'-{k}={v}'
 
-        c_opts = (c_char_p * len(opts))(*[c_char_p(x.encode('utf8'))
-                                          for x in opts])
+        options = [stringify_option(k, v) for k, v in options.items()]
+
+        c_opts = (c_char_p * len(options))(*[c_char_p(x.encode('utf8'))
+                                             for x in options])
         # verify
-        err = self.driver.nvvmVerifyProgram(self._handle, len(opts), c_opts)
+        err = self.driver.nvvmVerifyProgram(self._handle, len(options), c_opts)
         self._try_error(err, 'Failed to verify\n')
 
         # compile
-        err = self.driver.nvvmCompileProgram(self._handle, len(opts), c_opts)
+        err = self.driver.nvvmCompileProgram(self._handle, len(options), c_opts)
         self._try_error(err, 'Failed to compile\n')
 
         # get result

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -236,7 +236,7 @@ class CompilationUnit(object):
         Compilation options are accepted as keyword arguments, with the
         following considerations:
 
-        - Underscores (`_`_ in option names are converted to dashes (`-`), to
+        - Underscores (`_`) in option names are converted to dashes (`-`), to
           match NVVM's option name format.
         - Options that take a value will be emitted in the form
           "-<name>=<value>".

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -240,6 +240,7 @@ class CompilationUnit(object):
           match NVVM's option name format.
         - Options that take a value will be emitted in the form
           "-<name>=<value>".
+        - Booleans passed as option values will be converted to integers.
         - Options which take no value (such as `-gen-lto`) should have a value
           of `None` passed in and will be emitted in the form "-<name>".
 

--- a/numba/cuda/tests/cudadrv/test_nvvm_driver.py
+++ b/numba/cuda/tests/cudadrv/test_nvvm_driver.py
@@ -41,6 +41,13 @@ class TestNvvmDriver(unittest.TestCase):
         # from NVVM (by looking for the expected magic number for LTOIR)
         self.assertEqual(ltoir[:4], b'\xed\x43\x4e\x7f')
 
+    def test_nvvm_bad_option(self):
+        # Ensure that unsupported / non-existent options are reported as such
+        # to the user / caller
+        msg = "-made-up-option=2 is an unsupported option"
+        with self.assertRaisesRegex(NvvmError, msg):
+            nvvm.llvm_to_ptx("", made_up_option=2)
+
     def test_nvvm_from_llvm(self):
         m = ir.Module("test_nvvm_from_llvm")
         m.triple = 'nvptx64-nvidia-cuda'

--- a/numba/cuda/tests/cudadrv/test_nvvm_driver.py
+++ b/numba/cuda/tests/cudadrv/test_nvvm_driver.py
@@ -25,6 +25,17 @@ class TestNvvmDriver(unittest.TestCase):
         self.assertTrue('simple' in ptx)
         self.assertTrue('ave' in ptx)
 
+    def test_nvvm_compile_nullary_option(self):
+        # Tests compilation with an option that doesn't take an argument
+        # ("-gen-lto") - all other NVVM options are of the form
+        # "-<name>=<value>"
+        nvvmir = self.get_nvvmir()
+        ltoir = nvvm.llvm_to_ptx(nvvmir, opt=3, gen_lto=None, arch="compute_52")
+
+        # Verify we correctly passed the option by checking if we got LTOIR
+        # from NVVM (by looking for the expected magic number for LTOIR)
+        self.assertEqual(ltoir[:4], b'\xed\x43\x4e\x7f')
+
     def test_nvvm_from_llvm(self):
         m = ir.Module("test_nvvm_from_llvm")
         m.triple = 'nvptx64-nvidia-cuda'

--- a/numba/cuda/tests/cudadrv/test_nvvm_driver.py
+++ b/numba/cuda/tests/cudadrv/test_nvvm_driver.py
@@ -1,7 +1,7 @@
 import warnings
 
 from llvmlite import ir
-from numba.cuda.cudadrv import nvvm
+from numba.cuda.cudadrv import nvvm, runtime
 from ctypes import c_size_t, c_uint64, sizeof
 from numba.cuda.testing import unittest
 from numba.cuda.cudadrv.nvvm import LibDevice, NvvmError, NVVM
@@ -29,6 +29,11 @@ class TestNvvmDriver(unittest.TestCase):
         # Tests compilation with an option that doesn't take an argument
         # ("-gen-lto") - all other NVVM options are of the form
         # "-<name>=<value>"
+
+        # -gen-lto is not available prior to CUDA 11.5
+        if runtime.get_version() < (11, 5):
+            self.skipTest("-gen-lto unavailable in this toolkit version")
+
         nvvmir = self.get_nvvmir()
         ltoir = nvvm.llvm_to_ptx(nvvmir, opt=3, gen_lto=None, arch="compute_52")
 


### PR DESCRIPTION
Maintaining a list of flags that we know about for NVVM and validating them is extra work to keep in sync with the CUDA documentation.

This PR removes this maintenance burden and allows a bit more flexibility for future changes by allowing arbitrary flags to be passed through, transforming them in the same manner as before but without a restriction on what the flag names are.

Some flags may not take a parameter - `-gen-lto` is an example of this. To support this case, options can be passed with a value of `None`. Since this expands slighty on the functionality, a new test cases is added with this particular flag, that validates it was passed correctly based on the NVVM output.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
