### PR TITLE
Fix #9222 - Don't replace `.` with `_` in func arg names in inline closures

### DIFF
--- a/docs/upcoming_changes/9222.bug_fix.rst
+++ b/docs/upcoming_changes/9222.bug_fix.rst
@@ -1,0 +1,5 @@
+Fixed handling of float default arguments in inline closures
+============================================================
+
+Float default arguments in inline closures would produce incorrect results since
+updates for Python 3.11 - these are now handled correctly again.

--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -1739,8 +1739,6 @@ def _create_function_from_code_obj(fcode, func_env, func_arg, func_clo, glbls):
     * func_clo - string for the closure args
     * glbls - the function globals
     """
-    # in py3.11, func_arg contains '.'
-    func_arg = func_arg.replace('.', '_')
     sanitized_co_name = fcode.co_name.replace('<', '_').replace('>', '_')
     func_text = (f"def closure():\n{func_env}\n"
                  f"\tdef {sanitized_co_name}({func_arg}):\n"

--- a/numba/tests/test_closure.py
+++ b/numba/tests/test_closure.py
@@ -473,6 +473,24 @@ class TestInlinedClosure(TestCase):
             regex = r'closure__locals__bar_v[0-9]+.x'
             self.assertRegex(name, regex)
 
+    def test_issue9222(self):
+        # Ensures that float default arguments are handled correctly in
+        # closures.
+
+        @njit
+        def foo():
+            def bar(x, y=1.1):
+                return x + y
+            return bar
+
+        @njit
+        def consume():
+            return foo()(4)
+
+        # In Issue #9222, the result was completely wrong - 15 instead of 5.1 -
+        # so allclose should be sufficient for comparison here.
+        np.testing.assert_allclose(consume(), 4 + 1.1)
+
 
 class TestObjmodeFallback(TestCase):
     # These are all based on tests from real life issues where, predominantly,


### PR DESCRIPTION
This is suggested as a fix for Issue #9222 in its description, as it seems it may no longer be necessary.

Testing on CI for now.