### PR TITLE
Post py38 remove cleanup

### DIFF
--- a/numba/core/byteflow.py
+++ b/numba/core/byteflow.py
@@ -866,13 +866,6 @@ class TraceRunner(object):
         state.append(inst)
         state.fork(pc=inst.get_jump_target())
 
-    def op_BREAK_LOOP(self, state, inst):
-        # NOTE: bytecode removed since py3.8
-        end = state.get_top_block('LOOP')['end']
-        state.append(inst, end=end)
-        state.pop_block()
-        state.fork(pc=end)
-
     def op_RETURN_VALUE(self, state, inst):
         state.append(inst, retval=state.pop(), castval=state.make_temp())
         state.terminate()

--- a/numba/core/byteflow.py
+++ b/numba/core/byteflow.py
@@ -979,15 +979,6 @@ class TraceRunner(object):
         # we don't emulate the exact stack behavior
         state.append(inst)
 
-    def op_SETUP_LOOP(self, state, inst):
-        # NOTE: bytecode removed since py3.8
-        state.push_block(
-            state.make_block(
-                kind='LOOP',
-                end=inst.get_jump_target(),
-            )
-        )
-
     def op_BEFORE_WITH(self, state, inst):
         # Almost the same as py3.10 SETUP_WITH just lacking the finally block.
         cm = state.pop()    # the context-manager

--- a/numba/core/controlflow.py
+++ b/numba/core/controlflow.py
@@ -956,7 +956,3 @@ class ControlFlowAnalysis(object):
     def op_RAISE_VARARGS(self, inst):
         self._curblock.terminating = True
         self._force_new_block = True
-
-    def op_BREAK_LOOP(self, inst):
-        self.jump(self._blockstack[-1])
-        self._force_new_block = True

--- a/numba/core/controlflow.py
+++ b/numba/core/controlflow.py
@@ -9,7 +9,7 @@ from numba.core.utils import PYVERSION
 # List of bytecodes creating a new block in the control flow graph
 # (in addition to explicit jump labels).
 NEW_BLOCKERS = frozenset([
-    'SETUP_LOOP', 'FOR_ITER', 'SETUP_WITH', 'BEFORE_WITH'
+    'FOR_ITER', 'SETUP_WITH', 'BEFORE_WITH'
 ])
 
 
@@ -888,16 +888,6 @@ class ControlFlowAnalysis(object):
                        "(variable):' construct is not "
                        "supported.")
                 raise UnsupportedError(msg)
-
-    def op_SETUP_LOOP(self, inst):
-        end = inst.get_jump_target()
-        self._blockstack.append(end)
-        self._loops.append((inst.offset, end))
-        # TODO: Looplifting requires the loop entry be its own block.
-        #       Forcing a new block here is the simplest solution for now.
-        #       But, we should consider other less ad-hoc ways.
-        self.jump(inst.next)
-        self._force_new_block = True
 
     def op_SETUP_WITH(self, inst):
         end = inst.get_jump_target()

--- a/numba/core/interpreter.py
+++ b/numba/core/interpreter.py
@@ -2942,14 +2942,6 @@ class Interpreter(object):
             out = ir.Expr.unary('not', value=tmp, loc=self.loc)
             self.store(out, res)
 
-    def op_BREAK_LOOP(self, inst, end=None):
-        if end is None:
-            loop = self.syntax_blocks[-1]
-            assert isinstance(loop, ir.Loop)
-            end = loop.exit
-        jmp = ir.Jump(target=end, loc=self.loc)
-        self.current_block.append(jmp)
-
     def _op_JUMP_IF(self, inst, pred, iftrue):
         brs = {
             True: inst.get_jump_target(),

--- a/numba/core/interpreter.py
+++ b/numba/core/interpreter.py
@@ -2362,11 +2362,6 @@ class Interpreter(object):
     else:
         raise NotImplementedError(PYVERSION)
 
-    def op_SETUP_LOOP(self, inst):
-        assert self.blocks[inst.offset] is self.current_block
-        loop = ir.Loop(inst.offset, exit=(inst.next + inst.arg))
-        self.syntax_blocks.append(loop)
-
     def op_SETUP_WITH(self, inst, contextmanager, exitfn=None):
         assert self.blocks[inst.offset] is self.current_block
         # Handle with

--- a/numba/tests/test_dataflow.py
+++ b/numba/tests/test_dataflow.py
@@ -169,7 +169,6 @@ class TestDataFlow(TestCase):
         self.test_var_swapping(no_pyobj_flags)
 
     def test_for_break(self, flags=force_pyobj_flags):
-        # BREAK_LOOP must unwind the current inner syntax block.
         pyfunc = for_break
         cr = compile_isolated(pyfunc, (types.intp, types.intp), flags=flags)
         cfunc = cr.entry_point

--- a/numba/tests/test_tuples.py
+++ b/numba/tests/test_tuples.py
@@ -667,7 +667,7 @@ class TestTupleBuild(TestCase):
         with self.assertRaises(errors.TypingError) as raises:
             check([4, 5])
 
-        # Python 3.9 has a peephole rewrite due to large changes in tuple
+        # Python 3.9+ has a peephole rewrite due to large changes in tuple
         # unpacking. It results in a tuple + list situation from the above
         # so the error message reflects that. Catching this specific and
         # seemingly rare sequence in the peephole rewrite is prohibitively


### PR DESCRIPTION
Following #9310 I found two more bytecodes that were last seen with 3.7: `SETUP_LOOP` and `BREAK_LOOP`. These also appear in the documentation about the Numba architecture `docs/source/developer/architecture.rst`. However, updating the examples to show output generated under 3.11 appears to be quite rabitthole and will require some more work. The pull-request is opened as non-draft anyway, such that public CI can run and check if the code changes are good.