### PR TITLE
Fix SSA to consider variables whose use is not dominated by the definition

### DIFF
--- a/docs/upcoming_changes/9242.bug_fix.rst
+++ b/docs/upcoming_changes/9242.bug_fix.rst
@@ -1,6 +1,6 @@
-Fix SSA to consider variables whose use is not dominated by the definition
+Fix SSA to consider variables where use is not dominated by the definition
 ==========================================================================
 
 A SSA problem is fixed such that a conditionally defined variable will receive
-a phi node showing that there is a path where the variable is undefined. 
+a phi node showing that there is a path where the variable is undefined.
 This affects extension code that relies on SSA behavior.

--- a/docs/upcoming_changes/9242.bug_fix.rst
+++ b/docs/upcoming_changes/9242.bug_fix.rst
@@ -1,0 +1,5 @@
+Fix SSA to consider variables whose use is not dominated by the definition
+==========================================================================
+
+A SSA problem is fixed such that a conditionally defined variable will receive
+a phi node showing that there is a path where the variable is undefined. 

--- a/docs/upcoming_changes/9242.bug_fix.rst
+++ b/docs/upcoming_changes/9242.bug_fix.rst
@@ -3,3 +3,4 @@ Fix SSA to consider variables whose use is not dominated by the definition
 
 A SSA problem is fixed such that a conditionally defined variable will receive
 a phi node showing that there is a path where the variable is undefined. 
+This affects extension code that relies on SSA behavior.

--- a/numba/core/ssa.py
+++ b/numba/core/ssa.py
@@ -257,7 +257,7 @@ class _BaseHandler:
 class _GatherDefsHandler(_BaseHandler):
     """Find all defs and uses of variable in each block
 
-    ``states["label"] is a int; label of the current block
+    ``states["label"]`` is a int; label of the current block
     ``states["defs"]`` is a Mapping[str, List[Tuple[ir.Assign, int]]]
     ``states["uses"]`` is a Mapping[Set[int]]
     """

--- a/numba/core/ssa.py
+++ b/numba/core/ssa.py
@@ -258,7 +258,9 @@ class _GatherDefsHandler(_BaseHandler):
     """Find all defs and uses of variable in each block
 
     ``states["label"]`` is a int; label of the current block
-    ``states["defs"]`` is a Mapping[str, List[Tuple[ir.Assign, int]]]
+    ``states["defs"]`` is a Mapping[str, List[Tuple[ir.Assign, int]]]:
+        - a mapping of the name of the assignee variable to the assignment
+          IR node and the block label.
     ``states["uses"]`` is a Mapping[Set[int]]
     """
     def on_assign(self, states, assign):

--- a/numba/core/ssa.py
+++ b/numba/core/ssa.py
@@ -54,7 +54,7 @@ def _run_ssa(blocks):
     cfg = compute_cfg_from_blocks(blocks)
     df_plus = _iterated_domfronts(cfg)
     # Find SSA violators
-    violators = _find_defs_violators(blocks)
+    violators = _find_defs_violators(blocks, cfg)
     # Make cache for .list_vars()
     cache_list_vars = _CacheListVars()
 
@@ -142,7 +142,7 @@ def _get_scope(blocks):
     return first.scope
 
 
-def _find_defs_violators(blocks):
+def _find_defs_violators(blocks, cfg):
     """
     Returns
     -------
@@ -150,9 +150,22 @@ def _find_defs_violators(blocks):
         The SSA violators in a dictionary of variable names.
     """
     defs = defaultdict(list)
-    _run_block_analysis(blocks, defs, _GatherDefsHandler())
+    uses = defaultdict(set)
+    states = dict(defs=defs, uses=uses)
+    _run_block_analysis(blocks, states, _GatherDefsHandler())
     _logger.debug("defs %s", pformat(defs))
+    # Gather violators by number of definitions
     violators = {k for k, vs in defs.items() if len(vs) > 1}
+    # Gather violators by uses not dominated by the one def
+    doms = cfg.dominators()
+    for k, use_blocks in uses.items():
+        if k not in violators:
+            for label in use_blocks:
+                dom = doms[label]
+                def_labels = {label for _assign, label in defs[k] }
+                if not def_labels.intersection(dom):
+                    violators.add(k)
+                    break
     _logger.debug("SSA violators %s", pformat(violators))
     return violators
 
@@ -160,6 +173,7 @@ def _find_defs_violators(blocks):
 def _run_block_analysis(blocks, states, handler):
     for label, blk in blocks.items():
         _logger.debug("==== SSA block analysis pass on %s", label)
+        states['label'] = label
         for _ in _run_ssa_block_pass(states, blk, handler):
             pass
 
@@ -241,12 +255,26 @@ class _BaseHandler:
 
 
 class _GatherDefsHandler(_BaseHandler):
-    """Find all defs
+    """Find all defs and uses of variable in each block
 
-    ``states`` is a Mapping[str, List[ir.Assign]]
+    ``states["label"] is a int; label of the current block
+    ``states["defs"]`` is a Mapping[str, List[Tuple[ir.Assign, int]]]
+    ``states["uses"]`` is a Mapping[Set[int]]
     """
     def on_assign(self, states, assign):
-        states[assign.target.name].append(assign)
+        # keep track of assignment and the block
+        states["defs"][assign.target.name].append((assign, states["label"]))
+        # keep track of uses
+        for var in assign.list_vars():
+            k = var.name
+            if k != assign.target.name:
+                states["uses"][k].add(states["label"])
+
+    def on_other(self, states, stmt):
+        # keep track of uses
+        for var in stmt.list_vars():
+            k = var.name
+            states["uses"][k].add(states["label"])
 
 
 class UndefinedVariable:

--- a/numba/core/typed_passes.py
+++ b/numba/core/typed_passes.py
@@ -983,14 +983,16 @@ class PreLowerStripPhis(FunctionPass):
         # Find and simplify conditionally defined variables
         suspects = set()
         for varname, deflist in defs.items():
-            if len(deflist) == 2:
-                if any(map(lambda x: ir.UNDEFINED, deflist)):
-                    unver = scope.get_exact(
-                        scope.get_exact(varname).unversioned_name
-                    )
-                    if unver in deflist:
-                        if len(unver.versioned_names) == 1:
-                            suspects.add(unver)
+            unique_defs = deflist
+            # Only consider variables with only two definitions and one of them
+            # is UNDEFINED and the other is the unversioned variable.
+            if len(unique_defs) == 2 and unique_defs:
+                unver = scope.get_exact(
+                    scope.get_exact(varname).unversioned_name
+                )
+                if unver in deflist:
+                    if len(unver.versioned_names) == 1:
+                        suspects.add(unver)
 
         delete_set = set()
         replace_map = {}

--- a/numba/core/typed_passes.py
+++ b/numba/core/typed_passes.py
@@ -883,6 +883,7 @@ class PreLowerStripPhis(FunctionPass):
         state.func_ir = self._strip_phi_nodes(state.func_ir)
         state.func_ir._definitions = build_definitions(state.func_ir.blocks)
         self._simplify_conditionally_defined_variable(state.func_ir)
+        state.func_ir._definitions = build_definitions(state.func_ir.blocks)
 
         # Rerun postprocessor to update metadata
         post_proc = postproc.PostProcessor(state.func_ir)
@@ -1003,7 +1004,7 @@ class PreLowerStripPhis(FunctionPass):
                 replace_map[versioned] = var
 
         # remove assignments to the versioned names
-        for label, blk in func_ir.blocks.items():
+        for _label, blk in func_ir.blocks.items():
             for assign in blk.find_insts(ir.Assign):
                 if assign.target in delete_set:
                     blk.remove(assign)

--- a/numba/core/typed_passes.py
+++ b/numba/core/typed_passes.py
@@ -999,7 +999,7 @@ class PreLowerStripPhis(FunctionPass):
             if not var.versioned_names:
                 return False
             for verioned in var.versioned_names:
-                vs = defs[verioned]
+                vs = defs.get(verioned, ())
                 if not all(map(partial(unver_or_undef, k), vs)):
                     return False
             return True

--- a/numba/core/typed_passes.py
+++ b/numba/core/typed_passes.py
@@ -882,8 +882,9 @@ class PreLowerStripPhis(FunctionPass):
     def run_pass(self, state):
         state.func_ir = self._strip_phi_nodes(state.func_ir)
         state.func_ir._definitions = build_definitions(state.func_ir.blocks)
-        self._simplify_conditionally_defined_variable(state.func_ir)
-        state.func_ir._definitions = build_definitions(state.func_ir.blocks)
+        if "flags" in state and state.flags.auto_parallel.enabled:
+            self._simplify_conditionally_defined_variable(state.func_ir)
+            state.func_ir._definitions = build_definitions(state.func_ir.blocks)
 
         # Rerun postprocessor to update metadata
         post_proc = postproc.PostProcessor(state.func_ir)
@@ -975,6 +976,7 @@ class PreLowerStripPhis(FunctionPass):
             # delete all assignments to ver1
             uses(ver)
 
+        This is only needed for parfors.
         """
         any_block = next(iter(func_ir.blocks.values()))
         scope = any_block.scope

--- a/numba/core/typed_passes.py
+++ b/numba/core/typed_passes.py
@@ -996,12 +996,12 @@ class PreLowerStripPhis(FunctionPass):
             return False
 
         def legalize_all_versioned_names(var):
-            # Is all versioned names undefined or defined to the same
+            # Are all versioned names undefined or defined to the same
             # variable chain?
             if not var.versioned_names:
                 return False
-            for verioned in var.versioned_names:
-                vs = defs.get(verioned, ())
+            for versioned in var.versioned_names:
+                vs = defs.get(versioned, ())
                 if not all(map(partial(unver_or_undef, k), vs)):
                     return False
             return True
@@ -1014,7 +1014,7 @@ class PreLowerStripPhis(FunctionPass):
                 var = scope.get_exact(k)
             except errors.NotDefinedError:
                 continue
-            # is the unversioned?
+            # is the var name unversioned?
             if var.unversioned_name == k:
                 if legalize_all_versioned_names(var):
                     suspects.add(var)

--- a/numba/core/typed_passes.py
+++ b/numba/core/typed_passes.py
@@ -1007,7 +1007,11 @@ class PreLowerStripPhis(FunctionPass):
         # Find unversioned variables that met the conditions
         suspects = set()
         for k in defs:
-            var = scope.get_exact(k)
+            try:
+                # This may fail?
+                var = scope.get_exact(k)
+            except errors.NotDefinedError:
+                continue
             # is the unversioned?
             if var.unversioned_name == k:
                 if legalize_all_versioned_names(var):

--- a/numba/core/typed_passes.py
+++ b/numba/core/typed_passes.py
@@ -977,7 +977,9 @@ class PreLowerStripPhis(FunctionPass):
             # delete all assignments to ver1
             uses(ver)
 
-        This is only needed for parfors.
+        This is only needed for parfors because the SSA pass will create extra
+        variable assignments that the parfor code does not expect.
+        This pass helps avoid problems by reverting the effect of SSA.
         """
         any_block = next(iter(func_ir.blocks.values()))
         scope = any_block.scope

--- a/numba/core/typed_passes.py
+++ b/numba/core/typed_passes.py
@@ -985,10 +985,12 @@ class PreLowerStripPhis(FunctionPass):
         # Find and simplify conditionally defined variables
         suspects = set()
         for varname, deflist in defs.items():
-            unique_defs = deflist
+            unique_defs = set(deflist)
+            atleast_one_undef = any(map(lambda x: x == ir.UNDEFINED,
+                                        unique_defs))
             # Only consider variables with only two definitions and one of them
             # is UNDEFINED and the other is the unversioned variable.
-            if len(unique_defs) == 2 and unique_defs:
+            if len(unique_defs) == 2 and atleast_one_undef:
                 unver = scope.get_exact(
                     scope.get_exact(varname).unversioned_name
                 )

--- a/numba/parfors/parfor_lowering.py
+++ b/numba/parfors/parfor_lowering.py
@@ -55,7 +55,7 @@ class ParforLower(lowering.Lower):
     @property
     def _disable_sroa_like_opt(self):
         """
-        Force disable this because Parfor usedefs is incompatible---it only
+        Force disable this because Parfor use-defs is incompatible---it only
         considers use-defs in blocks that must be executing.
         See https://github.com/numba/numba/commit/017e2ff9db87fc34149b49dd5367ecbf0bb45268
         """

--- a/numba/parfors/parfor_lowering.py
+++ b/numba/parfors/parfor_lowering.py
@@ -52,6 +52,15 @@ class ParforLower(lowering.Lower):
         else:
             super().lower_inst(inst)
 
+    @property
+    def _disable_sroa_like_opt(self):
+        """
+        Force disable this because Parfor usedefs is incompatible---it only
+        considers use-defs in blocks that must be executing.
+        See https://github.com/numba/numba/commit/017e2ff9db87fc34149b49dd5367ecbf0bb45268
+        """
+        return True
+
 
 def _lower_parfor_parallel(lowerer, parfor):
     if parfor.lowerer is None:

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2311,6 +2311,16 @@ class TestParfors(TestParforsBase):
         self.check(test_impl, 3.7, 4.3)
         self.assertEqual(countParfors(test_impl, (types.float64, types.float64)), 1)
 
+    def test_issue9256_lower_sroa_conflict(self):
+        @njit(parallel=True)
+        def def_in_loop(x):
+            c = 0
+            for i in prange(x):
+                c = i
+            return c
+
+        self.assertEqual(def_in_loop(10), def_in_loop.py_func(10))
+
 
 @skip_parfors_unsupported
 class TestParforsLeaks(MemoryLeakMixin, TestParforsBase):

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2315,6 +2315,7 @@ class TestParfors(TestParforsBase):
         @njit(parallel=True)
         def def_in_loop(x):
             c = 0
+            set_num_threads(1)
             for i in prange(x):
                 c = i
             return c

--- a/numba/tests/test_ssa.py
+++ b/numba/tests/test_ssa.py
@@ -528,7 +528,8 @@ class TestReportedSSAIssues(SSABaseTest):
                 return False
 
         class SSACheckPipeline(CompilerBase):
-            """Inject SSACheck pass into the default pipeline following the SSA pass
+            """Inject SSACheck pass into the default pipeline following the SSA
+            pass
             """
 
             def define_pipelines(self):

--- a/numba/tests/test_ssa.py
+++ b/numba/tests/test_ssa.py
@@ -518,7 +518,7 @@ class TestReportedSSAIssues(SSABaseTest):
             Check SSA on variable `d`
             """
 
-            _name = "preserve_ir"
+            _name = "SSA_Check"
 
             def __init__(self):
                 AnalysisPass.__init__(self)
@@ -528,12 +528,12 @@ class TestReportedSSAIssues(SSABaseTest):
                 return False
 
         class SSACheckPipeline(CompilerBase):
-            """Inject SSACheck pass into the default pipeline by SSA pass
+            """Inject SSACheck pass into the default pipeline following the SSA pass
             """
 
             def define_pipelines(self):
                 pipeline = DefaultPassBuilder.define_nopython_pipeline(
-                    self.state, "ir_preserving_custom_pipe")
+                    self.state, "ssa_check_custom_pipeline")
 
                 pipeline._finalized = False
                 pipeline.add_pass_after(SSACheck, ReconstructSSA)

--- a/numba/tests/test_ssa.py
+++ b/numba/tests/test_ssa.py
@@ -498,6 +498,59 @@ class TestReportedSSAIssues(SSABaseTest):
         # One phi?
         self.assertEqual(phi_counter, [1])
 
+    def test_issue9242_use_not_dom_def(self):
+        from numba.core.ir import FunctionIR
+        from numba.core.compiler_machinery import (
+            AnalysisPass,
+            register_pass,
+        )
+
+        def check(fir: FunctionIR):
+            [blk, *_] = fir.blocks.values()
+            var = blk.scope.get("d")
+            defn = fir.get_definition(var)
+            self.assertEqual(defn.op, "phi")
+            self.assertIn(ir.UNDEFINED, defn.incoming_values)
+
+        @register_pass(mutates_CFG=False, analysis_only=True)
+        class SSACheck(AnalysisPass):
+            """
+            Check SSA on variable `d`
+            """
+
+            _name = "preserve_ir"
+
+            def __init__(self):
+                AnalysisPass.__init__(self)
+
+            def run_pass(self, state):
+                check(state.func_ir)
+                return False
+
+        class SSACheckPipeline(CompilerBase):
+            """Inject SSACheck pass into the default pipeline by SSA pass
+            """
+
+            def define_pipelines(self):
+                pipeline = DefaultPassBuilder.define_nopython_pipeline(
+                    self.state, "ir_preserving_custom_pipe")
+
+                pipeline._finalized = False
+                pipeline.add_pass_after(SSACheck, ReconstructSSA)
+
+                pipeline.finalize()
+                return [pipeline]
+
+        @njit(pipeline_class=SSACheckPipeline)
+        def py_func(a):
+            c = a > 0
+            if c:
+                d = a + 5  # d is only defined here; undef in the else branch
+
+            return c and d > 0
+
+        py_func(10)
+
 
 class TestSROAIssues(MemoryLeakMixin, TestCase):
     # This tests issues related to the SROA optimization done in lowering, which


### PR DESCRIPTION
Fixes #9242 and #9256.

* SSA reconstruction is adjusted to also consider definitions that do not dominate all uses.
* The above changes unfortunately is not compatible with Parfors; therefore, its effect is undone when Phi is stripped.
* https://github.com/numba/numba/pull/9255/commits/80dd8df240a4b73aa3af64b1abe077897dfa23a1 is part of debugging the Parfors breakage due to the initial commit. Any user code that makes a new variable definition in a loop not in the pattern of reduction will trigger a problem in SROA-avoidance due to incompatible postcondition of use-def analysis on Parfor node.

 