### PR TITLE
CUDA: Add support for compiling device functions with C ABI

### DIFF
--- a/docs/source/cuda/cuda_compilation.rst
+++ b/docs/source/cuda/cuda_compilation.rst
@@ -1,0 +1,107 @@
+
+.. _cuda_compilation:
+
+Compiling Python functions for use with other languages
+=======================================================
+
+Numba can compile Python code to PTX so that Python functions can be
+incorporated into CUDA code written in other languages (e.g. C/C++).  It is
+commonly used to support User-Defined Functions written in Python within the
+context of a library or application.
+
+The main API for compiling Python to PTX can be used without a GPU present, as
+it uses no driver functions and avoids initializing CUDA in the process. It is
+invoked through the following function:
+
+.. autofunction:: numba.cuda.compile_ptx
+   :noindex:
+
+If a device is available and PTX for the compute capability of the current
+device is required (for example when building a JIT compilation workflow using
+Numba), the ``compile_ptx_for_current_device`` function can be used:
+
+.. autofunction:: numba.cuda.compile_ptx_for_current_device
+   :noindex:
+
+
+Using the C ABI
+---------------
+
+Numba compiles functions with its ABI by default - this is as described in
+:ref:`device-function-abi`, without the ``extern "C"`` modifier. Calling Numba
+ABI device functions requires three issues to be addressed:
+
+- The name of the function will be mangled according to Numba's ABI rules -
+  these are based on the Itanium C++ ABI rules, but are extended beyond its
+  specifications.
+- The Python return value is expected to be stored into a pointer value passed
+  in the first argument.
+- The return value of the compiled function will contain a status code, instead
+  of the return value of the function. For use of Numba-compiled functions
+  outside of Numba, this can generally be ignored.
+
+A simple way to address all these issues is to compile device functions with the
+C ABI instead. This results in the following:
+
+- The name of the compiled device function in PTX will match the name of the
+  function in Python, so it is easy to determine. This is the function's
+  ``__name__``, rather than ``__qualname__``, because ``__qualname__`` encodes
+  additional scoping information that would make the function name hard to
+  predict, and in a lot of cases, an illegal identifier in C.
+- The returned value of the Python code is placed in the return value of the
+  compiled function.
+- Status codes are ignored / unreported, so they do not need to be handled.
+
+C and Numba ABI examples
+------------------------
+
+The following function:
+
+.. code:: python
+
+   def add(x, y):
+       return x + y
+
+compiled for the Numba ABI using, for example:
+
+.. code:: python
+
+    ptx, resty = ptx, resty = cuda.compile_ptx(add, int32(int32, int32), device=True)
+
+results in PTX where the function prototype is:
+
+.. code:: text
+
+   .visible .func  (.param .b32 func_retval0) _ZN8__main__3addB2v1B94cw51cXTLSUwv1sCUt9Uw1VEw0NRRQPKzLTg4gaGKFsG2oMQGEYakJSQB1PQBk0Bynm21OiwU1a0UoLGhDpQE8oxrNQE_3dEii(
+       .param .b64 _ZN8__main__3addB2v1B94cw51cXTLSUwv1sCUt9Uw1VEw0NRRQPKzLTg4gaGKFsG2oMQGEYakJSQB1PQBk0Bynm21OiwU1a0UoLGhDpQE8oxrNQE_3dEii_param_0,
+       .param .b32 _ZN8__main__3addB2v1B94cw51cXTLSUwv1sCUt9Uw1VEw0NRRQPKzLTg4gaGKFsG2oMQGEYakJSQB1PQBk0Bynm21OiwU1a0UoLGhDpQE8oxrNQE_3dEii_param_1,
+       .param .b32 _ZN8__main__3addB2v1B94cw51cXTLSUwv1sCUt9Uw1VEw0NRRQPKzLTg4gaGKFsG2oMQGEYakJSQB1PQBk0Bynm21OiwU1a0UoLGhDpQE8oxrNQE_3dEii_param_2
+    )
+
+Note that there are three parameters, for the pointer to the return value,
+``x``, and ``y``. The name is mangled in a way that is hard to predict outside
+of Numba internals.
+
+Compiling for the C ABI with:
+
+.. code:: python
+
+   ptx, resty = cuda.compile_ptx(add, int32(int32, int32), device=True, abi="c")
+
+instead results in the following PTX prototype:
+
+.. code:: text
+
+   .visible .func  (.param .b32 func_retval0) add(
+       .param .b32 add_param_0,
+       .param .b32 add_param_1
+   )
+
+The function name matches the Python source function name, and there are exactly
+two parameters, for ``x`` and ``y``. The result of the function is directly
+placed in the return value:
+
+.. code:: text
+
+   add.s32 	%r3, %r2, %r1;
+   st.param.b32 	[func_retval0+0], %r3;

--- a/docs/source/cuda/cuda_ffi.rst
+++ b/docs/source/cuda/cuda_ffi.rst
@@ -13,6 +13,7 @@ of a Python kernel call to a foreign device function are:
 - A declaration of the device function in Python.
 - A kernel that links with and calls the foreign function.
 
+.. _device-function-abi:
 
 Device function ABI
 -------------------

--- a/docs/source/cuda/index.rst
+++ b/docs/source/cuda/index.rst
@@ -25,6 +25,7 @@ Numba for CUDA GPUs
    external-memory.rst
    bindings.rst
    cuda_ffi.rst
+   cuda_compilation.rst
    caching.rst
    minor_version_compatibility.rst
    faq.rst

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -1,3 +1,4 @@
+from llvmlite import ir
 from numba.core.typing.templates import ConcreteTemplate
 from numba.core import types, typing, funcdesc, config, compiler, sigutils
 from numba.core.compiler import (sanitize_compile_result_entries, CompilerBase,
@@ -11,6 +12,7 @@ from numba.core.typed_passes import (IRLegalization, NativeLowering,
                                      AnnotateTypes)
 from warnings import warn
 from numba.cuda.api import get_current_device
+from numba.cuda.target import CUDACABICallConv
 
 
 def _nvvm_options_type(x):
@@ -206,9 +208,53 @@ def compile_cuda(pyfunc, return_type, args, debug=False, lineinfo=False,
     return cres
 
 
+def cabi_wrap_function(context, lib, fndesc, wrapper_function_name,
+                       nvvm_options):
+    """
+    Wrap a Numba ABI function in a C ABI wrapper at the NVVM IR level.
+
+    The C ABI wrapper will have the same name as the source Python function.
+    """
+    # The wrapper will be contained in a new library that links to the wrapped
+    # function's library
+    library = lib.codegen.create_library(f'{lib.name}_function_',
+                                         entry_name=wrapper_function_name,
+                                         nvvm_options=nvvm_options)
+    library.add_linking_library(lib)
+
+    # Determine the caller (C ABI) and wrapper (Numba ABI) function types
+    argtypes = fndesc.argtypes
+    restype = fndesc.restype
+    c_call_conv = CUDACABICallConv(context)
+    wrapfnty = c_call_conv.get_function_type(restype, argtypes)
+    fnty = context.call_conv.get_function_type(fndesc.restype, argtypes)
+
+    # Create a new module and declare the callee
+    wrapper_module = context.create_module("cuda.cabi.wrapper")
+    func = ir.Function(wrapper_module, fnty, fndesc.llvm_func_name)
+
+    # Define the caller - populate it with a call to the callee and return
+    # its return value
+
+    wrapfn = ir.Function(wrapper_module, wrapfnty, wrapper_function_name)
+    builder = ir.IRBuilder(wrapfn.append_basic_block(''))
+
+    arginfo = context.get_arg_packer(argtypes)
+    callargs = arginfo.from_arguments(builder, wrapfn.args)
+    # We get (status, return_value), but we ignore the status since we
+    # can't propagate it through the C ABI anyway
+    _, return_value = context.call_conv.call_function(
+        builder, func, restype, argtypes, callargs)
+    builder.ret(return_value)
+
+    library.add_ir_module(wrapper_module)
+    library.finalize()
+    return library
+
+
 @global_compiler_lock
 def compile_ptx(pyfunc, sig, debug=False, lineinfo=False, device=False,
-                fastmath=False, cc=None, opt=True):
+                fastmath=False, cc=None, opt=True, abi="numba"):
     """Compile a Python function to PTX for a given set of argument types.
 
     :param pyfunc: The Python function to compile.
@@ -233,9 +279,19 @@ def compile_ptx(pyfunc, sig, debug=False, lineinfo=False, device=False,
     :type cc: tuple
     :param opt: Enable optimizations. Defaults to ``True``.
     :type opt: bool
+    :param abi: The ABI for a compiled function - either ``"numba"`` or
+                ``"c"``. Note that the Numba ABI is not considered stable.
+                The C ABI is only supported for device functions at present.
+    :type abi: str
     :return: (ptx, resty): The PTX code and inferred return type
     :rtype: tuple
     """
+    if abi not in ("numba", "c"):
+        raise NotImplementedError(f'Unsupported ABI: {abi}')
+
+    if abi == 'c' and not device:
+        raise NotImplementedError('The C ABI is not supported for kernels')
+
     if debug and opt:
         msg = ("debug=True with opt=True (the default) "
                "is not supported by CUDA. This may result in a crash"
@@ -258,10 +314,14 @@ def compile_ptx(pyfunc, sig, debug=False, lineinfo=False, device=False,
     if resty and not device and resty != types.void:
         raise TypeError("CUDA kernel must have void return type.")
 
+    tgt = cres.target_context
+
     if device:
         lib = cres.library
+        if abi == "c":
+            lib = cabi_wrap_function(tgt, lib, cres.fndesc, pyfunc.__name__,
+                                     nvvm_options)
     else:
-        tgt = cres.target_context
         code = pyfunc.__code__
         filename = code.co_filename
         linenum = code.co_firstlineno
@@ -275,13 +335,15 @@ def compile_ptx(pyfunc, sig, debug=False, lineinfo=False, device=False,
 
 
 def compile_ptx_for_current_device(pyfunc, sig, debug=False, lineinfo=False,
-                                   device=False, fastmath=False, opt=True):
+                                   device=False, fastmath=False, opt=True,
+                                   abi="numba"):
     """Compile a Python function to PTX for a given set of argument types for
     the current device's compute capabilility. This calls :func:`compile_ptx`
     with an appropriate ``cc`` value for the current device."""
     cc = get_current_device().compute_capability
     return compile_ptx(pyfunc, sig, debug=debug, lineinfo=lineinfo,
-                       device=device, fastmath=fastmath, cc=cc, opt=True)
+                       device=device, fastmath=fastmath, cc=cc, opt=opt,
+                       abi=abi)
 
 
 def declare_device_function(name, restype, argtypes):

--- a/numba/cuda/target.py
+++ b/numba/cuda/target.py
@@ -6,7 +6,7 @@ from llvmlite import ir
 from numba.core import typing, types, debuginfo, itanium_mangler, cgutils
 from numba.core.dispatcher import Dispatcher
 from numba.core.base import BaseContext
-from numba.core.callconv import MinimalCallConv
+from numba.core.callconv import BaseCallConv, MinimalCallConv
 from numba.core.typing import cmathdecl
 from numba.core import datamodel
 
@@ -366,3 +366,72 @@ class CUDATargetContext(BaseContext):
 
 class CUDACallConv(MinimalCallConv):
     pass
+
+
+class CUDACABICallConv(BaseCallConv):
+    """
+    Calling convention aimed at matching the CUDA C/C++ ABI. The implemented
+    function signature is:
+
+        <Python return type> (<Python arguments>)
+
+    Exceptions are unsupported in this convention.
+    """
+
+    def _make_call_helper(self, builder):
+        # Call helpers are used to help report exceptions back to Python, so
+        # none is required here.
+        return None
+
+    def return_value(self, builder, retval):
+        return builder.ret(retval)
+
+    def return_user_exc(self, builder, exc, exc_args=None, loc=None,
+                        func_name=None):
+        msg = "Python exceptions are unsupported in the CUDA C/C++ ABI"
+        raise NotImplementedError(msg)
+
+    def return_status_propagate(self, builder, status):
+        msg = "Return status is unsupported in the CUDA C/C++ ABI"
+        raise NotImplementedError(msg)
+        pass
+
+    def get_function_type(self, restype, argtypes):
+        """
+        Get the LLVM IR Function type for *restype* and *argtypes*.
+        """
+        arginfo = self._get_arg_packer(argtypes)
+        argtypes = list(arginfo.argument_types)
+        fnty = ir.FunctionType(self.get_return_type(restype), argtypes)
+        return fnty
+
+    def decorate_function(self, fn, args, fe_argtypes, noalias=False):
+        """
+        Set names and attributes of function arguments.
+        """
+        assert not noalias
+        arginfo = self._get_arg_packer(fe_argtypes)
+        arginfo.assign_names(self.get_arguments(fn),
+                             ['arg.' + a for a in args])
+
+    def get_arguments(self, func):
+        """
+        Get the Python-level arguments of LLVM *func*.
+        """
+        return func.args
+
+    def call_function(self, builder, callee, resty, argtys, args):
+        """
+        Call the Numba-compiled *callee*.
+        """
+        arginfo = self._get_arg_packer(argtys)
+        realargs = arginfo.as_arguments(builder, args)
+        code = builder.call(callee, realargs)
+        # No status required as we don't support exceptions or a distinct None
+        # value in a C ABI.
+        status = None
+        out = self.context.get_returned_value(builder, resty, code)
+        return status, out
+
+    def get_return_type(self, ty):
+        return self.context.data_model_manager[ty].get_return_type()


### PR DESCRIPTION
This makes it easier to use Numba as a compiler for user-defined Python functions, by more closely matching the prototype from other languages like C and C++.

A C calling convention is implemented using Numba's calling convention mechanisms - whilst this was possibly not technically required to support a C ABI for device functions, it should provide a base for further internal use of a C ABI where appropriate / possible (which will be more efficient than the Numba ABI).

Documentation of the ABI is added by adding a section on compilation to the user documentation - having some user docs for the compilation APIs was probably a good idea anyway.