### PR TITLE
Improve reorderable ufunc support

### DIFF
--- a/docs/upcoming_changes/9295.improvement.rst
+++ b/docs/upcoming_changes/9295.improvement.rst
@@ -1,0 +1,4 @@
+Improve reorderable ufunc support and add NumPy reduce related tests
+--------------------------------------------------------------------
+
+Improve reorderable ufunc support and add NumPy ufunc.reduce related tests.

--- a/numba/np/ufunc/dufunc.py
+++ b/numba/np/ufunc/dufunc.py
@@ -497,7 +497,6 @@ class DUFunc(serialize.ReduceMixin, _internal._DUFunc, UfuncBase):
                 msg = 'The first argument "array" must be array-like'
                 raise errors.NumbaTypeError(msg)
 
-            axis_tuple = isinstance(axis, types.BaseTuple)
             axis_int_tuple = isinstance(axis, types.UniTuple) and \
                 isinstance(axis.dtype, types.Integer)
             axis_empty_tuple = isinstance(axis, types.Tuple) and len(axis) == 0
@@ -508,7 +507,7 @@ class DUFunc(serialize.ReduceMixin, _internal._DUFunc, UfuncBase):
 
             # In NumPy, a ufunc is reorderable if its identity type is **not**
             # PyUfunc_None.
-            if not self.reorderable and axis_tuple and len(axis) > 1:
+            if not self.reorderable and axis_int_tuple and len(axis) > 1:
                 msg = (f"reduction operation '{ufunc_name}' is not "
                        "reorderable, so at most one axis may be specified")
                 raise errors.NumbaTypeError(msg)

--- a/numba/np/ufunc/dufunc.py
+++ b/numba/np/ufunc/dufunc.py
@@ -186,6 +186,7 @@ class DUFunc(serialize.ReduceMixin, _internal._DUFunc, UfuncBase):
         super(DUFunc, self).__init__(dispatcher, identity=identity)
         # Loop over a copy of the keys instead of the keys themselves,
         # since we're changing the dictionary while looping.
+        self.reorderable = (identity != _internal.PyUFunc_None)
         self.__name__ = dispatcher.py_func.__name__
         self.__doc__ = dispatcher.py_func.__doc__
         self._lower_me = DUFuncLowerer(self)
@@ -496,17 +497,19 @@ class DUFunc(serialize.ReduceMixin, _internal._DUFunc, UfuncBase):
                 msg = 'The first argument "array" must be array-like'
                 raise errors.NumbaTypeError(msg)
 
-            axis_int = isinstance(axis, types.Integer)
+            axis_tuple = isinstance(axis, types.BaseTuple)
             axis_int_tuple = isinstance(axis, types.UniTuple) and \
                 isinstance(axis.dtype, types.Integer)
             axis_empty_tuple = isinstance(axis, types.Tuple) and len(axis) == 0
             axis_none = cgutils.is_nonelike(axis)
-            axis_tuple_size = len(axis) if axis_int_tuple else 0
 
-            if self.ufunc.identity is None and not (
-                    (axis_int_tuple and axis_tuple_size == 1) or
-                    axis_empty_tuple or axis_int or axis_none):
-                msg = (f"reduction operation '{self.ufunc.__name__}' is not "
+            identity_none = self.ufunc.identity is None
+            ufunc_name = self.ufunc.__name__
+
+            # In NumPy, a ufunc is reorderable if its identity type is **not**
+            # PyUfunc_None.
+            if not self.reorderable and axis_tuple and len(axis) > 1:
+                msg = (f"reduction operation '{ufunc_name}' is not "
                        "reorderable, so at most one axis may be specified")
                 raise errors.NumbaTypeError(msg)
 
@@ -630,6 +633,11 @@ class DUFunc(serialize.ReduceMixin, _internal._DUFunc, UfuncBase):
                 return idx, e
 
             def impl_1d(ufunc, array, axis=0, dtype=None, initial=None):
+                if identity_none and initial is None and len(array) == 0:
+                    msg = ('zero-size array to reduction operation '
+                           f'{ufunc_name} which has no identity')
+                    raise ValueError(msg)
+
                 start = 0
                 if init_none and id_none:
                     start = 1
@@ -657,6 +665,11 @@ class DUFunc(serialize.ReduceMixin, _internal._DUFunc, UfuncBase):
 
                 if axis < 0 or axis >= array.ndim:
                     raise ValueError("Invalid axis")
+
+                if identity_none and initial is None and array.shape[axis] == 0:
+                    msg = ('zero-size array to reduction operation '
+                           f'{ufunc_name} which has no identity')
+                    raise ValueError(msg)
 
                 # create result array
                 shape = tuple_slice(array.shape, axis)
@@ -765,8 +778,6 @@ class DUFunc(serialize.ReduceMixin, _internal._DUFunc, UfuncBase):
                 # axis is default value (0) or an integer
                 # ufunc(array, axis=0)
                 return impl_nd_axis_int
-            # elif array.ndim == 1:
-            #     return impl_1d
 
     def at(self, a, indices, b=None):
         # dynamic compile ufunc.at


### PR DESCRIPTION
Improve reorderable ufunc support (#9283) and add NumPy ufunc.reduce tests.