### PR TITLE
CUDA: Make `grid()` and `gridsize()` use 64-bit integers

### DIFF
--- a/numba/cuda/nvvmutils.py
+++ b/numba/cuda/nvvmutils.py
@@ -217,9 +217,10 @@ class SRegBuilder(object):
         return call_sreg(self.builder, 'nctaid.%s' % xyz)
 
     def getdim(self, xyz):
-        tid = self.tid(xyz)
-        ntid = self.ntid(xyz)
-        nctaid = self.ctaid(xyz)
+        i64 = ir.IntType(64)
+        tid = self.builder.sext(self.tid(xyz), i64)
+        ntid = self.builder.sext(self.ntid(xyz), i64)
+        nctaid = self.builder.sext(self.ctaid(xyz), i64)
         res = self.builder.add(self.builder.mul(ntid, nctaid), tid)
         return res
 

--- a/numba/cuda/tests/cudapy/test_intrinsics.py
+++ b/numba/cuda/tests/cudapy/test_intrinsics.py
@@ -440,6 +440,29 @@ class TestCudaIntrinsic(CUDATestCase):
         compiled[nctaid, ntid](ary)
         self.assertEqual(ary[0], nctaid * ntid)
 
+    def test_issue_9229(self):
+        # Ensure that grid and grid size are correct - #9229 showed that they
+        # overflowed an int32.
+        @cuda.jit
+        def f(grid_error, gridsize_error):
+            i1 = cuda.grid(1)
+            i2 = cuda.blockIdx.x * cuda.blockDim.x + cuda.threadIdx.x
+            gs1 = cuda.gridsize(1)
+            gs2 = cuda.blockDim.x * cuda.gridDim.x
+            if i1 != i2:
+                grid_error[0] = 1
+            if gs1 != gs2:
+                gridsize_error[0] = 1
+
+        grid_error = np.zeros(1, dtype=np.uint64)
+        gridsize_error = np.zeros(1, dtype=np.uint64)
+
+        # A lerge enough grid for thread IDs to overflow an int32
+        f[22121216, 256](grid_error, gridsize_error)
+
+        self.assertEqual(grid_error[0], 0)
+        self.assertEqual(gridsize_error[0], 0)
+
     @skip_on_cudasim('Tests PTX emission')
     def test_selp(self):
         sig = (int64[:], int64, int64[:])


### PR DESCRIPTION
It is possible to launch more than `2**31` threads, so `cuda.grid()` and `cuda.gridsize()` need to use 64 bit integers.

Fixes #9229.