### PR TITLE
Workaround for tempfile.TemporaryFile hanging indefinitely on Windows

### DIFF
--- a/numba/core/caching.py
+++ b/numba/core/caching.py
@@ -104,7 +104,11 @@ class _CacheLocator(metaclass=ABCMeta):
         path = self.get_cache_path()
         os.makedirs(path, exist_ok=True)
         # Ensure the directory is writable by trying to write a temporary file
-        tempfile.TemporaryFile(dir=path).close()
+        # Avoid using tempfile.TemporaryFile since it may hang indefinitely on Windows:
+        # https://github.com/python/cpython/issues/66305
+        filename = os.path.join(path, "cache_write_test.txt")
+        open(filename).close()
+        os.remove(filename)
 
     @abstractmethod
     def get_cache_path(self):


### PR DESCRIPTION
This fixes #8755 for me, which is due to a nasty long-standing bug with tempfile on Windows in CPython: https://github.com/python/cpython/issues/66305

There is more use of tempfile within numba, but that does not seem to be causing problems. This likely warrants more research and better testing, but I don't think many maintainers have the time time currently.

Having said that, this minor change seems easily worth it it stops numba from hanging indefinitely on Windows.
