### PR TITLE
Fix parfor reduction issue with Python 3.12.

### DIFF
--- a/docs/upcoming_changes/9334.bug_fix.rst
+++ b/docs/upcoming_changes/9334.bug_fix.rst
@@ -1,0 +1,11 @@
+Fix issue with parfor reductions and Python 3.12.
+=================================================
+
+The parfor reduction code has certain expectations on the order of statements
+that it discovers that are based on the code that previous versions of Numba
+generation.  With Python 3.12, one assignment that used to follow the
+reduction operator statement, such as a binop, is now moved to its own basic
+block.  This change reorders the set of discovered reduction nodes so that
+this assignment is right after the reduciton operator as it was in previous
+Numba versions.  This only affects internal parfor reduction code and
+doesn't actually change the Numba IR.

--- a/docs/upcoming_changes/9334.bug_fix.rst
+++ b/docs/upcoming_changes/9334.bug_fix.rst
@@ -2,8 +2,8 @@ Fix issue with parfor reductions and Python 3.12.
 =================================================
 
 The parfor reduction code has certain expectations on the order of statements
-that it discovers that are based on the code that previous versions of Numba
-generation.  With Python 3.12, one assignment that used to follow the
+that it discovers, these are based on the code that previous versions of Numba
+generated.  With Python 3.12, one assignment that used to follow the
 reduction operator statement, such as a binop, is now moved to its own basic
 block.  This change reorders the set of discovered reduction nodes so that
 this assignment is right after the reduciton operator as it was in previous

--- a/docs/upcoming_changes/9334.bug_fix.rst
+++ b/docs/upcoming_changes/9334.bug_fix.rst
@@ -6,6 +6,6 @@ that it discovers, these are based on the code that previous versions of Numba
 generated.  With Python 3.12, one assignment that used to follow the
 reduction operator statement, such as a binop, is now moved to its own basic
 block.  This change reorders the set of discovered reduction nodes so that
-this assignment is right after the reduciton operator as it was in previous
+this assignment is right after the reduction operator as it was in previous
 Numba versions.  This only affects internal parfor reduction code and
 doesn't actually change the Numba IR.

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -3888,7 +3888,7 @@ def get_reduce_nodes(reduction_node, nodes, func_ir):
                 # the assignment that should follow the reduction operator
                 # and then reorders the reduction nodes so that assignment
                 # follows the reduction operator.
-                if (i+1 < len(nodes) and
+                if (i + 1 < len(nodes) and
                     ((not isinstance(nodes[i+1], ir.Assign)) or
                      nodes[i+1].target.unversioned_name != unversioned_name)):
                     foundj = None

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -3885,7 +3885,7 @@ def get_reduce_nodes(reduction_node, nodes, func_ir):
                 # to a new basic block.  The code below looks and sees if an
                 # assignment to the reduction var follows the reduction operator
                 # and if not it searches the rest of the reduction nodes to find
-                # correct assignment that should follow the reduction operator
+                # the assignment that should follow the reduction operator
                 # and then reorders the reduction nodes so that assignment
                 # follows the reduction operator.
                 if (i+1 < len(nodes) and

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -3893,7 +3893,7 @@ def get_reduce_nodes(reduction_node, nodes, func_ir):
                      nodes[i + 1].target.unversioned_name != unversioned_name)):
                     foundj = None
                     # Iterate through the rest of the reduction nodes.
-                    for j, jstmt in enumerate(nodes[i+1:]):
+                    for j, jstmt in enumerate(nodes[i + 1:]):
                         # If this stmt is an assignment where the right-hand
                         # side of the assignment is the output of the reduction
                         # operator.

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -3890,7 +3890,7 @@ def get_reduce_nodes(reduction_node, nodes, func_ir):
                 # follows the reduction operator.
                 if (i + 1 < len(nodes) and
                     ((not isinstance(nodes[i + 1], ir.Assign)) or
-                     nodes[i+1].target.unversioned_name != unversioned_name)):
+                     nodes[i + 1].target.unversioned_name != unversioned_name)):
                     foundj = None
                     # Iterate through the rest of the reduction nodes.
                     for j, jstmt in enumerate(nodes[i+1:]):

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -3906,10 +3906,10 @@ def get_reduce_nodes(reduction_node, nodes, func_ir):
                     if foundj is not None:
                         # If we found the correct assignment then move it to
                         # after the reduction operator.
-                        nodes = (nodes[:i+1] +   # nodes up to operator
-                                 nodes[foundj:foundj+1] + # assignment node
-                                 nodes[i+1:foundj] + # between op and assign
-                                 nodes[foundj+1:]) # after assignment node
+                        nodes = (nodes[:i + 1] +   # nodes up to operator
+                                 nodes[foundj:foundj + 1] + # assignment node
+                                 nodes[i + 1:foundj] + # between op and assign
+                                 nodes[foundj + 1:]) # after assignment node
 
                 if (not (i+1 < len(nodes) and isinstance(nodes[i+1], ir.Assign)
                         and nodes[i+1].target.unversioned_name == unversioned_name)

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -3889,7 +3889,7 @@ def get_reduce_nodes(reduction_node, nodes, func_ir):
                 # and then reorders the reduction nodes so that assignment
                 # follows the reduction operator.
                 if (i + 1 < len(nodes) and
-                    ((not isinstance(nodes[i+1], ir.Assign)) or
+                    ((not isinstance(nodes[i + 1], ir.Assign)) or
                      nodes[i+1].target.unversioned_name != unversioned_name)):
                     foundj = None
                     # Iterate through the rest of the reduction nodes.

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -46,7 +46,7 @@ from numba.tests.support import (TestCase, captured_stdout, MemoryLeakMixin,
                       override_env_config, linux_only, tag,
                       skip_parfors_unsupported, _32bit, needs_blas,
                       needs_lapack, disabled_test, skip_unless_scipy,
-                      needs_subprocess, expected_failure_py312)
+                      needs_subprocess)
 from numba.core.extending import register_jitable
 from numba.core.bytecode import _fix_LOAD_GLOBAL_arg
 from numba.core import utils
@@ -4002,7 +4002,6 @@ class TestPrangeBasic(TestPrangeBase):
 class TestPrangeSpecific(TestPrangeBase):
     """ Tests specific features/problems found under prange"""
 
-    @expected_failure_py312
     def test_prange_two_instances_same_reduction_var(self):
         # issue4922 - multiple uses of same reduction variable
         def test_impl(n):
@@ -4014,7 +4013,6 @@ class TestPrangeSpecific(TestPrangeBase):
             return c
         self.prange_tester(test_impl, 9)
 
-    @expected_failure_py312
     def test_prange_conflicting_reduction_ops(self):
         def test_impl(n):
             c = 0


### PR DESCRIPTION
Resolves #9290.

Reorder reduction nodes for Python 3.12 to get back to the expected order for prior versions.
