### PR TITLE
Fix slow InlineInlineable

### DIFF
--- a/docs/upcoming_changes/9245.performance.rst
+++ b/docs/upcoming_changes/9245.performance.rst
@@ -2,4 +2,4 @@ Improvement to IR copying speed
 ===============================
 
 Improvements were made to the deepcopying of ``FunctionIR``. 
-In one case, ``InlineInlineable`` pass is 3x faster.
+In one case, the ``InlineInlineables`` pass is 3x faster.

--- a/docs/upcoming_changes/9245.performance.rst
+++ b/docs/upcoming_changes/9245.performance.rst
@@ -1,0 +1,5 @@
+Improvement to IR copying speed
+===============================
+
+Improvements were made to the deepcopying of ``FunctionIR``. 
+In one case, ``InlineInlineable`` pass is 3x faster.

--- a/numba/core/ir.py
+++ b/numba/core/ir.py
@@ -1128,6 +1128,11 @@ class Var(EqualityCheckMixin, AbstractRHS):
         """
         return self.versioned_names | {self.unversioned_name,}
 
+    def __deepcopy__(self, memo):
+        out = Var(copy.deepcopy(self.scope, memo), self.name, self.loc)
+        memo[id(self)] = out
+        return out
+
 
 class Scope(EqualityCheckMixin):
     """


### PR DESCRIPTION
Fixes https://github.com/numba/numba/issues/9204

Avoid deepcopying Loc in `Var.__deepcopy__.` [This fixes slow IR copying in `InlineInlineable`](https://github.com/numba/numba/issues/9204#issuecomment-1765096208).

In one case, time spend in `InlineInlineable` went from 1second to <300ms.