### PR TITLE
add support for checking dtypes equal

### DIFF
--- a/docs/upcoming_changes/9249.np_support.rst
+++ b/docs/upcoming_changes/9249.np_support.rst
@@ -1,0 +1,3 @@
+Adds support for checking if dtypes are equal.
+========================================================================================================================================================================
+Support is added for checking if two dtype objects are equal, for example `assert X.dtype == np.dtype(np.float64)`.

--- a/docs/upcoming_changes/9249.np_support.rst
+++ b/docs/upcoming_changes/9249.np_support.rst
@@ -1,3 +1,3 @@
 Adds support for checking if dtypes are equal.
-========================================================================================================================================================================
+=============================================
 Support is added for checking if two dtype objects are equal, for example `assert X.dtype == np.dtype(np.float64)`.

--- a/docs/upcoming_changes/9249.np_support.rst
+++ b/docs/upcoming_changes/9249.np_support.rst
@@ -1,3 +1,3 @@
 Adds support for checking if dtypes are equal.
-=============================================
+==============================================
 Support is added for checking if two dtype objects are equal, for example `assert X.dtype == np.dtype(np.float64)`.

--- a/numba/core/typing/npydecl.py
+++ b/numba/core/typing/npydecl.py
@@ -681,3 +681,11 @@ class NdIndex(AbstractTemplate):
         if all(isinstance(x, types.Integer) for x in shape):
             iterator_type = types.NumpyNdIndexType(len(shape))
             return signature(iterator_type, *args)
+
+
+@infer_global(operator.eq)
+class DtypeEq(AbstractTemplate):
+    def generic(self, args, kws):
+        [lhs, rhs] = args
+        if isinstance(lhs, types.DType) and isinstance(rhs, types.DType):
+            return signature(types.boolean, lhs, rhs)

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -4150,6 +4150,14 @@ def iternext_numpy_nditer2(context, builder, sig, args, result):
     nditer.iternext_specific(context, builder, result)
 
 
+@lower_builtin(operator.eq, types.DType, types.DType)
+def dtype_eq_impl(context, builder, sig, args):
+    arg1, arg2 = sig.args
+    val = 1 if arg1 == arg2 else 0
+    res = ir.Constant(ir.IntType(1), val)
+    return impl_ret_untracked(context, builder, sig.return_type, res)
+
+
 # ------------------------------------------------------------------------------
 # Numpy array constructors
 

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -4153,8 +4153,7 @@ def iternext_numpy_nditer2(context, builder, sig, args, result):
 @lower_builtin(operator.eq, types.DType, types.DType)
 def dtype_eq_impl(context, builder, sig, args):
     arg1, arg2 = sig.args
-    val = 1 if arg1 == arg2 else 0
-    res = ir.Constant(ir.IntType(1), val)
+    res = ir.Constant(ir.IntType(1), int(arg1 == arg2))
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 

--- a/numba/tests/test_array_attr.py
+++ b/numba/tests/test_array_attr.py
@@ -19,6 +19,10 @@ def use_dtype(a, b):
     return a.view(b.dtype)
 
 
+def dtype_eq_int64(a):
+    return a.dtype == np.dtype('int64')
+
+
 def array_itemsize(a):
     return a.itemsize
 
@@ -167,6 +171,12 @@ class TestArrayAttr(MemoryLeakMixin, TestCase):
         cfunc = self.get_cfunc(pyfunc, (typeof(self.a), typeof(b)))
         expected = pyfunc(self.a, b)
         self.assertPreciseEqual(cfunc(self.a, b), expected)
+
+    def test_dtype_equal(self):
+        # Test checking if a dtype is equal to another dtype
+        pyfunc = dtype_eq_int64
+        self.check_unary(pyfunc, np.empty(1, dtype=np.int16))
+        self.check_unary(pyfunc, np.empty(1, dtype=np.int64))
 
     def test_flags_contiguous(self):
         self.check_unary_with_arrays(array_flags_contiguous)


### PR DESCRIPTION
This PR adds support for checking if two dtypes are equal.


I have code that I generate that looks like this:

```python
assert X.dtype == np.dtype(np.float64)
```

that I would like to compile with Numba. With this PR, it is able to work under no-python mode.