### PR TITLE
Continue #9044, prevent compilation on the CPU target when listing tests.

### DIFF
--- a/docs/upcoming_changes/9309.change.rst
+++ b/docs/upcoming_changes/9309.change.rst
@@ -1,0 +1,8 @@
+Make test listing not invoke CPU compilation.
+---------------------------------------------
+
+Numba's test listing command ``python -m numba.runtests -l`` has historically
+triggered CPU target compilation due to the way in which certain test functions
+were declared within the test suite. It has now been made such that the CPU
+target compiler is not invoked on test listing and a test is added to ensure
+that it remains the case.

--- a/numba/stencils/stencil.py
+++ b/numba/stencils/stencil.py
@@ -80,8 +80,6 @@ class StencilFunc(object):
         # stencils only supported for CPU context currently
         self._typingctx = registry.cpu_target.typing_context
         self._targetctx = registry.cpu_target.target_context
-        self._typingctx.refresh()
-        self._targetctx.refresh()
         self._install_type(self._typingctx)
         self.neighborhood = self.options.get("neighborhood")
         self._type_cache = {}
@@ -766,6 +764,7 @@ class StencilFunc(object):
         return new_func
 
     def __call__(self, *args, **kwargs):
+        self._typingctx.refresh()
         if (self.neighborhood is not None and
             len(self.neighborhood) != args[0].ndim):
             raise ValueError("{} dimensional neighborhood specified for {} "

--- a/numba/tests/chained_assign_usecases.py
+++ b/numba/tests/chained_assign_usecases.py
@@ -1,0 +1,69 @@
+from numba import jit
+import numpy as np
+
+
+@jit
+def inc(a):
+    for i in range(len(a)):
+        a[i] += 1
+    return a
+
+
+@jit
+def inc1(a):
+    a[0] += 1
+    return a[0]
+
+
+@jit
+def inc2(a):
+    a[0] += 1
+    return a[0], a[0] + 1
+
+
+def chain1(a):
+    x = y = z = inc(a)
+    return x + y + z
+
+
+def chain2(v):
+    a = np.zeros(2)
+    a[0] = x = a[1] = v
+    return a[0] + a[1] + (x / 2)
+
+
+def unpack1(x, y):
+    a, b = x, y
+    return a + b / 2
+
+
+def unpack2(x, y):
+    a, b = c, d = inc1(x), inc1(y)
+    return a + c / 2, b + d / 2
+
+
+def chain3(x, y):
+    a = (b, c) = (inc1(x), inc1(y))
+    (d, e) = f = (inc1(x), inc1(y))
+    return (a[0] + b / 2 + d + f[0]), (a[1] + c + e / 2 + f[1])
+
+
+def unpack3(x):
+    a, b = inc2(x)
+    return a + b / 2
+
+
+def unpack4(x):
+    a, b = c, d = inc2(x)
+    return a + c / 2, b + d / 2
+
+
+def unpack5(x):
+    a = b, c = inc2(x)
+    d, e = f = inc2(x)
+    return (a[0] + b / 2 + d + f[0]), (a[1] + c + e / 2 + f[1])
+
+
+def unpack6(x, y):
+    (a, b), (c, d) = (x, y), (y + 1, x + 1)
+    return a + c / 2, b / 2 + d

--- a/numba/tests/errorhandling_usecases.py
+++ b/numba/tests/errorhandling_usecases.py
@@ -1,0 +1,14 @@
+from numba import typed, int64
+
+# used in TestMiscErrorHandling::test_handling_of_write_to_*_global
+_global_list = [1, 2, 3, 4]
+
+_global_dict = typed.Dict.empty(int64, int64)
+
+
+def global_reflected_write():
+    _global_list[0] = 10
+
+
+def global_dict_write():
+    _global_dict[0] = 10

--- a/numba/tests/inlining_usecases.py
+++ b/numba/tests/inlining_usecases.py
@@ -1,5 +1,6 @@
 """ Test cases for inlining IR from another module """
-from numba import njit
+from numba import jit, njit
+from numba.core import types
 from numba.core.extending import overload
 
 _GLOBAL1 = 100
@@ -43,3 +44,26 @@ def bop_factory(a):
         return impl
 
     return bop
+
+
+@jit((types.int32,), nopython=True)
+def inner(a):
+    return a + 1
+
+
+@jit((types.int32,), nopython=True)
+def more(a):
+    return inner(inner(a))
+
+
+def outer_simple(a):
+    return inner(a) * 2
+
+
+def outer_multiple(a):
+    return inner(a) * more(a)
+
+
+@njit
+def __dummy__():
+    return

--- a/numba/tests/npyufunc/test_ufuncbuilding.py
+++ b/numba/tests/npyufunc/test_ufuncbuilding.py
@@ -1,5 +1,3 @@
-import sys
-
 import numpy as np
 
 from numba.np.ufunc.ufuncbuilder import GUFuncBuilder
@@ -11,68 +9,10 @@ from numba.core import config
 import unittest
 
 
-def add(a, b):
-    """An addition"""
-    return a + b
-
-def equals(a, b):
-    return a == b
-
-def mul(a, b):
-    """A multiplication"""
-    return a * b
-
-def guadd(a, b, c):
-    """A generalized addition"""
-    x, y = c.shape
-    for i in range(x):
-        for j in range(y):
-            c[i, j] = a[i, j] + b[i, j]
-
-@vectorize(nopython=True)
-def inner(a, b):
-    return a + b
-
-@vectorize(["int64(int64, int64)"], nopython=True)
-def inner_explicit(a, b):
-    return a + b
-
-def outer(a, b):
-    return inner(a, b)
-
-def outer_explicit(a, b):
-    return inner_explicit(a, b)
-
-
-class Dummy: pass
-
-
-def guadd_obj(a, b, c):
-    Dummy()  # to force object mode
-    x, y = c.shape
-    for i in range(x):
-        for j in range(y):
-            c[i, j] = a[i, j] + b[i, j]
-
-def guadd_scalar_obj(a, b, c):
-    Dummy()  # to force object mode
-    x, y = c.shape
-    for i in range(x):
-        for j in range(y):
-            c[i, j] = a[i, j] + b
-
-
-class MyException(Exception):
-    pass
-
-
-def guerror(a, b, c):
-    raise MyException
-
-
 class TestUfuncBuilding(TestCase):
 
     def test_basic_ufunc(self):
+        from numba.tests.npyufunc.ufuncbuilding_usecases import add
         ufb = UFuncBuilder(add)
         cres = ufb.add("int32(int32, int32)")
         self.assertFalse(cres.objectmode)
@@ -98,6 +38,7 @@ class TestUfuncBuilding(TestCase):
         self.assertIn("An addition", ufunc.__doc__)
 
     def test_ufunc_struct(self):
+        from numba.tests.npyufunc.ufuncbuilding_usecases import add
         ufb = UFuncBuilder(add)
         cres = ufb.add("complex64(complex64, complex64)")
         self.assertFalse(cres.objectmode)
@@ -117,6 +58,7 @@ class TestUfuncBuilding(TestCase):
         check(a)
 
     def test_ufunc_forceobj(self):
+        from numba.tests.npyufunc.ufuncbuilding_usecases import add
         ufb = UFuncBuilder(add, targetoptions={'forceobj': True})
         cres = ufb.add("int32(int32, int32)")
         self.assertTrue(cres.objectmode)
@@ -130,6 +72,7 @@ class TestUfuncBuilding(TestCase):
         """
         Check nested call to an implicitly-typed ufunc.
         """
+        from numba.tests.npyufunc.ufuncbuilding_usecases import outer
         builder = UFuncBuilder(outer,
                                targetoptions={'nopython': True})
         builder.add("(int64, int64)")
@@ -140,6 +83,7 @@ class TestUfuncBuilding(TestCase):
         """
         Check nested call to an explicitly-typed ufunc.
         """
+        from numba.tests.npyufunc.ufuncbuilding_usecases import outer_explicit
         builder = UFuncBuilder(outer_explicit,
                                targetoptions={'nopython': True})
         builder.add("(int64, int64)")
@@ -160,6 +104,7 @@ class TestUfuncBuildingJitDisabled(TestUfuncBuilding):
 class TestGUfuncBuilding(TestCase):
 
     def test_basic_gufunc(self):
+        from numba.tests.npyufunc.ufuncbuilding_usecases import guadd
         gufb = GUFuncBuilder(guadd, "(x, y),(x, y)->(x, y)")
         cres = gufb.add("void(int32[:,:], int32[:,:], int32[:,:])")
         self.assertFalse(cres.objectmode)
@@ -176,6 +121,7 @@ class TestGUfuncBuilding(TestCase):
         self.assertIn("A generalized addition", ufunc.__doc__)
 
     def test_gufunc_struct(self):
+        from numba.tests.npyufunc.ufuncbuilding_usecases import guadd
         gufb = GUFuncBuilder(guadd, "(x, y),(x, y)->(x, y)")
         cres = gufb.add("void(complex64[:,:], complex64[:,:], complex64[:,:])")
         self.assertFalse(cres.objectmode)
@@ -187,6 +133,7 @@ class TestGUfuncBuilding(TestCase):
         self.assertPreciseEqual(a + a, b)
 
     def test_gufunc_struct_forceobj(self):
+        from numba.tests.npyufunc.ufuncbuilding_usecases import guadd
         gufb = GUFuncBuilder(guadd, "(x, y),(x, y)->(x, y)",
                              targetoptions=dict(forceobj=True))
         cres = gufb.add("void(complex64[:,:], complex64[:,:], complex64[:,"
@@ -215,24 +162,28 @@ class TestVectorizeDecor(TestCase):
     _supported_identities = [0, 1, None, "reorderable"]
 
     def test_vectorize(self):
+        from numba.tests.npyufunc.ufuncbuilding_usecases import add
         ufunc = vectorize(['int32(int32, int32)'])(add)
         a = np.arange(10, dtype='int32')
         b = ufunc(a, a)
         self.assertPreciseEqual(a + a, b)
 
     def test_vectorize_objmode(self):
+        from numba.tests.npyufunc.ufuncbuilding_usecases import add
         ufunc = vectorize(['int32(int32, int32)'], forceobj=True)(add)
         a = np.arange(10, dtype='int32')
         b = ufunc(a, a)
         self.assertPreciseEqual(a + a, b)
 
     def test_vectorize_bool_return(self):
+        from numba.tests.npyufunc.ufuncbuilding_usecases import equals
         ufunc = vectorize(['bool_(int32, int32)'])(equals)
         a = np.arange(10, dtype='int32')
         r = ufunc(a,a)
         self.assertPreciseEqual(r, np.ones(r.shape, dtype=np.bool_))
 
     def test_vectorize_identity(self):
+        from numba.tests.npyufunc.ufuncbuilding_usecases import add
         sig = 'int32(int32, int32)'
         for identity in self._supported_identities:
             ufunc = vectorize([sig], identity=identity)(add)
@@ -248,6 +199,7 @@ class TestVectorizeDecor(TestCase):
             vectorize([sig], identity=2)(add)
 
     def test_vectorize_no_args(self):
+        from numba.tests.npyufunc.ufuncbuilding_usecases import add
         a = np.linspace(0,1,10)
         b = np.linspace(1,2,10)
         ufunc = vectorize(add)
@@ -258,6 +210,7 @@ class TestVectorizeDecor(TestCase):
         self.assertPreciseEqual(c, a + b)
 
     def test_vectorize_only_kws(self):
+        from numba.tests.npyufunc.ufuncbuilding_usecases import mul
         a = np.linspace(0,1,10)
         b = np.linspace(1,2,10)
         ufunc = vectorize(identity=PyUFunc_One, nopython=True)(mul)
@@ -277,6 +230,7 @@ class TestVectorizeDecor(TestCase):
                 ufunc(a, a, zzz=out)
 
         # With explicit sigs
+        from numba.tests.npyufunc.ufuncbuilding_usecases import add
         ufunc = vectorize(['int32(int32, int32)'], nopython=True)(add)
         check(ufunc)
         # With implicit sig
@@ -285,6 +239,7 @@ class TestVectorizeDecor(TestCase):
         check(ufunc)  # after compiling
 
     def test_guvectorize(self):
+        from numba.tests.npyufunc.ufuncbuilding_usecases import guadd
         ufunc = guvectorize(['(int32[:,:], int32[:,:], int32[:,:])'],
                             "(x,y),(x,y)->(x,y)")(guadd)
         a = np.arange(10, dtype='int32').reshape(2, 5)
@@ -292,6 +247,7 @@ class TestVectorizeDecor(TestCase):
         self.assertPreciseEqual(a + a, b)
 
     def test_guvectorize_no_output(self):
+        from numba.tests.npyufunc.ufuncbuilding_usecases import guadd
         ufunc = guvectorize(['(int32[:,:], int32[:,:], int32[:,:])'],
                             "(x,y),(x,y),(x,y)")(guadd)
         a = np.arange(10, dtype='int32').reshape(2, 5)
@@ -300,6 +256,7 @@ class TestVectorizeDecor(TestCase):
         self.assertPreciseEqual(a + a, out)
 
     def test_guvectorize_objectmode(self):
+        from numba.tests.npyufunc.ufuncbuilding_usecases import guadd_obj
         ufunc = guvectorize(['(int32[:,:], int32[:,:], int32[:,:])'],
                             "(x,y),(x,y)->(x,y)")(guadd_obj)
         a = np.arange(10, dtype='int32').reshape(2, 5)
@@ -310,6 +267,7 @@ class TestVectorizeDecor(TestCase):
         """
         Test passing of scalars to object mode gufuncs.
         """
+        from numba.tests.npyufunc.ufuncbuilding_usecases import guadd_scalar_obj
         ufunc = guvectorize(['(int32[:,:], int32, int32[:,:])'],
                             "(x,y),()->(x,y)")(guadd_scalar_obj)
         a = np.arange(10, dtype='int32').reshape(2, 5)
@@ -317,6 +275,8 @@ class TestVectorizeDecor(TestCase):
         self.assertPreciseEqual(a + 3, b)
 
     def test_guvectorize_error_in_objectmode(self):
+        from numba.tests.npyufunc.ufuncbuilding_usecases import guerror, \
+            MyException
         ufunc = guvectorize(['(int32[:,:], int32[:,:], int32[:,:])'],
                             "(x,y),(x,y)->(x,y)", forceobj=True)(guerror)
         a = np.arange(10, dtype='int32').reshape(2, 5)
@@ -324,6 +284,7 @@ class TestVectorizeDecor(TestCase):
             ufunc(a, a)
 
     def test_guvectorize_identity(self):
+        from numba.tests.npyufunc.ufuncbuilding_usecases import add, guadd
         args = (['(int32[:,:], int32[:,:], int32[:,:])'], "(x,y),(x,y)->(x,y)")
         for identity in self._supported_identities:
             ufunc = guvectorize(*args, identity=identity)(guadd)
@@ -339,6 +300,7 @@ class TestVectorizeDecor(TestCase):
             guvectorize(*args, identity=2)(add)
 
     def test_guvectorize_invalid_layout(self):
+        from numba.tests.npyufunc.ufuncbuilding_usecases import guadd
         sigs = ['(int32[:,:], int32[:,:], int32[:,:])']
         # Syntax error
         with self.assertRaises(ValueError) as raises:

--- a/numba/tests/npyufunc/ufuncbuilding_usecases.py
+++ b/numba/tests/npyufunc/ufuncbuilding_usecases.py
@@ -1,0 +1,69 @@
+from numba import vectorize
+
+
+def add(a, b):
+    """An addition"""
+    return a + b
+
+
+def equals(a, b):
+    return a == b
+
+
+def mul(a, b):
+    """A multiplication"""
+    return a * b
+
+
+def guadd(a, b, c):
+    """A generalized addition"""
+    x, y = c.shape
+    for i in range(x):
+        for j in range(y):
+            c[i, j] = a[i, j] + b[i, j]
+
+
+@vectorize(nopython=True)
+def inner(a, b):
+    return a + b
+
+
+@vectorize(["int64(int64, int64)"], nopython=True)
+def inner_explicit(a, b):
+    return a + b
+
+
+def outer(a, b):
+    return inner(a, b)
+
+
+def outer_explicit(a, b):
+    return inner_explicit(a, b)
+
+
+class Dummy:
+    pass
+
+
+def guadd_obj(a, b, c):
+    Dummy()  # to force object mode
+    x, y = c.shape
+    for i in range(x):
+        for j in range(y):
+            c[i, j] = a[i, j] + b[i, j]
+
+
+def guadd_scalar_obj(a, b, c):
+    Dummy()  # to force object mode
+    x, y = c.shape
+    for i in range(x):
+        for j in range(y):
+            c[i, j] = a[i, j] + b
+
+
+class MyException(Exception):
+    pass
+
+
+def guerror(a, b, c):
+    raise MyException

--- a/numba/tests/test_chained_assign.py
+++ b/numba/tests/test_chained_assign.py
@@ -5,73 +5,9 @@ import copy
 from numba.tests.support import MemoryLeakMixin
 
 
-@jit
-def inc(a):
-    for i in range(len(a)):
-        a[i] += 1
-    return a
-
-@jit
-def inc1(a):
-    a[0] += 1
-    return a[0]
-
-@jit
-def inc2(a):
-    a[0] += 1
-    return a[0], a[0] + 1
-
-
-def chain1(a):
-    x = y = z = inc(a)
-    return x + y + z
-
-
-def chain2(v):
-    a = np.zeros(2)
-    a[0] = x = a[1] = v
-    return a[0] + a[1] + (x / 2)
-
-
-def unpack1(x, y):
-    a, b = x, y
-    return a + b / 2
-
-
-def unpack2(x, y):
-    a, b = c, d = inc1(x), inc1(y)
-    return a + c / 2, b + d / 2
-
-
-def chain3(x, y):
-    a = (b, c) = (inc1(x), inc1(y))
-    (d, e) = f = (inc1(x), inc1(y))
-    return (a[0] + b / 2 + d + f[0]), (a[1] + c + e / 2 + f[1])
-
-
-def unpack3(x):
-    a, b = inc2(x)
-    return a + b / 2
-
-
-def unpack4(x):
-    a, b = c, d = inc2(x)
-    return a + c / 2, b + d / 2
-
-
-def unpack5(x):
-    a = b, c = inc2(x)
-    d, e = f = inc2(x)
-    return (a[0] + b / 2 + d + f[0]), (a[1] + c + e / 2 + f[1])
-
-
-def unpack6(x, y):
-    (a, b), (c, d) = (x, y), (y + 1, x + 1)
-    return a + c / 2, b / 2 + d
-
-
 class TestChainedAssign(MemoryLeakMixin, unittest.TestCase):
     def test_chain1(self):
+        from numba.tests.chained_assign_usecases import chain1
         args = [
             [np.arange(2)],
             [np.arange(4, dtype=np.double)],
@@ -79,6 +15,7 @@ class TestChainedAssign(MemoryLeakMixin, unittest.TestCase):
         self._test_template(chain1, args)
 
     def test_chain2(self):
+        from numba.tests.chained_assign_usecases import chain2
         args = [
             [3],
             [3.0],
@@ -86,6 +23,7 @@ class TestChainedAssign(MemoryLeakMixin, unittest.TestCase):
         self._test_template(chain2, args)
 
     def test_unpack1(self):
+        from numba.tests.chained_assign_usecases import unpack1
         args = [
             [1, 3.0],
             [1.0, 3],
@@ -93,6 +31,7 @@ class TestChainedAssign(MemoryLeakMixin, unittest.TestCase):
         self._test_template(unpack1, args)
 
     def test_unpack2(self):
+        from numba.tests.chained_assign_usecases import unpack2
         args = [
             [np.array([2]), np.array([4.0])],
             [np.array([2.0]), np.array([4])],
@@ -100,6 +39,7 @@ class TestChainedAssign(MemoryLeakMixin, unittest.TestCase):
         self._test_template(unpack2, args)
 
     def test_chain3(self):
+        from numba.tests.chained_assign_usecases import chain3
         args = [
             [np.array([0]), np.array([1.5])],
             [np.array([0.5]), np.array([1])],
@@ -107,6 +47,7 @@ class TestChainedAssign(MemoryLeakMixin, unittest.TestCase):
         self._test_template(chain3, args)
 
     def test_unpack3(self):
+        from numba.tests.chained_assign_usecases import unpack3
         args = [
             [np.array([1])],
             [np.array([1.0])],
@@ -114,6 +55,7 @@ class TestChainedAssign(MemoryLeakMixin, unittest.TestCase):
         self._test_template(unpack3, args)
 
     def test_unpack4(self):
+        from numba.tests.chained_assign_usecases import unpack4
         args = [
             [np.array([1])],
             [np.array([1.0])],
@@ -121,6 +63,7 @@ class TestChainedAssign(MemoryLeakMixin, unittest.TestCase):
         self._test_template(unpack4, args)
 
     def test_unpack5(self):
+        from numba.tests.chained_assign_usecases import unpack5
         args = [
             [np.array([2])],
             [np.array([2.0])],
@@ -128,6 +71,7 @@ class TestChainedAssign(MemoryLeakMixin, unittest.TestCase):
         self._test_template(unpack5, args)
 
     def test_unpack6(self):
+        from numba.tests.chained_assign_usecases import unpack6
         args1 = 3.0, 2
         args2 = 3.0, 2.0
         self._test_template(unpack6, [args1, args2])

--- a/numba/tests/test_errorhandling.py
+++ b/numba/tests/test_errorhandling.py
@@ -6,7 +6,7 @@ import numpy as np
 import os
 import warnings
 
-from numba import jit, njit, typed, int64, types
+from numba import jit, njit, types
 from numba.core import errors
 from numba.experimental import structref
 from numba.extending import (overload, intrinsic, overload_method,
@@ -23,10 +23,6 @@ from numba.tests.support import (skip_parfors_unsupported, override_config,
                                  SerialMixin, skip_unless_cffi,
                                  skip_unless_scipy, TestCase)
 import unittest
-
-# used in TestMiscErrorHandling::test_handling_of_write_to_*_global
-_global_list = [1, 2, 3, 4]
-_global_dict = typed.Dict.empty(int64, int64)
 
 
 class TestErrorHandlingBeforeLowering(unittest.TestCase):
@@ -135,18 +131,12 @@ class TestMiscErrorHandling(unittest.TestCase):
             self.assertIn(ex, str(raises.exception))
 
     def test_handling_of_write_to_reflected_global(self):
-        @njit
-        def foo():
-            _global_list[0] = 10
-
-        self.check_write_to_globals(foo)
+        from numba.tests.errorhandling_usecases import global_reflected_write
+        self.check_write_to_globals(njit(global_reflected_write))
 
     def test_handling_of_write_to_typed_dict_global(self):
-        @njit
-        def foo():
-            _global_dict[0] = 10
-
-        self.check_write_to_globals(foo)
+        from numba.tests.errorhandling_usecases import global_dict_write
+        self.check_write_to_globals(njit(global_dict_write))
 
     @skip_parfors_unsupported
     def test_handling_forgotten_numba_internal_import(self):

--- a/numba/tests/test_recursion.py
+++ b/numba/tests/test_recursion.py
@@ -9,50 +9,52 @@ import unittest
 
 class TestSelfRecursion(TestCase):
 
-    def setUp(self):
-        # Avoid importing this module at toplevel, as it triggers compilation
-        # and can therefore fail
-        from numba.tests import recursion_usecases
-        self.mod = recursion_usecases
-
     def check_fib(self, cfunc):
         self.assertPreciseEqual(cfunc(10), 55)
 
     def test_global_explicit_sig(self):
-        self.check_fib(self.mod.fib1)
+        from numba.tests.recursion_usecases import fib1
+        self.check_fib(fib1)
 
     def test_inner_explicit_sig(self):
-        self.check_fib(self.mod.fib2)
+        from numba.tests.recursion_usecases import fib2
+        self.check_fib(fib2)
 
     def test_global_implicit_sig(self):
-        self.check_fib(self.mod.fib3)
+        from numba.tests.recursion_usecases import fib3
+        self.check_fib(fib3)
 
     def test_runaway(self):
+        from numba.tests.recursion_usecases import runaway_self
         with self.assertRaises(TypingError) as raises:
-            self.mod.runaway_self(123)
+            runaway_self(123)
         self.assertIn("cannot type infer runaway recursion",
                       str(raises.exception))
 
     def test_type_change(self):
-        pfunc = self.mod.make_type_change_self()
-        cfunc = self.mod.make_type_change_self(jit(nopython=True))
+        from numba.tests.recursion_usecases import make_type_change_self
+        pfunc = make_type_change_self()
+        cfunc = make_type_change_self(jit(nopython=True))
         args = 13, 0.125
         self.assertPreciseEqual(pfunc(*args), cfunc(*args))
 
     def test_raise(self):
+        from numba.tests.recursion_usecases import raise_self
         with self.assertRaises(ValueError) as raises:
-            self.mod.raise_self(3)
+            raise_self(3)
 
         self.assertEqual(str(raises.exception), "raise_self")
 
     def test_optional_return(self):
-        pfunc = self.mod.make_optional_return_case()
-        cfunc = self.mod.make_optional_return_case(jit(nopython=True))
+        from numba.tests.recursion_usecases import make_optional_return_case
+        pfunc = make_optional_return_case()
+        cfunc = make_optional_return_case(jit(nopython=True))
         for arg in (0, 5, 10, 15):
             self.assertEqual(pfunc(arg), cfunc(arg))
 
     def test_growing_return_tuple(self):
-        cfunc = self.mod.make_growing_tuple_case(jit(nopython=True))
+        from numba.tests.recursion_usecases import make_growing_tuple_case
+        cfunc = make_growing_tuple_case(jit(nopython=True))
         with self.assertRaises(TypingError) as raises:
             cfunc(100)
         self.assertIn(
@@ -63,57 +65,60 @@ class TestSelfRecursion(TestCase):
 
 class TestMutualRecursion(TestCase):
 
-    def setUp(self):
-        from numba.tests import recursion_usecases
-        self.mod = recursion_usecases
-
     def test_mutual_1(self):
+        from numba.tests.recursion_usecases import outer_fac
         expect = math.factorial(10)
-        self.assertPreciseEqual(self.mod.outer_fac(10), expect)
+        self.assertPreciseEqual(outer_fac(10), expect)
 
     def test_mutual_2(self):
-        pfoo, pbar = self.mod.make_mutual2()
-        cfoo, cbar = self.mod.make_mutual2(jit(nopython=True))
+        from numba.tests.recursion_usecases import make_mutual2
+        pfoo, pbar = make_mutual2()
+        cfoo, cbar = make_mutual2(jit(nopython=True))
         for x in [-1, 0, 1, 3]:
             self.assertPreciseEqual(pfoo(x=x), cfoo(x=x))
             self.assertPreciseEqual(pbar(y=x, z=1), cbar(y=x, z=1))
 
     def test_runaway(self):
+        from numba.tests.recursion_usecases import runaway_mutual
         with self.assertRaises(TypingError) as raises:
-            self.mod.runaway_mutual(123)
+            runaway_mutual(123)
         self.assertIn("cannot type infer runaway recursion",
                       str(raises.exception))
 
     def test_type_change(self):
-        pfunc = self.mod.make_type_change_mutual()
-        cfunc = self.mod.make_type_change_mutual(jit(nopython=True))
+        from numba.tests.recursion_usecases import make_type_change_mutual
+        pfunc = make_type_change_mutual()
+        cfunc = make_type_change_mutual(jit(nopython=True))
         args = 13, 0.125
         self.assertPreciseEqual(pfunc(*args), cfunc(*args))
 
     def test_four_level(self):
-        pfunc = self.mod.make_four_level()
-        cfunc = self.mod.make_four_level(jit(nopython=True))
+        from numba.tests.recursion_usecases import make_four_level
+        pfunc = make_four_level()
+        cfunc = make_four_level(jit(nopython=True))
         arg = 7
         self.assertPreciseEqual(pfunc(arg), cfunc(arg))
 
     def test_inner_error(self):
+        from numba.tests.recursion_usecases import make_inner_error
         # nopython mode
-        cfunc = self.mod.make_inner_error(jit(nopython=True))
+        cfunc = make_inner_error(jit(nopython=True))
         with self.assertRaises(TypingError) as raises:
             cfunc(2)
         errmsg = 'Unknown attribute \'ndim\''
         self.assertIn(errmsg, str(raises.exception))
         # objectmode
         # error is never trigger, function return normally
-        cfunc = self.mod.make_inner_error(jit)
-        pfunc = self.mod.make_inner_error()
+        cfunc = make_inner_error(jit)
+        pfunc = make_inner_error()
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore', category=NumbaWarning)
             got = cfunc(6)
         self.assertEqual(got, pfunc(6))
 
     def test_raise(self):
-        cfunc = self.mod.make_raise_mutual()#jit(nopython=True))
+        from numba.tests.recursion_usecases import make_raise_mutual
+        cfunc = make_raise_mutual()#jit(nopython=True))
         with self.assertRaises(ValueError) as raises:
             cfunc(2)
 

--- a/numba/tests/test_serialize.py
+++ b/numba/tests/test_serialize.py
@@ -12,7 +12,6 @@ from numba.core.errors import TypingError
 from numba.tests.support import TestCase
 from numba.core.target_extension import resolve_dispatcher_from_str
 from numba.cloudpickle import dumps, loads
-from .serialize_usecases import *
 
 
 class TestDispatcherPickling(TestCase):
@@ -51,33 +50,40 @@ class TestDispatcherPickling(TestCase):
             check_result(new_func)
 
     def test_call_with_sig(self):
+        from .serialize_usecases import add_with_sig
         self.run_with_protocols(self.check_call, add_with_sig, 5, (1, 4))
         # Compilation has been disabled => float inputs will be coerced to int
         self.run_with_protocols(self.check_call, add_with_sig, 5, (1.2, 4.2))
 
     def test_call_without_sig(self):
+        from .serialize_usecases import add_without_sig
         self.run_with_protocols(self.check_call, add_without_sig, 5, (1, 4))
         self.run_with_protocols(self.check_call, add_without_sig, 5.5, (1.2, 4.3))
         # Object mode is enabled
         self.run_with_protocols(self.check_call, add_without_sig, "abc", ("a", "bc"))
 
     def test_call_nopython(self):
+        from .serialize_usecases import add_nopython
         self.run_with_protocols(self.check_call, add_nopython, 5.5, (1.2, 4.3))
         # Object mode is disabled
         self.run_with_protocols(self.check_call, add_nopython, TypingError, (object(), object()))
 
     def test_call_nopython_fail(self):
+        from .serialize_usecases import add_nopython_fail
         # Compilation fails
         self.run_with_protocols(self.check_call, add_nopython_fail, TypingError, (1, 2))
 
     def test_call_objmode_with_global(self):
+        from .serialize_usecases import get_global_objmode
         self.run_with_protocols(self.check_call, get_global_objmode, 7.5, (2.5,))
 
     def test_call_closure(self):
+        from .serialize_usecases import closure
         inner = closure(1)
         self.run_with_protocols(self.check_call, inner, 6, (2, 3))
 
     def check_call_closure_with_globals(self, **jit_args):
+        from .serialize_usecases import closure_with_globals
         inner = closure_with_globals(3.0, **jit_args)
         self.run_with_protocols(self.check_call, inner, 7.0, (4.0,))
 
@@ -88,22 +94,27 @@ class TestDispatcherPickling(TestCase):
         self.check_call_closure_with_globals(forceobj=True)
 
     def test_call_closure_calling_other_function(self):
+        from .serialize_usecases import closure_calling_other_function
         inner = closure_calling_other_function(3.0)
         self.run_with_protocols(self.check_call, inner, 11.0, (4.0, 6.0))
 
     def test_call_closure_calling_other_closure(self):
+        from .serialize_usecases import closure_calling_other_closure
         inner = closure_calling_other_closure(3.0)
         self.run_with_protocols(self.check_call, inner, 8.0, (4.0,))
 
     def test_call_dyn_func(self):
+        from .serialize_usecases import dyn_func
         # Check serializing a dynamically-created function
         self.run_with_protocols(self.check_call, dyn_func, 36, (6,))
 
     def test_call_dyn_func_objmode(self):
+        from .serialize_usecases import dyn_func_objmode
         # Same with an object mode function
         self.run_with_protocols(self.check_call, dyn_func_objmode, 36, (6,))
 
     def test_renamed_module(self):
+        from .serialize_usecases import get_renamed_module
         # Issue #1559: using a renamed module (e.g. `import numpy as np`)
         # should not fail serializing
         expected = get_renamed_module(0.0)
@@ -111,6 +122,7 @@ class TestDispatcherPickling(TestCase):
                                 expected, (0.0,))
 
     def test_call_generated(self):
+        from .serialize_usecases import generated_add
         self.run_with_protocols(self.check_call, generated_add,
                                 46, (1, 2))
         self.run_with_protocols(self.check_call, generated_add,
@@ -121,6 +133,7 @@ class TestDispatcherPickling(TestCase):
         Check that reconstructing doesn't depend on resources already
         instantiated in the original process.
         """
+        from .serialize_usecases import closure_calling_other_closure
         func = closure_calling_other_closure(3.0)
         pickled = pickle.dumps(func)
         code = """if 1:
@@ -140,6 +153,7 @@ class TestDispatcherPickling(TestCase):
 
         Note that "same function" is intentionally under-specified.
         """
+        from .serialize_usecases import closure
         func = closure(5)
         pickled = pickle.dumps(func)
         func2 = closure(6)
@@ -207,7 +221,6 @@ class TestSerializationMisc(TestCase):
         got2 = _numba_unpickle(id(random_obj), bytebuf, hashed)
         # unpickled results are the same objects
         self.assertIs(got1, got2)
-
 
 
 class TestCloudPickleIssues(TestCase):

--- a/numba/tests/typedlist_usecases.py
+++ b/numba/tests/typedlist_usecases.py
@@ -1,0 +1,14 @@
+from numba import int32
+from numba.typed import List
+
+
+# global typed-list for testing purposes
+global_typed_list = List.empty_list(int32)
+for i in (1, 2, 3):
+    global_typed_list.append(int32(i))
+
+
+def catch_global():
+    x = List()
+    for i in global_typed_list:
+        x.append(i)


### PR DESCRIPTION
This PR continues on from #9044, with thanks to @apmasell for the original patch. It prevents compilation on the CPU target when listing tests. It adds to the original PR to prevent compilation through the use of the `@stencil` decorator and also adds a best effort unit test to ensure that test listing will not invoke CPU target compilation in future.