### PR TITLE
Fix automatic unwrapping of optional type

### DIFF
--- a/docs/upcoming_changes/9248.bug_fix.rst
+++ b/docs/upcoming_changes/9248.bug_fix.rst
@@ -1,0 +1,7 @@
+Fix automatic unwrapping of optional type
+"""""""""""""""""""""""""""""""""""""""""
+
+Previously, if an extension code (e.g. ``@overload``) raises a ``TypingError``
+due to the lack of support of optional type, there were no automatic unwrapping 
+of the  optional typed arguments. However, if the extension code rejects by
+returning ``None``, automatic unwrapping is done. This is now fixed.

--- a/numba/core/typing/builtins.py
+++ b/numba/core/typing/builtins.py
@@ -825,7 +825,10 @@ class NumberClassAttribute(AttributeTemplate):
                 sig = fnty.get_call_type(self.context, (val, types.DType(ty)),
                                          {})
                 return sig.return_type
-            elif isinstance(val, (types.Number, types.Boolean, types.IntEnumMember)):
+            elif isinstance(val, (types.Number,
+                                  types.Boolean,
+                                  types.IntEnumMember,
+                                  types.Optional)):
                  # Scalar constructor, e.g. np.int32(42)
                  return ty
             elif isinstance(val, (types.NPDatetime, types.NPTimedelta)):

--- a/numba/core/typing/builtins.py
+++ b/numba/core/typing/builtins.py
@@ -825,10 +825,7 @@ class NumberClassAttribute(AttributeTemplate):
                 sig = fnty.get_call_type(self.context, (val, types.DType(ty)),
                                          {})
                 return sig.return_type
-            elif isinstance(val, (types.Number,
-                                  types.Boolean,
-                                  types.IntEnumMember,
-                                  types.Optional)):
+            elif isinstance(val, (types.Number, types.Boolean, types.IntEnumMember)):
                  # Scalar constructor, e.g. np.int32(42)
                  return ty
             elif isinstance(val, (types.NPDatetime, types.NPTimedelta)):

--- a/numba/tests/test_optional.py
+++ b/numba/tests/test_optional.py
@@ -259,6 +259,20 @@ class TestOptional(TestCase):
         # incref being made on the returned None.
         work()
 
+    def test_optional_to_int(self):
+        @njit
+        def foo(key):
+            d = {1:1}
+            value = d.get(key)
+            if value is None:
+                return None
+            else:
+                # allow using types.int64 as int for optional type
+                return types.int64(value)
+
+        for key in [1, 2]:
+            self.assertEqual(foo.py_func(key), foo(key))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Alternative to #9161.

The root problem of optional typed arguments not unpacking is due to lack of exception handling around the `typer`. With the fix, we don't need to specialize individual function to handle optional types.