### PR TITLE
Fix pickle `RecursionError` when serializing the constant part of a dynamic exception

### DIFF
--- a/docs/upcoming_changes/9262.bug_fix.rst
+++ b/docs/upcoming_changes/9262.bug_fix.rst
@@ -1,0 +1,5 @@
+Fix pickle ``RecursionError`` when serializing exception
+========================================================
+
+Fix a bug when serializing the constant part of a dynamic exception that would
+trigger a ``RecursionError`` in Pickle.

--- a/numba/core/callconv.py
+++ b/numba/core/callconv.py
@@ -684,7 +684,10 @@ class CPUCallConv(BaseCallConv):
 
         # serialize comp. time args
         pyapi = self.context.get_python_api(builder)
-        exc = self.build_excinfo_struct(exc, exc_args, loc, func_name)
+        dummy = self.context.get_dummy_value()
+        exc_args_static = tuple(
+            [dummy if isinstance(arg, ir.Value) else arg for arg in exc_args])
+        exc = self.build_excinfo_struct(exc, exc_args_static, loc, func_name)
         excinfo_pp = self._get_excinfo_argument(builder.function)
         struct_gv = builder.load(pyapi.serialize_object(exc))
 


### PR DESCRIPTION
"Fix" an odd bug where serializing the constant part of an exception would trigger "maximum recursion depth exceeded while pickling an object" in Pickle.

This shall unblock https://github.com/numba/numba/pull/9076