### PR TITLE
Fix Syntax and Deprecation Warnings from 3.12.

### DIFF
--- a/numba/np/ufunc/array_exprs.py
+++ b/numba/np/ufunc/array_exprs.py
@@ -298,7 +298,7 @@ def _arr_expr_to_ast(expr):
                         lineno=expr.loc.line,
                         col_offset=expr.loc.col if expr.loc.col else 0), {}
     elif isinstance(expr, ir.Const):
-        return ast.Num(expr.value), {}
+        return ast.Constant(expr.value), {}
     raise NotImplementedError(
         "Don't know how to translate array expression '%r'" % (expr,))
 

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -1303,7 +1303,7 @@ class TestDictIterableCtorNoJit(TestCase, DictIterableCtor):
             Dict(1, 2)
 
     def test_exception_mapping_ctor(self):
-        msg = '.*dict\(mapping\) is not supported.*'  # noqa: W605
+        msg = r'.*dict\(mapping\) is not supported.*'  # noqa: W605
         with self.assertRaisesRegex(TypingError, msg):
             Dict({1: 2})
 

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -4131,9 +4131,9 @@ class TestPrangeSpecific(TestPrangeBase):
         cres = self.compile_parallel_fastmath(pfunc, ())
         ir = self._get_gufunc_ir(cres)
         _id = '%[A-Z_0-9]?(.[0-9]+)+[.]?[i]?'
-        recipr_str = '\s+%s = fmul fast double %s, 5.000000e-01'
+        recipr_str = r'\s+%s = fmul fast double %s, 5.000000e-01'
         reciprocal_inst = re.compile(recipr_str % (_id, _id))
-        fadd_inst = re.compile('\s+%s = fadd fast double %s, %s'
+        fadd_inst = re.compile(r'\s+%s = fadd fast double %s, %s'
                                % (_id, _id, _id))
         # check there is something like:
         #  %.329 = fmul fast double %.325, 5.000000e-01
@@ -4582,7 +4582,7 @@ class TestParforsVectorizer(TestPrangeBase):
             asm = self._get_gufunc_asm(cres)
 
             if assertions:
-                schedty = re.compile('call\s+\w+\*\s+@do_scheduling_(\w+)\(')
+                schedty = re.compile(r'call\s+\w+\*\s+@do_scheduling_(\w+)\(')
                 matches = schedty.findall(cres.library.get_llvm_str())
                 self.assertGreaterEqual(len(matches), 1) # at least 1 parfor call
                 self.assertEqual(matches[0], schedule_type)

--- a/numba/tests/test_svml.py
+++ b/numba/tests/test_svml.py
@@ -171,7 +171,7 @@ class TestSVMLGeneration(TestCase):
     # env mutating, must not run in parallel
     _numba_parallel_test_ = False
     # RE for a generic symbol reference and for each particular SVML function
-    asm_filter = re.compile('|'.join(['\$[a-z_]\w+,']+list(svml_funcs)))
+    asm_filter = re.compile('|'.join([r'\$[a-z_]\w+,']+list(svml_funcs)))
 
     @classmethod
     def mp_runner(cls, testname, outqueue):

--- a/numba/tests/test_typingerror.py
+++ b/numba/tests/test_typingerror.py
@@ -207,7 +207,7 @@ class TestArgumentTypingError(unittest.TestCase):
             cfunc(1, foo, 1)
 
         expected=re.compile(("This error may have been caused by the following "
-                             "argument\(s\):\\n- argument 1:.*Cannot determine "
+                             r"argument\(s\):\n- argument 1:.*Cannot determine "
                              "Numba type of "
                              "<class \'numba.tests.test_typingerror.Foo\'>"))
         self.assertTrue(expected.search(str(raises.exception)) is not None)

--- a/numba/tests/test_withlifting.py
+++ b/numba/tests/test_withlifting.py
@@ -548,7 +548,7 @@ class TestLiftObj(MemoryLeak, TestCase):
             njit(foo)(123)
         # Check that an error occurred in with-lifting in objmode
         pat = ("During: resolving callee type: "
-               "type\(ObjModeLiftedWith\(<.*>\)\)")
+               r"type\(ObjModeLiftedWith\(<.*>\)\)")
         self.assertRegex(str(raises.exception), pat)
 
     def test_case07_mystery_key_error(self):
@@ -822,7 +822,7 @@ class TestLiftObj(MemoryLeak, TestCase):
         with self.assertRaisesRegex(
             errors.CompilerError,
             ("Error handling objmode argument 'val'. "
-             "Global 'gv_type2' is not defined\.")
+             r"Global 'gv_type2' is not defined.")
         ):
             global_var()
 


### PR DESCRIPTION
Python 3.12 highlighted a few Syntax and Deprecation warnings. This updates the code base to fix the issues highlighted (mostly use of raw strings for regex and `ast.Constant` to replace `ast.Num`).

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
