### PR TITLE
Add configuration variable to force llvmlite memory manager on / off

### DIFF
--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -414,6 +414,21 @@ Compilation options
 
     *Default value:* "all"
 
+.. envvar:: NUMBA_USE_LLVMLITE_MEMORY_MANAGER
+
+   Whether llvmlite's built-in memory manager is enabled. The default is to
+   enable it on 64-bit ARM platforms (macOS on Apple Silicon and Linux on
+   AArch64), where it is needed to ensure ABI compliance, specifically
+   conformance with the requirements for GOT and text segment placement in the
+   large code model.
+
+   This environment variable can be used to override the default setting and
+   force it to be enabled or disabled. This should not normally be required, but
+   it is provided as an option for debugging and potential workaround
+   situations.
+
+   *Default value:* None (Use the default for the system)
+
 .. envvar:: NUMBA_USE_RVSDG_FRONTEND
 
    Turns on the experimental RVSDG frontend. It depends on the ``numba-rvsdg`` 

--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -423,9 +423,9 @@ Compilation options
    large code model.
 
    This environment variable can be used to override the default setting and
-   force it to be enabled or disabled. This should not normally be required, but
-   it is provided as an option for debugging and potential workaround
-   situations.
+   force it to be enabled (``1``) or disabled (``0``). This should not normally
+   be required, but it is provided as an option for debugging and potential
+   workaround situations.
 
    *Default value:* None (Use the default for the system)
 

--- a/docs/upcoming_changes/9341.new_feature.rst
+++ b/docs/upcoming_changes/9341.new_feature.rst
@@ -1,0 +1,5 @@
+Add a config variable to enable / disable the llvmlite memory manager
+=====================================================================
+
+A config variable to force enable or disable the llvmlite memory manager is
+added.

--- a/numba/core/codegen.py
+++ b/numba/core/codegen.py
@@ -1178,7 +1178,8 @@ class CPUCodegen(Codegen):
         self._tm_features = self._customize_tm_features()
         self._customize_tm_options(tm_options)
         tm = target.create_target_machine(**tm_options)
-        engine = ll.create_mcjit_compiler(llvm_module, tm)
+        use_lmm = config.USE_LLVMLITE_MEMORY_MANAGER
+        engine = ll.create_mcjit_compiler(llvm_module, tm, use_lmm=use_lmm)
 
         if config.ENABLE_PROFILING:
             engine.enable_jit_events()

--- a/numba/core/config.py
+++ b/numba/core/config.py
@@ -557,6 +557,11 @@ class _EnvReloader(object):
             "all" if LLVM_REFPRUNE_PASS else "",
         )
 
+        # llvmlite memory manager
+        USE_LLVMLITE_MEMORY_MANAGER = _readenv(
+            "NUMBA_USE_LLVMLITE_MEMORY_MANAGER", int, None
+        )
+
         # Timing support.
 
         # LLVM_PASS_TIMINGS enables LLVM recording of pass timings.


### PR DESCRIPTION
Following the merge of numba/llvmlite#1009, it enables its built-in memory manager on 64-bit ARM platforms. However there are situations where it might be desirable to override the default, e.g.:

- To check if it introduces a regression on a platform on which it's normally enabled
- To debug / develop it on a platform where it's not (e.g. Linux on x86_64)

This PR adds a config / environment variable and the relevant documentation.