### PR TITLE
CUDA: Switch cooperative groups to use overloads

### DIFF
--- a/numba/cuda/cg.py
+++ b/numba/cuda/cg.py
@@ -54,7 +54,7 @@ def _grid_group_sync(typingctx, group):
     return sig, codegen
 
 
-@overload_method(GridGroupClass, 'sync')
+@overload_method(GridGroupClass, 'sync', target='cuda')
 def _ol_grid_group_sync(group):
     if isinstance(group, GridGroupClass):
         def impl(group):

--- a/numba/cuda/cg.py
+++ b/numba/cuda/cg.py
@@ -18,7 +18,7 @@ def this_grid() -> GridGroup:
     return GridGroup()
 
 
-@intrinsic
+@intrinsic(target='cuda')
 def _this_grid(typingctx):
     sig = signature(grid_group)
 
@@ -40,7 +40,7 @@ def _ol_this_grid():
     return impl
 
 
-@intrinsic
+@intrinsic(target='cuda')
 def _grid_group_sync(typingctx, group):
     sig = signature(types.int32, group)
 

--- a/numba/cuda/cg.py
+++ b/numba/cuda/cg.py
@@ -1,0 +1,63 @@
+from numba.core import types
+from numba.core.extending import overload, overload_method
+from numba.core.typing import signature
+from numba.cuda import nvvmutils
+from numba.cuda.extending import intrinsic
+from numba.cuda.types import grid_group, GridGroup as GridGroupClass
+
+
+class GridGroup:
+    """A cooperative group representing the entire grid"""
+
+    def sync() -> None:
+        """Synchronize this grid group"""
+
+
+def this_grid() -> GridGroup:
+    """Get the current grid group."""
+    return GridGroup()
+
+
+@intrinsic
+def _this_grid(typingctx):
+    sig = signature(grid_group)
+
+    def codegen(context, builder, sig, args):
+        one = context.get_constant(types.int32, 1)
+        mod = builder.module
+        return builder.call(
+            nvvmutils.declare_cudaCGGetIntrinsicHandle(mod),
+            (one,))
+
+    return sig, codegen
+
+
+@overload(this_grid, target='cuda')
+def _ol_this_grid():
+    def impl():
+        return _this_grid()
+
+    return impl
+
+
+@intrinsic
+def _grid_group_sync(typingctx, group):
+    sig = signature(types.int32, group)
+
+    def codegen(context, builder, sig, args):
+        flags = context.get_constant(types.int32, 0)
+        mod = builder.module
+        return builder.call(
+            nvvmutils.declare_cudaCGSynchronize(mod),
+            (*args, flags))
+
+    return sig, codegen
+
+
+@overload_method(GridGroupClass, 'sync')
+def _ol_grid_group_sync(group):
+    if isinstance(group, GridGroupClass):
+        def impl(group):
+            return _grid_group_sync(group)
+
+        return impl

--- a/numba/cuda/cg.py
+++ b/numba/cuda/cg.py
@@ -18,7 +18,7 @@ def this_grid() -> GridGroup:
     return GridGroup()
 
 
-@intrinsic(target='cuda')
+@intrinsic
 def _this_grid(typingctx):
     sig = signature(grid_group)
 
@@ -40,7 +40,7 @@ def _ol_this_grid():
     return impl
 
 
-@intrinsic(target='cuda')
+@intrinsic
 def _grid_group_sync(typingctx, group):
     sig = signature(types.int32, group)
 

--- a/numba/cuda/cg.py
+++ b/numba/cuda/cg.py
@@ -56,8 +56,7 @@ def _grid_group_sync(typingctx, group):
 
 @overload_method(GridGroupClass, 'sync', target='cuda')
 def _ol_grid_group_sync(group):
-    if isinstance(group, GridGroupClass):
-        def impl(group):
-            return _grid_group_sync(group)
+    def impl(group):
+        return _grid_group_sync(group)
 
-        return impl
+    return impl

--- a/numba/cuda/cudadecl.py
+++ b/numba/cuda/cudadecl.py
@@ -9,7 +9,7 @@ from numba.core.typing.npydecl import (parse_dtype, parse_shape,
 from numba.core.typing.templates import (AttributeTemplate, ConcreteTemplate,
                                          AbstractTemplate, CallableTemplate,
                                          signature, Registry)
-from numba.cuda.types import dim3, grid_group
+from numba.cuda.types import dim3
 from numba.core.typeconv import Conversion
 from numba import cuda
 from numba.cuda.compiler import declare_device_function_template
@@ -88,35 +88,6 @@ class Cuda_threadfence_system(ConcreteTemplate):
 class Cuda_syncwarp(ConcreteTemplate):
     key = cuda.syncwarp
     cases = [signature(types.none), signature(types.none, types.i4)]
-
-
-@register
-class Cuda_cg_this_grid(ConcreteTemplate):
-    key = cuda.cg.this_grid
-    cases = [signature(grid_group)]
-
-
-@register_attr
-class CudaCgModuleTemplate(AttributeTemplate):
-    key = types.Module(cuda.cg)
-
-    def resolve_this_grid(self, mod):
-        return types.Function(Cuda_cg_this_grid)
-
-
-class Cuda_grid_group_sync(AbstractTemplate):
-    key = "GridGroup.sync"
-
-    def generic(self, args, kws):
-        return signature(types.int32, recvr=self.this)
-
-
-@register_attr
-class GridGroup_attrs(AttributeTemplate):
-    key = grid_group
-
-    def resolve_sync(self, mod):
-        return types.BoundFunction(Cuda_grid_group_sync, grid_group)
 
 
 @register

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -14,7 +14,7 @@ from numba.np.npyimpl import register_ufuncs
 from .cudadrv import nvvm
 from numba import cuda
 from numba.cuda import nvvmutils, stubs, errors
-from numba.cuda.types import dim3, grid_group, CUDADispatcher
+from numba.cuda.types import dim3, CUDADispatcher
 
 registry = Registry()
 lower = registry.lower
@@ -67,24 +67,6 @@ def dim3_y(context, builder, sig, args):
 @lower_attr(dim3, 'z')
 def dim3_z(context, builder, sig, args):
     return builder.extract_value(args, 2)
-
-
-@lower(cuda.cg.this_grid)
-def cg_this_grid(context, builder, sig, args):
-    one = context.get_constant(types.int32, 1)
-    lmod = builder.module
-    return builder.call(
-        nvvmutils.declare_cudaCGGetIntrinsicHandle(lmod),
-        (one,))
-
-
-@lower('GridGroup.sync', grid_group)
-def ptx_sync_group(context, builder, sig, args):
-    flags = context.get_constant(types.int32, 0)
-    lmod = builder.module
-    return builder.call(
-        nvvmutils.declare_cudaCGSynchronize(lmod),
-        (*args, flags))
 
 
 # -----------------------------------------------------------------------------

--- a/numba/cuda/device_init.py
+++ b/numba/cuda/device_init.py
@@ -1,10 +1,11 @@
 # Re export
 import sys
+from numba.cuda import cg
 from .stubs import (threadIdx, blockIdx, blockDim, gridDim, laneid, warpsize,
                     syncwarp, shared, local, const, atomic,
                     shfl_sync_intrinsic, vote_sync_intrinsic, match_any_sync,
                     match_all_sync, threadfence_block, threadfence_system,
-                    threadfence, selp, popc, brev, clz, ffs, fma, cbrt, cg,
+                    threadfence, selp, popc, brev, clz, ffs, fma, cbrt,
                     activemask, lanemask_lt, nanosleep, fp16,
                     _vector_type_stubs)
 from .intrinsics import (grid, gridsize, syncthreads, syncthreads_and,

--- a/numba/cuda/stubs.py
+++ b/numba/cuda/stubs.py
@@ -157,27 +157,6 @@ class const(Stub):
         '''
 
 
-#-------------------------------------------------------------------------------
-# Cooperative groups
-
-class cg(Stub):
-    '''
-    Cooperative groups
-    '''
-
-    @stub_function
-    def this_grid():
-        '''
-        Get the current grid group.
-        '''
-
-    class GridGroup(Stub):
-        def sync():
-            '''
-            Synchronize the current grid group.
-            '''
-
-
 # -------------------------------------------------------------------------------
 # warp level operations
 

--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -171,7 +171,8 @@ def cudadevrt_missing():
     if config.ENABLE_CUDASIM:
         return False
     try:
-        libs.check_static_lib('cudadevrt')
+        path = libs.get_cudalib('cudadevrt', static=True)
+        libs.check_static_lib(path)
     except FileNotFoundError:
         return True
     return False


### PR DESCRIPTION
This is a non-functional change that only moves the CGs API implementation up to the high-level extension API. Note that CGs were never defined with a data model, so it's a little confusing to see what's going on when the grid group is passed to the `sync()` method, but it's an `i64` that is passed around opaquely.

Type hints are added on the public API to help IDEs / autocompleting REPLs.

The CGs tests have accidentally been skipped for a long time - this PR also includes a fix that reinstates them.
