### PR TITLE
CUDA: Add support for CUDA 12.0 Windows conda packages

### DIFF
--- a/docs/upcoming_changes/9279.cuda.rst
+++ b/docs/upcoming_changes/9279.cuda.rst
@@ -1,0 +1,5 @@
+Support for Windows CUDA 12.0 toolkit conda packages
+====================================================
+
+The library paths used in CUDA toolkit 12.0 conda packages on Windows are
+added to the search paths used when detecting CUDA libraries.


### PR DESCRIPTION
Windows CUDA 12.x conda packages place libraries in the `Library` subdir of the environment. This is an additional location to search, so no logic is removed, in order that libraries from 11.x packages will continue to be found.

Testing with the packages suggested in https://github.com/conda-forge/numba-feedstock/issues/130#issuecomment-1806595555:

```
conda install -c conda-forge cuda-version=12.0 cuda-nvcc-impl cuda-nvrtc
```

gives the following library test output for me on Windows:

```
(numba-issue-9278) C:\work\numbadev\numba [main ≡ +0 ~1 -0 !]> python -c "from numba.cuda.cudadrv.libs import test; test()"
Finding driver from candidates:
        nvcuda.dll
        \windows\system32\nvcuda.dll
Using loader <class 'ctypes.WinDLL'>
        Trying to load driver...        ok
                Loaded from nvcuda.dll
Finding nvvm from Conda environment (NVIDIA package)
        Located at C:\work\miniconda3\envs\numba-issue-9278\Library\nvvm\bin\nvvm64_40_0.dll
        Trying to open library...       ok
Finding nvrtc from Conda environment (NVIDIA package)
        Located at C:\work\miniconda3\envs\numba-issue-9278\Library\bin\nvrtc64_120_0.dll
        Trying to open library...       ok
Finding cudart from Conda environment (NVIDIA package)
        Located at C:\work\miniconda3\envs\numba-issue-9278\Library\bin\cudart64_12.dll
        Trying to open library...       ok
Finding cudadevrt from Conda environment (NVIDIA package)
        Located at C:\work\miniconda3\envs\numba-issue-9278\Library\lib\cudadevrt.lib
        Checking library...     ok
Finding libdevice from Conda environment (NVIDIA package)
        Located at C:\work\miniconda3\envs\numba-issue-9278\Library\nvvm\libdevice\libdevice.10.bc
        Checking library...     ok
```

This is without modifying my existing environment variables - I have:

```
(numba-issue-9278) C:\work\numbadev\numba [issue-9278]> echo $env:CUDA_PATH
C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.4
(numba-issue-9278) C:\work\numbadev\numba [issue-9278]> echo $env:CUDA_HOME
C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.4
(numba-issue-9278) C:\work\numbadev\numba [issue-9278]>
```

Fixes #9278.

cc @jakirkham 