### PR TITLE
Add category to warning

### DIFF
--- a/numba/core/errors.py
+++ b/numba/core/errors.py
@@ -103,6 +103,12 @@ class NumbaDebugInfoWarning(NumbaWarning):
     Warning category for an issue with the emission of debug information.
     """
 
+
+class NumbaSystemWarning(NumbaWarning):
+    """
+    Warning category for an issue with the system configuration.
+    """
+
 # These are needed in the color formatting of errors setup
 
 

--- a/numba/np/ufunc/parallel.py
+++ b/numba/np/ufunc/parallel.py
@@ -321,7 +321,7 @@ def _set_init_process_lock():
             "this initialization sequence/module import is deferred to the "
             "user! ***\n"
         )
-        warnings.warn(msg % str(e), errors.NumbaParallelSafetyWarning)
+        warnings.warn(msg % str(e), errors.NumbaSystemWarning)
 
         _backend_init_process_lock = _nop()
 

--- a/numba/np/ufunc/parallel.py
+++ b/numba/np/ufunc/parallel.py
@@ -321,7 +321,7 @@ def _set_init_process_lock():
             "this initialization sequence/module import is deferred to the "
             "user! ***\n"
         )
-        warnings.warn(msg % str(e))
+        warnings.warn(msg % str(e), errors.NumbaParallelSafetyWarning)
 
         _backend_init_process_lock = _nop()
 


### PR DESCRIPTION
### Background

For my project, I'm using [rembg](https://github.com/danielgatis/rembg) in order to remove background for images in a AWS lambda function. This library is using [PyMatting](https://github.com/pymatting/pymatting) to implement Alpha Matting which depends on numba. But, since [_multiprocessing.SemLock is not implemented when running on AWS Lambda](https://stackoverflow.com/questions/34005930/multiprocessing-semlock-is-not-implemented-when-running-on-aws-lambda), I get a warning every time the lambda function runs. This pollutes the function logs

### Workaround

Since

* I cannot control what Amazon offers
* I actually don't use Alpha Matting, so this warning is irrelevant for my use case

I would like to silence this specific warning using [warnings.simplefilter](https://docs.python.org/3/library/warnings.html#warnings.simplefilter)

### Solution
In order to support silencing this specific warning and not everything, I have added the category parameter to the `warnings.warn` call. Hopefully, this is the proper class for this warning, but if needed, another warning class can be added

