### PR TITLE
Add validation capability for user generated towncrier .rst files.

### DIFF
--- a/.github/workflows/towncrier.yml
+++ b/.github/workflows/towncrier.yml
@@ -3,6 +3,9 @@ name: Check Release Notes
 on:
   pull_request: {}
 
+env:
+  GITHUB_PR_NUMBER: ${{github.event.pull_request.number}}
+
 jobs:
   check:
     name: Check release notes
@@ -18,10 +21,11 @@ jobs:
           python-version: 3.9
       - name: Install towncrier
         run: |
-          python3 -m pip install towncrier==23.6 "importlib_resources<6"
+          python3 -m pip install towncrier==23.6 "importlib_resources<6" rstcheck
       - name: Run towncrier
         run: |
           git fetch --no-tags origin +refs/heads/${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}
           towncrier check --compare-with remotes/origin/${BASE_BRANCH}
+          python maint/towncrier_rst_validator.py --pull_request_id $GITHUB_PR_NUMBER
     env:
       BASE_BRANCH: ${{ github.base_ref }}

--- a/docs/upcoming_changes/9089.bug_fix.rst
+++ b/docs/upcoming_changes/9089.bug_fix.rst
@@ -1,4 +1,4 @@
 Handling of `None` args fixed in `PythonAPI.call`.
-=======================================================================================
+==================================================
 
 Fixing segfault when `args=None` was passed to `PythonAPI.call`.

--- a/docs/upcoming_changes/9141.np_support.rst
+++ b/docs/upcoming_changes/9141.np_support.rst
@@ -1,3 +1,4 @@
 Added support for functions ``np.polynomial.polyutils.as_series()``, as well as functions ``polydiv()``, ``polyint()``, ``polyval()`` from ``np.polynomial.polynomial``.
 ========================================================================================================================================================================
+
 Support is added for ``np.polynomial.polyutils.as_series()``, ``np.polynomial.polynomial.polydiv()``, ``np.polynomial.polynomial.polyint()`` (only the first 2 arguments), ``np.polynomial.polynomial.polyval()`` (only the first 2 arguments).

--- a/docs/upcoming_changes/9144.bug_fix.rst
+++ b/docs/upcoming_changes/9144.bug_fix.rst
@@ -1,5 +1,5 @@
 Fix propagation of literal values in PHI nodes.
-"""""""""""""""""""""""""""""""""""""""""""""""
+===============================================
 
 Fixed a bug in the literal propagation pass where a PHI node could be wrongly
 replaced by a constant.

--- a/docs/upcoming_changes/9154.np_support.rst
+++ b/docs/upcoming_changes/9154.np_support.rst
@@ -1,4 +1,4 @@
 Added support for np.unwrap() function.
-==========================================
+=======================================
 
 Support is added for ``numpy.unwrap()``. The ``axis`` argument is only supported when its value equals -1.

--- a/docs/upcoming_changes/9169.bug_fix.rst
+++ b/docs/upcoming_changes/9169.bug_fix.rst
@@ -1,5 +1,5 @@
 ``numpy.digitize`` implementation behaviour aligned with numpy
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+==============================================================
 
 The implementation of ``numpy.digitize`` is updated to behave per
 numpy in a wider set of cases, including where the supplied bins

--- a/docs/upcoming_changes/9189.bug_fix.rst
+++ b/docs/upcoming_changes/9189.bug_fix.rst
@@ -1,5 +1,6 @@
 ``numpy.searchsorted`` and ``numpy.sort`` behaviour updates
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+===========================================================
+
 * ``numpy.searchsorted`` implementation updated to produce
   identical outputs to numpy for a wider set of use cases,
   including where the provided array `a` is in fact not

--- a/docs/upcoming_changes/9244.bug_fix.rst
+++ b/docs/upcoming_changes/9244.bug_fix.rst
@@ -1,4 +1,4 @@
-Fixed ``RecursionError`` in ``prange`` 
+Fixed ``RecursionError`` in ``prange``
 ======================================
 
 A problem with certain loop patterns using ``prange`` leading to 

--- a/docs/upcoming_changes/9246.highlight.rst
+++ b/docs/upcoming_changes/9246.highlight.rst
@@ -1,4 +1,4 @@
 Python 3.12 Support
-"""""""""""""""""""
+===================
 
 Support is added for Python 3.12.

--- a/docs/upcoming_changes/9249.np_support.rst
+++ b/docs/upcoming_changes/9249.np_support.rst
@@ -1,3 +1,4 @@
 Adds support for checking if dtypes are equal.
 ==============================================
+
 Support is added for checking if two dtype objects are equal, for example `assert X.dtype == np.dtype(np.float64)`.

--- a/docs/upcoming_changes/9310.highlight.rst
+++ b/docs/upcoming_changes/9310.highlight.rst
@@ -1,5 +1,5 @@
 Move minimum supported Python version to 3.9.
-"""""""""""""""""""""""""""""""""""""""""""""
+=============================================
 
 Support for Python 3.8 has been removed, Numba's minimum supported Python
 version is now Python 3.9.

--- a/docs/upcoming_changes/9315.change.rst
+++ b/docs/upcoming_changes/9315.change.rst
@@ -1,5 +1,5 @@
-Semantic differences due to Python 3.12 variable shadowing in comprehensions 
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+Semantic differences due to Python 3.12 variable shadowing in comprehensions
+============================================================================
 
 Python 3.12 introduced a new bytecode ``LOAD_FAST_AND_CLEAR`` that is only used 
 in comprehensions. It has dynamic semantics that Numba cannot model. 

--- a/docs/upcoming_changes/9335.infrastructure.rst
+++ b/docs/upcoming_changes/9335.infrastructure.rst
@@ -1,0 +1,6 @@
+Add validation capability for user generated towncrier ``.rst`` files.
+======================================================================
+
+Added a validation script for user generated towncrier ``.rst`` files.
+The script will run as a part of towncrier Github workflow automatically
+on every PR.

--- a/docs/upcoming_changes/README.rst
+++ b/docs/upcoming_changes/README.rst
@@ -7,7 +7,7 @@ small **ReST**-formatted text that will be added to the next what's new page.
 
 Make sure to use full sentences with correct case and punctuation, and please
 try to use Sphinx intersphinx using backticks. The fragment should have a
-header line and an underline using ``""""""""`` followed by description of
+header line and an underline using ``======`` followed by description of
 your user-facing changes as they should appear in the release notes.
 
 Each file should be named like ``<PULL REQUEST>.<TYPE>.rst``, where
@@ -32,6 +32,11 @@ Each file should be named like ``<PULL REQUEST>.<TYPE>.rst``, where
 
 If you are unsure what pull request type to use, don't hesitate to ask in your
 PR.
+
+Once you've generated your fragment, to validate it, run 
+``python maint/towncrier_rst_validator.py --pull_request_id {PR Number}``
+while on your branch and in numba base directory, where PR Number is the
+assigned ID for your respective pull request on Github.
 
 You can install ``towncrier`` and run ``towncrier build --draft``
 if you want to get a preview of how your change will look in the final release

--- a/maint/towncrier_rst_validator.py
+++ b/maint/towncrier_rst_validator.py
@@ -39,7 +39,14 @@ def list_rst_filename() -> str:
             stderr=STDOUT,
         )
         all_files = output.strip().splitlines()
-        rst_file = [file for file in all_files if 
+        rst_dir_modified = [file for file in all_files if 
+                    file.startswith(rst_dir)]
+        print("Found modified .rst files in directory",
+              f"{rst_dir} from git diff: ")
+        for file in rst_dir_modified:
+            print(file)
+        print("\n")
+        rst_file = [file for file in rst_dir_modified if 
                     file.startswith(rst_dir + "/" + str(args.pull_request_id) + ".")]
     assert len(rst_file) == 1, f"No valid .rst file found in {rst_dir} for the given" + \
         f" Pull Request ID: {pr_id}. Valid .rst file should " + \

--- a/maint/towncrier_rst_validator.py
+++ b/maint/towncrier_rst_validator.py
@@ -25,7 +25,7 @@ types_of_changes = ["highlight",
 
 def list_rst_filename() -> str:
     output = check_output(
-        ["git", "diff", "--name-only", "main"],
+        ["git", "diff", "--name-only", "origin/main"],
         encoding="utf-8",
         stderr=STDOUT,
     )

--- a/maint/towncrier_rst_validator.py
+++ b/maint/towncrier_rst_validator.py
@@ -1,0 +1,89 @@
+from subprocess import STDOUT, check_output
+import argparse
+import os
+
+parser=argparse.ArgumentParser()
+
+parser.add_argument("--pull_request_id", required=True, type=int)
+
+args=parser.parse_args()
+
+rst_dir = "docs/upcoming_changes"
+types_of_changes = ["highlight",
+                    "np_support",
+                    "deprecation",
+                    "expired",
+                    "compatibility",
+                    "cuda",
+                    "new_feature",
+                    "improvement",
+                    "performance",
+                    "change",
+                    "doc",
+                    "infrastructure",
+                    "bug_fix"]
+
+def list_rst_filename() -> str:
+    output = check_output(
+        ["git", "diff", "--name-only", "main"],
+        encoding="utf-8",
+        stderr=STDOUT,
+    )
+
+    all_files = output.strip().splitlines()
+    rst_file = [file for file in all_files if 
+                file.startswith(rst_dir + "/" + str(args.pull_request_id) + ".")]
+    assert len(rst_file) == 1, "There must be a relevant .rst file added in the PR." + \
+        "Filename must start with the respective Pull Request ID" + \
+        " (eg 1234. for PR #1234) followed by a . character"
+    return rst_file[0]
+
+file = list_rst_filename()
+print(f"Checking {file}")
+# Must be an .rst file
+assert file.endswith(".rst"), "File must be a .rst file"
+# Must start file name with the PR number, followed by a ".",
+# followed by type of change
+filename = file.split("/")[-1]
+
+all_towncrier_rst = os.listdir(rst_dir)
+all_towncrier_rst = [rst for rst in all_towncrier_rst 
+                     if not (rst.startswith("template")
+                             or rst.startswith("README"))]
+all_pr_ids = [int(rst.split(".")[0]) for rst in all_towncrier_rst]
+assert len(set(all_pr_ids)) == len(all_pr_ids), \
+    "All PR IDs must be unique. Please check for duplicate PR IDs"
+
+assert len(filename.split(".")) == 3, \
+    "Filename must be in the format <PR_ID>.<type_of_change>.rst"
+
+# Must be one of the required types of changes
+assert filename.split(".")[1] in types_of_changes, \
+    "File must be one of the following types of changes:" + \
+    " highlight, np_support, deprecation, expired, compatibility" + \
+    ", cuda, new_feature, improvement, performance, change, doc" + \
+    ", infrastructure, bug_fix"
+print(f"Passed: Filename is valid")
+
+# Check rst contents
+with open(file, "r") as f:
+    contents = f.read().splitlines()
+    # First line must be the title followed by the underline
+    assert len(contents) >= 4, "File must have at least four lines"
+    title = contents[0]
+    assert len(title) > 0, "Title must not be empty"
+    underline = contents[1]
+    for underline_type in underline:
+        assert underline_type == "=", "Header should be underlined with = characters"
+    assert len(title) == len(underline), "Title and underline must be the same length." + \
+        f" (Found Title: {len(title)}, Underline: {len(underline)})"
+    blank_line = contents[2]
+    assert len(blank_line) == 0, "Third line must be blank"
+    description = contents[3]
+    assert len(description) > 0, "Description must not be empty"
+    print(f"Passed: File contents are valid")
+
+output = check_output(["rstcheck", file], stderr=STDOUT, encoding="utf-8")
+assert "Success! No issues detected." in output, \
+    "File is not a valid .rst file. Please check for errors using rstcheck"
+print(f"Passed: rstcheck passed")

--- a/maint/towncrier_rst_validator.py
+++ b/maint/towncrier_rst_validator.py
@@ -33,7 +33,7 @@ def list_rst_filename() -> str:
     all_files = output.strip().splitlines()
     rst_file = [file for file in all_files if 
                 file.startswith(rst_dir + "/" + str(args.pull_request_id) + ".")]
-    assert len(rst_file) == 1, "There must be a relevant .rst file added in the PR." + \
+    assert len(rst_file) == 1, "There must be a relevant .rst file added in the PR. " + \
         "Filename must start with the respective Pull Request ID" + \
         " (eg 1234. for PR #1234) followed by a . character"
     return rst_file[0]


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

Fixes #9311,

As titled, 

This PR adds a validation script for user generated release notes / `.rst` file snippets for `towncrier` usage in their respective Pull requests. Also existing files have been passed through the validation and fixed accordingly.