### PR TITLE
Support NumPy 1.26 (PR aimed at review / merge)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,9 +17,9 @@ jobs:
         NUMPY: '1.22'
         CONDA_ENV: 'azure_ci'
         TEST_START_INDEX: 0
-      py311_np125:
+      py311_np126:
         PYTHON: '3.11'
-        NUMPY: '1.25'
+        NUMPY: '1.26'
         CONDA_ENV: 'azure_ci'
         TEST_THREADING: 'tbb'
         TEST_START_INDEX: 1
@@ -73,9 +73,9 @@ jobs:
         CONDA_ENV: azure_ci
         RUN_TYPEGUARD: yes
         TEST_START_INDEX: 8
-      py39_np124:
+      py39_np126:
         PYTHON: '3.9'
-        NUMPY: '1.24'
+        NUMPY: '1.26'
         CONDA_ENV: azure_ci
         TEST_START_INDEX: 9
       py39_np125:
@@ -83,9 +83,9 @@ jobs:
         NUMPY: '1.25'
         CONDA_ENV: azure_ci
         TEST_START_INDEX: 10
-      py310_np122:
+      py310_np126:
         PYTHON: '3.10'
-        NUMPY: '1.22'
+        NUMPY: '1.26'
         CONDA_ENV: azure_ci
         TEST_START_INDEX: 11
       py310_np123:
@@ -103,9 +103,9 @@ jobs:
         NUMPY: '1.25'
         CONDA_ENV: azure_ci
         TEST_START_INDEX: 14
-      py311_np123:
+      py311_np126:
         PYTHON: '3.11'
-        NUMPY: '1.23'
+        NUMPY: '1.26'
         CONDA_ENV: azure_ci
         TEST_START_INDEX: 15
       py311_np124:
@@ -119,9 +119,9 @@ jobs:
         CONDA_ENV: azure_ci
         TEST_START_INDEX: 17
       # RVSDG tests
-      py311_np124_rvsdg:
+      py311_np126_rvsdg:
         PYTHON: '3.11'
-        NUMPY: '1.24'
+        NUMPY: '1.26'
         RUN_MYPY: yes
         RUN_FLAKE8: yes
         CONDA_ENV: azure_ci

--- a/buildscripts/azure/azure-windows.yml
+++ b/buildscripts/azure/azure-windows.yml
@@ -13,9 +13,9 @@ jobs:
         NUMPY: '1.22.3'
         CONDA_ENV: 'testenv'
         TEST_START_INDEX: 18
-      py311_np125:
+      py311_np126:
         PYTHON: '3.11'
-        NUMPY: '1.25'
+        NUMPY: '1.26'
         CONDA_ENV: 'testenv'
         TEST_START_INDEX: 19
 

--- a/buildscripts/gpuci/build.sh
+++ b/buildscripts/gpuci/build.sh
@@ -35,7 +35,7 @@ fi;
 # Test with different NumPy versions with each toolkit (it's not worth testing
 # the Cartesian product of versions here, we just need to test with different
 # CUDA and NumPy versions).
-declare -A CTK_NUMPY_VMAP=( ["11.2"]="1.22" ["11.3"]="1.23" ["11.5"]="1.24" ["11.8"]="1.25")
+declare -A CTK_NUMPY_VMAP=( ["11.2"]="1.22" ["11.3"]="1.23" ["11.5"]="1.25" ["11.8"]="1.26")
 NUMPY_VER="${CTK_NUMPY_VMAP[$CUDA_TOOLKIT_VER]}"
 
 ################################################################################

--- a/docs/upcoming_changes/9227.np_support.rst
+++ b/docs/upcoming_changes/9227.np_support.rst
@@ -1,0 +1,4 @@
+Support NumPy 1.26
+==================
+
+Support for NumPy 1.26 is added.

--- a/numba/tests/test_jitclasses.py
+++ b/numba/tests/test_jitclasses.py
@@ -1880,6 +1880,7 @@ def f(x, y):
                 self.arr = array
 
         n = 3
+        np.random.seed(1)
         vec = np.random.random(size=(n,))
         mat = np.random.random(size=(n, n))
 
@@ -1894,54 +1895,33 @@ def f(x, y):
         jit_matrix_at = jitclass(ArrayAt, spec={"arr": float64[:,::1]})(mat)
 
         # __matmul__
-        self.assertEqual(
-            vector_at @ vector_noat,
-            jit_vector_at @ jit_vector_noat
-        )
-        self.assertTupleEqual(
-            tuple(vector_at @ matrix_noat),
-            tuple(jit_vector_at @ jit_matrix_noat)
-        )
-        self.assertTupleEqual(
-            tuple(matrix_at @ vector_noat),
-            tuple(jit_matrix_at @ jit_vector_noat)
-        )
-        self.assertTupleEqual(
-            tuple((matrix_at @ matrix_noat).ravel()),
-            tuple((jit_matrix_at @ jit_matrix_noat).ravel())
-        )
+        np.testing.assert_allclose(vector_at @ vector_noat,
+                                   jit_vector_at @ jit_vector_noat)
+        np.testing.assert_allclose(vector_at @ matrix_noat,
+                                   jit_vector_at @ jit_matrix_noat)
+        np.testing.assert_allclose(matrix_at @ vector_noat,
+                                   jit_matrix_at @ jit_vector_noat)
+        np.testing.assert_allclose(matrix_at @ matrix_noat,
+                                   jit_matrix_at @ jit_matrix_noat)
 
         # __rmatmul__
-        self.assertEqual(
-            vector_noat @ vector_at,
-            jit_vector_noat @ jit_vector_at
-        )
-        self.assertTupleEqual(
-            tuple(vector_noat @ matrix_at),
-            tuple(jit_vector_noat @ jit_matrix_at)
-        )
-        self.assertTupleEqual(
-            tuple(matrix_noat @ vector_at),
-            tuple(jit_matrix_noat @ jit_vector_at)
-        )
-        self.assertTupleEqual(
-            tuple((matrix_noat @ matrix_at).ravel()),
-            tuple((jit_matrix_noat @ jit_matrix_at).ravel())
-        )
+        np.testing.assert_allclose(vector_noat @ vector_at,
+                                   jit_vector_noat @ jit_vector_at)
+        np.testing.assert_allclose(vector_noat @ matrix_at,
+                                   jit_vector_noat @ jit_matrix_at)
+        np.testing.assert_allclose(matrix_noat @ vector_at,
+                                   jit_matrix_noat @ jit_vector_at)
+        np.testing.assert_allclose(matrix_noat @ matrix_at,
+                                   jit_matrix_noat @ jit_matrix_at)
 
         # __imatmul__
         vector_at @= matrix_noat
         matrix_at @= matrix_noat
         jit_vector_at @= jit_matrix_noat
         jit_matrix_at @= jit_matrix_noat
-        self.assertTupleEqual(
-            tuple(vector_at.arr.ravel()),
-            tuple(jit_vector_at.arr.ravel())
-        )
-        self.assertTupleEqual(
-            tuple(matrix_at.arr.ravel()),
-            tuple(jit_matrix_at.arr.ravel())
-        )
+
+        np.testing.assert_allclose(vector_at.arr, jit_vector_at.arr)
+        np.testing.assert_allclose(matrix_at.arr, jit_matrix_at.arr)
 
     def test_arithmetic_logical_reflection(self):
         class OperatorsDefined:

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -5111,7 +5111,8 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
                     self.assertPreciseEqual(expected,
                                             got, prec='double', ulps=2)
                 else:
-                    self.assertPreciseEqual(expected, got, prec='exact')
+                    self.assertPreciseEqual(expected, got, prec='double',
+                                            ulps=2)
 
         for M in ['a', 1.1, 1j]:
             with self.assertRaises(TypingError) as raises:


### PR DESCRIPTION
This PR adds support for NumPy 1.26 and modifies the CI matrix appropriately for testing going forward. It contains the same changes as #9202, which used NumPy 1.26 for every CI configuration (to demonstrate there were no missed changes in NumPy 1.26 that needed to be accounted for).

The only changes needed other than the CI configuration are to tests, which needed a little loosening in some cases due to the changes in NumPy's SIMD configuration. References:

* https://numpy.org/doc/stable/release/1.26.0-notes.html#numpy-specific-build-customization
* https://github.com/numpy/numpy/pull/24405