### PR TITLE
GPU CI: Test with Python 3.9-3.12

### DIFF
--- a/buildscripts/gpuci/build.sh
+++ b/buildscripts/gpuci/build.sh
@@ -56,7 +56,7 @@ gpuci_logger "Create testing env"
 gpuci_mamba_retry create -n numba_ci -y \
                   "python=${PYTHON_VER}" \
                   "cudatoolkit=${CUDA_TOOLKIT_VER}" \
-                  "rapidsai::cubinlinker" \
+                  "gmarkall::cubinlinker" \
                   "conda-forge::ptxcompiler" \
                   "numba/label/dev::llvmlite" \
                   "numpy=${NUMPY_VER}" \

--- a/buildscripts/gpuci/build.sh
+++ b/buildscripts/gpuci/build.sh
@@ -72,7 +72,7 @@ conda activate numba_ci
 if [ $NUMBA_CUDA_USE_NVIDIA_BINDING == "1" ]
 then
   gpuci_logger "Install NVIDIA CUDA Python bindings";
-  gpuci_mamba_retry install nvidia::cuda-python=11.7.0;
+  gpuci_mamba_retry install cuda-python=11.8;
 fi;
 
 gpuci_logger "Install numba"

--- a/buildscripts/gpuci/build.sh
+++ b/buildscripts/gpuci/build.sh
@@ -56,7 +56,7 @@ gpuci_logger "Create testing env"
 gpuci_mamba_retry create -n numba_ci -y \
                   "python=${PYTHON_VER}" \
                   "cudatoolkit=${CUDA_TOOLKIT_VER}" \
-                  "gmarkall::cubinlinker" \
+                  "rapidsai-nightly::cubinlinker" \
                   "conda-forge::ptxcompiler" \
                   "numba/label/dev::llvmlite" \
                   "numpy=${NUMPY_VER}" \

--- a/buildscripts/gpuci/build.sh
+++ b/buildscripts/gpuci/build.sh
@@ -32,11 +32,14 @@ else
   export NUMBA_CUDA_ENABLE_MINOR_VERSION_COMPATIBILITY=0;
 fi;
 
-# Test with different NumPy versions with each toolkit (it's not worth testing
-# the Cartesian product of versions here, we just need to test with different
-# CUDA and NumPy versions).
+# Test with different NumPy and Python versions with each toolkit (it's not
+# worth testing the Cartesian product of versions here, we just need to test
+# with different CUDA, NumPy, and Python versions).
 declare -A CTK_NUMPY_VMAP=( ["11.2"]="1.22" ["11.3"]="1.23" ["11.5"]="1.25" ["11.8"]="1.26")
 NUMPY_VER="${CTK_NUMPY_VMAP[$CUDA_TOOLKIT_VER]}"
+
+declare -A CTK_PYTHON_VMAP=( ["11.2"]="3.9" ["11.3"]="3.10" ["11.5"]="3.11" ["11.8"]="3.12")
+PYTHON_VER="${CTK_PYTHON_VMAP[$CUDA_TOOLKIT_VER]}"
 
 ################################################################################
 # SETUP - Check environment
@@ -51,7 +54,7 @@ nvidia-smi
 gpuci_logger "Create testing env"
 . /opt/conda/etc/profile.d/conda.sh
 gpuci_mamba_retry create -n numba_ci -y \
-                  "python=3.10" \
+                  "python=${PYTHON_VER}" \
                   "cudatoolkit=${CUDA_TOOLKIT_VER}" \
                   "rapidsai::cubinlinker" \
                   "conda-forge::ptxcompiler" \


### PR DESCRIPTION
Now that Python 3.12 support is merged, this PR runs CUDA tests with Python versions 3.9 - 3.12 on gpuCI. A couple of other changes are required to support this:

- I built new cubinlinker packages for Python 3.12. These have to come from the `rapidsai-nightly` conda channel at present. Once they have proven to be stable for a few days, they will be moved to the `rapidsai` channel and I will create a new PR here so that cubinlinker comes from the `rapidsai` channel again.
- CUDA Python is now obtained from conda-forge, as it is a better source for CUDA packages than the NVIDIA channel - in particular the latest version on conda-forge supports up to Python 3.12.