### PR TITLE
Revert #8583 which skip tests due to M1 RuntimeDyLd Assertion error

### DIFF
--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -154,10 +154,6 @@ skip_ppc64le_issue6465 = unittest.skipIf(platform.machine() == 'ppc64le',
 # https://github.com/numba/numba/issues/7822#issuecomment-1065356758
 _uname = platform.uname()
 IS_OSX_ARM64 = _uname.system == 'Darwin' and _uname.machine == 'arm64'
-skip_m1_llvm_rtdyld_failure  = unittest.skipIf(IS_OSX_ARM64,
-    "skip tests that contribute to triggering an AssertionError in LLVM's "
-    "RuntimeDyLd on OSX arm64. (see: numba#8567)")
-
 skip_m1_fenv_errors = unittest.skipIf(IS_OSX_ARM64,
     "fenv.h-like functionality unreliable on OSX arm64")
 

--- a/numba/tests/test_array_constants.py
+++ b/numba/tests/test_array_constants.py
@@ -5,7 +5,6 @@ from numba.core.compiler import compile_isolated
 from numba.core.errors import TypingError
 from numba import jit, typeof
 from numba.core import types
-from numba.tests.support import skip_m1_llvm_rtdyld_failure
 
 
 a0 = np.array(42)
@@ -141,7 +140,6 @@ class TestConstantArray(unittest.TestCase):
         out = cres.entry_point()
         self.assertEqual(out, 86)
 
-    @skip_m1_llvm_rtdyld_failure
     def test_too_big_to_freeze(self):
         """
         Test issue https://github.com/numba/numba/issues/2188 where freezing

--- a/numba/tests/test_stencils.py
+++ b/numba/tests/test_stencils.py
@@ -11,11 +11,7 @@ from numba import njit, stencil
 from numba.core import types, registry
 from numba.core.compiler import compile_extra, Flags
 from numba.core.cpu import ParallelOptions
-from numba.tests.support import (
-    skip_parfors_unsupported,
-    _32bit,
-    skip_m1_llvm_rtdyld_failure,
-)
+from numba.tests.support import skip_parfors_unsupported, _32bit
 from numba.core.errors import LoweringError, TypingError, NumbaValueError
 import unittest
 
@@ -80,7 +76,6 @@ if not _32bit: # prevent compilation on unsupported 32bit targets
         return a + 1
 
 
-@skip_m1_llvm_rtdyld_failure   # skip all stencil tests on m1
 class TestStencilBase(unittest.TestCase):
 
     _numba_parallel_test_ = False


### PR DESCRIPTION
Revert https://github.com/numba/numba/pull/8583
Because the problem is fixed by https://github.com/numba/llvmlite/pull/1009