### PR TITLE
Charseq to charseq cast

### DIFF
--- a/docs/upcoming_changes/9305.charseq_cast.rst
+++ b/docs/upcoming_changes/9305.charseq_cast.rst
@@ -1,0 +1,5 @@
+Implement casting from charseq to charseq
+=========================================
+
+Allows automatic casting from dtype "S<N>" to "S<M>" 
+if M is larger or equal to N.

--- a/numba/core/types/npytypes.py
+++ b/numba/core/types/npytypes.py
@@ -31,6 +31,11 @@ class CharSeq(Type):
         if isinstance(other, Bytes):
             return Conversion.safe
 
+    def can_convert_to(self, typingctx, other):
+        if isinstance(other, CharSeq):
+            if other.count < self.count:
+                return Conversion.unsafe
+            return Conversion.safe
 
 class UnicodeCharSeq(Type):
     """

--- a/numba/cpython/charseq.py
+++ b/numba/cpython/charseq.py
@@ -218,8 +218,15 @@ def charseq_to_bytes(context, builder, fromty, toty, val):
     cgutils.memcpy(builder, bstr.data, ptr, bstr.nitems)
     return bstr
 
+
 @lower_cast(types.CharSeq, types.CharSeq)
-def charseq_to_charseq(context, builder: ir.IRBuilder, fromty: types.CharSeq, toty: types.CharSeq, val: ir.values.values.Value):
+def charseq_to_charseq(
+    context,
+    builder: ir.IRBuilder,
+    fromty: types.CharSeq,
+    toty: types.CharSeq,
+    val: ir.values.values.Value
+):
     char_t = ir.IntType(8)
     count_t = ir.IntType(32)
 
@@ -245,7 +252,6 @@ def charseq_to_charseq(context, builder: ir.IRBuilder, fromty: types.CharSeq, to
         builder.store(in_val, builder.gep(dst, [loop.index]))
 
     return builder.load(dst_ptr)
-
 
 
 @lower_cast(types.UnicodeType, types.Bytes)

--- a/numba/tests/test_casting.py
+++ b/numba/tests/test_casting.py
@@ -135,6 +135,23 @@ class TestCasting(unittest.TestCase):
         self.assertEqual(foo(2), 2)
         self.assertIsNone(foo(None))
 
+    def test_charseq_to_charseq(self):
+        src_typ = types.Array(types.CharSeq(4), 1, "A")
+        dst_typ = types.Array(types.CharSeq(5), 1, "A")
+        sig = types.int32(src_typ, dst_typ)
+
+        @njit(sig)
+        def assign_charseq_array(src, dst):
+            for i in range(len(src)):
+                dst[i] = src[i]
+            return 0
+
+        x = np.array(["1234", "5678"], dtype="S4")
+        y = np.empty(2, dtype="S5")
+        assign_charseq_array(x, y)
+
+        self.assertEqual(y[0], b"1234")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
closes #9305 

Implements conversions/casts from CharSeq to CharSeq, to support assignment from numpy byte-string arrays. (e.g., np.array(["x", "y"], dtype="S")).

The  numpy.bytes_ type seems to be implemented with a signed int32 - `np.dtype(f"S{2**31}")` wraps around (this actually returns an un-instantiable `dtype('S-2147483648')`). Thus in the lowering code, we use an ir.IntType(32) for the count size.

The lowering code is mostly inspired by the `bytes_to_charseq` function above it on L169.