### PR TITLE
Fixes numba/numba#9234

### DIFF
--- a/docs/source/cuda/examples.rst
+++ b/docs/source/cuda/examples.rst
@@ -346,7 +346,7 @@ Monte Carlo Integration
 =======================
 
 This example shows how to use Numba to approximate the value of a definite integral by rapidly generating 
-random numbers on the GPU. A detailed description of the mathematical mechanics of Monte Carlo integeration 
+random numbers on the GPU. A detailed description of the mathematical mechanics of Monte Carlo integration
 is out of the scope of the example, but it can briefly be described as an averaging process where the area 
 under the curve is approximated by taking the average of many rectangles formed by its function values.
 

--- a/docs/source/cuda/minor_version_compatibility.rst
+++ b/docs/source/cuda/minor_version_compatibility.rst
@@ -1,6 +1,6 @@
 .. _minor-version-compatibility:
 
-CUDA Minor Version Compatiblity
+CUDA Minor Version Compatibility
 ===============================
 
 CUDA `Minor Version Compatibility

--- a/docs/source/cuda/minor_version_compatibility.rst
+++ b/docs/source/cuda/minor_version_compatibility.rst
@@ -1,7 +1,7 @@
 .. _minor-version-compatibility:
 
 CUDA Minor Version Compatibility
-===============================
+================================
 
 CUDA `Minor Version Compatibility
 <https://docs.nvidia.com/deploy/cuda-compatibility/index.html#minor-version-compatibility>`_

--- a/docs/source/proposals/jit-classes.rst
+++ b/docs/source/proposals/jit-classes.rst
@@ -195,7 +195,7 @@ The use of ``classmethod`` is not supported.
 Inheritance
 ~~~~~~~~~~~
 
-Class inhertance is not considered in this proposal.  The only accepted base
+Class inheritance is not considered in this proposal.  The only accepted base
 class for a jitclass is `object`.
 
 Supported targets

--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -5,7 +5,7 @@ Installation
 Compatibility
 -------------
 
-For software compatability, please see the section on :ref:`version support
+For software compatibility, please see the section on :ref:`version support
 information<numba_support_info>` for details.
 
 Our supported platforms are:

--- a/docs/source/user/parallel.rst
+++ b/docs/source/user/parallel.rst
@@ -130,7 +130,7 @@ The following example demonstrates a product reduction on a two-dimensional arra
           Numba's ``prange`` when ``parallel=False``. However, for
           ``parallel=True``, if the range is identifiable as strictly positive,
           the type of the induction variable  will be ``uint64``. The impact of
-          a ``uint64`` induction variable is often most noticable when
+          a ``uint64`` induction variable is often most noticeable when
           undertaking operations involving it and a signed integer. Under
           Numba's type coercion rules, such a case will commonly result in the
           operation producing a floating point result type.

--- a/docs/upcoming_changes/README.rst
+++ b/docs/upcoming_changes/README.rst
@@ -8,7 +8,7 @@ small **ReST**-formatted text that will be added to the next what's new page.
 Make sure to use full sentences with correct case and punctuation, and please
 try to use Sphinx intersphinx using backticks. The fragment should have a
 header line and an underline using ``""""""""`` followed by description of
-your user-facing changes as they should appear in the relase notes.
+your user-facing changes as they should appear in the release notes.
 
 Each file should be named like ``<PULL REQUEST>.<TYPE>.rst``, where
 ``<PULL REQUEST>`` is a pull request number, and ``<TYPE>`` is one of:


### PR DESCRIPTION
This PR fixes the below typo issues with the numba documentation.

Fixes #9234 

```
source/cuda/cuda_array_interface.rst:515: documen ==> document (no fixes required, since it's an URL)
source/cuda/examples.rst:349: integeration ==> integration
source/cuda/minor_version_compatibility.rst:3: Compatiblity ==> Compatibility
source/proposals/jit-classes.rst:198: inhertance ==> inheritance
source/user/installing.rst:8: compatability ==> compatibility
source/user/parallel.rst:133: noticable ==> noticeable
upcoming_changes/README.rst:11: relase ==> release
```

Since this is a documentation changes, no unit tests required. This is not a breaking change.
