### PR TITLE
Setting ``NUMBA_CAPTURED_ERRORS=old_style`` will now raise warnings.

### DIFF
--- a/docs/upcoming_changes/9346.deprecation.rst
+++ b/docs/upcoming_changes/9346.deprecation.rst
@@ -5,4 +5,4 @@ As per deprecation schedule of old-style error-capturing, explicitly setting
 ``NUMBA_CAPTURED_ERRORS=old_style`` will raise deprecation warnings. 
 This release is the last to use "old_style" as the default.
 Details are documented at 
-https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-old-style-numba-captured-errors
+https://numba.readthedocs.io/en/0.58.1/reference/deprecation.html#deprecation-of-old-style-numba-captured-errors

--- a/docs/upcoming_changes/9346.deprecation.rst
+++ b/docs/upcoming_changes/9346.deprecation.rst
@@ -1,0 +1,8 @@
+Explicitly setting ``NUMBA_CAPTURED_ERRORS=old_style`` will raise deprecation warnings
+======================================================================================
+
+As per deprecation schedule of old-style error-capturing, explicitly setting 
+``NUMBA_CAPTURED_ERRORS=old_style`` will raise deprecation warnings. 
+This release is the last to use "old_style" as the default.
+Details are documented at 
+https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-old-style-numba-captured-errors

--- a/numba/core/config.py
+++ b/numba/core/config.py
@@ -4,6 +4,7 @@ import os
 import re
 import shutil
 import warnings
+import traceback
 
 # YAML needed to use file based Numba config
 try:
@@ -69,14 +70,29 @@ def _os_supports_avx():
             return False
 
 
+_old_style_deprecation_msg = (
+    "Explicitly setting NUMBA_CAPTURED_ERRORS=old_style is deprecated. "
+    "See details at "
+    "https://numba.readthedocs.io/en/latest/reference/deprecation.html#deprecation-of-old-style-numba-captured-errors" # noqa: E501
+)
+
+
 # Choose how to handle captured errors
 def _validate_captured_errors_style(style_str):
+    # to prevent circular import
+    from numba.core.errors import NumbaPendingDeprecationWarning
+
     rendered_style = str(style_str)
-    if rendered_style not in ('new_style', 'old_style'):
+    if rendered_style not in ('new_style', 'old_style', 'default'):
         msg = ("Invalid style in NUMBA_CAPTURED_ERRORS: "
                f"{rendered_style}")
         raise ValueError(msg)
     else:
+        if rendered_style == 'default':
+            rendered_style = 'old_style'
+        elif rendered_style == 'old_style':
+            warnings.warn(_old_style_deprecation_msg,
+                          NumbaPendingDeprecationWarning)
         return rendered_style
 
 
@@ -193,10 +209,11 @@ class _EnvReloader(object):
                 return default() if callable(default) else default
             try:
                 return ctor(value)
-            except Exception as e:
+            except Exception:
                 warnings.warn(f"Environment variable '{name}' is defined but "
                               f"its associated value '{value}' could not be "
-                              f"parsed.\nThe parse failed with exception: {e}.",
+                              "parsed.\nThe parse failed with exception:\n"
+                              f"{traceback.format_exc()}",
                               RuntimeWarning)
                 return default
 

--- a/numba/core/errors.py
+++ b/numba/core/errors.py
@@ -11,13 +11,23 @@ import warnings
 import numba.core.config
 import numpy as np
 from collections import defaultdict
-from numba.core.utils import (chain_exception, use_old_style_errors,
-                              use_new_style_errors)
 from functools import wraps
 from abc import abstractmethod
 
 # Filled at the end
 __all__ = []
+
+
+def _is_numba_core_config_loaded():
+    """
+    To detect if numba.core.config has been initialized due to circular imports.
+    """
+    try:
+        numba.core.config
+    except AttributeError:
+        return False
+    else:
+        return True
 
 
 class NumbaWarning(Warning):
@@ -28,7 +38,10 @@ class NumbaWarning(Warning):
     def __init__(self, msg, loc=None, highlighting=True, ):
         self.msg = msg
         self.loc = loc
-        if highlighting:
+
+        # If a warning is emitted inside validation of env-vars in
+        # numba.core.config. Highlighting will not be available.
+        if highlighting and _is_numba_core_config_loaded():
             highlight = termcolor().errmsg
         else:
             def highlight(x):
@@ -744,6 +757,9 @@ class ForceLiteralArg(NumbaError):
     def bind_fold_arguments(self, fold_arguments):
         """Bind the fold_arguments function
         """
+        # to avoid circular import
+        from numba.core.utils import chain_exception
+
         e = ForceLiteralArg(self.requested_args, fold_arguments,
                             loc=self.loc)
         return chain_exception(e, self)
@@ -828,6 +844,12 @@ def new_error_context(fmt_, *args, **kwargs):
     format string.  If there are additional arguments, it will be used as
     ``fmt_.format(*args, **kwargs)`` to produce the final message string.
     """
+    # Import here to avoid circular import.
+    from numba.core.utils import (
+        use_old_style_errors,
+        use_new_style_errors,
+    )
+
     errcls = kwargs.pop('errcls_', InternalError)
 
     loc = kwargs.get('loc', None)

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -633,8 +633,6 @@ class TestCase(unittest.TestCase):
                    f'captured stderr: {status.stderr}')
         self.assertEqual(status.returncode, 0, streams)
         self.assertIn('OK', status.stderr)
-        self.assertNotIn('FAIL', status.stderr)
-        self.assertNotIn('ERROR', status.stderr)
 
     def run_test_in_subprocess(maybefunc=None, timeout=60, envvars=None):
         """Runs the decorated test in a subprocess via invoking numba's test

--- a/numba/tests/test_config.py
+++ b/numba/tests/test_config.py
@@ -119,8 +119,8 @@ class TestConfig(TestCase):
                     "be parsed.")
         err_msg = err.decode('utf-8')
         self.assertIn(expected, err_msg)
-        ex_expected = ("The parse failed with exception: Invalid style in "
-                       "NUMBA_CAPTURED_ERRORS: not_a_known_style")
+        ex_expected = ("Invalid style in NUMBA_CAPTURED_ERRORS: "
+                       "not_a_known_style")
         self.assertIn(ex_expected, err_msg)
         self.assertIn(source_compiled, out.decode('utf-8'))
 

--- a/numba/tests/test_errorhandling.py
+++ b/numba/tests/test_errorhandling.py
@@ -2,6 +2,8 @@
 Unspecified error handling tests
 """
 
+import sys
+import subprocess
 import numpy as np
 import os
 import warnings
@@ -469,10 +471,48 @@ class TestCapturedErrorHandling(SerialMixin, TestCase):
                     expected = "object has no attribute 'some_invalid_attr'"
                     self.assertIn(expected, str(raises.exception))
 
-    @TestCase.run_test_in_subprocess(
-        envvars={"NUMBA_CAPTURED_ERRORS": "old_style"},
-    )
-    def test_old_style_deprecation(self):
+    def _run_in_separate_process(self, runcode, env):
+        # Run code in separate process with -Wall and specific env-vars
+        code = f"""if 1:
+            {runcode}\n
+            """
+        popen = subprocess.Popen([sys.executable, "-Wall", "-c", code],
+                                 stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE,
+                                 env=env)
+        out, err = popen.communicate()
+        if popen.returncode != 0:
+            raise AssertionError("process failed with code %s: stderr follows"
+                                 "\n%s\n" % (popen.returncode, err.decode()))
+        return out, err
+
+    def test_old_style_deprecation_on_import(self):
+        from numba.core.config import _old_style_deprecation_msg
+
+        code = """
+        import numba
+        """
+        # Check that the deprecated message is shown
+        # if NUMBA_CAPTURED_ERRORS=old_style
+        env = {"NUMBA_CAPTURED_ERRORS": "old_style"}
+        _out, err = self._run_in_separate_process(code, env)
+        self.assertIn(_old_style_deprecation_msg, err.decode())
+
+        # Check that the deprecated message is NOT shown
+        # if NUMBA_CAPTURED_ERRORS is unset
+        env = {"NUMBA_CAPTURED_ERRORS": ""}
+        _out, err = self._run_in_separate_process(code, env)
+        # Check that the deprecated message is shown
+        self.assertNotIn("NumbaPendingDeprecationWarning", err.decode())
+
+        # Check that the deprecated message is NOT shown
+        # if NUMBA_CAPTURED_ERRORS=new_style
+        env = {"NUMBA_CAPTURED_ERRORS": "new_style"}
+        _out, err = self._run_in_separate_process(code, env)
+        # Check that the deprecated message is shown
+        self.assertNotIn("NumbaPendingDeprecationWarning", err.decode())
+
+    def _test_old_style_deprecation(self):
         # Verify that old_style error raise the correct deprecation warning
         warnings.simplefilter("always", errors.NumbaPendingDeprecationWarning)
 
@@ -494,6 +534,17 @@ class TestCapturedErrorHandling(SerialMixin, TestCase):
                 "error-capturing",
                 str(warns.warnings[0].message),
             )
+
+    # Check deprecation warning when NUMBA_CAPTURED_ERRORS=old_style
+    test_old_style_deprecation = TestCase.run_test_in_subprocess(
+        envvars={"NUMBA_CAPTURED_ERRORS": "old_style"},
+    )(_test_old_style_deprecation)
+
+    # Check deprecation warning when NUMBA_CAPTURED_ERRORS=default
+    # ("default" means "old_style")
+    test_default_old_style_deprecation = TestCase.run_test_in_subprocess(
+        envvars={"NUMBA_CAPTURED_ERRORS": "default"},
+    )(_test_old_style_deprecation)
 
     @TestCase.run_test_in_subprocess(
         envvars={"NUMBA_CAPTURED_ERRORS": "old_style"},

--- a/numba/tests/test_errorhandling.py
+++ b/numba/tests/test_errorhandling.py
@@ -476,10 +476,16 @@ class TestCapturedErrorHandling(SerialMixin, TestCase):
         code = f"""if 1:
             {runcode}\n
             """
+        # On windows, missing the base environment variable can cause
+        # Fatal Python error: _Py_HashRandomization_Init: failed to get random
+        #                     numbers to initialize Python
+        proc_env = os.environ.copy()
+        proc_env.update(env)
         popen = subprocess.Popen([sys.executable, "-Wall", "-c", code],
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE,
-                                 env=env)
+                                 env=proc_env)
+
         out, err = popen.communicate()
         if popen.returncode != 0:
             raise AssertionError("process failed with code %s: stderr follows"

--- a/numba/tests/test_errorhandling.py
+++ b/numba/tests/test_errorhandling.py
@@ -508,14 +508,14 @@ class TestCapturedErrorHandling(SerialMixin, TestCase):
         # if NUMBA_CAPTURED_ERRORS is unset
         env = {"NUMBA_CAPTURED_ERRORS": ""}
         _out, err = self._run_in_separate_process(code, env)
-        # Check that the deprecated message is shown
+        # Check that the deprecated message is not shown
         self.assertNotIn("NumbaPendingDeprecationWarning", err.decode())
 
         # Check that the deprecated message is NOT shown
         # if NUMBA_CAPTURED_ERRORS=new_style
         env = {"NUMBA_CAPTURED_ERRORS": "new_style"}
         _out, err = self._run_in_separate_process(code, env)
-        # Check that the deprecated message is shown
+        # Check that the deprecated message is not shown
         self.assertNotIn("NumbaPendingDeprecationWarning", err.decode())
 
     def _test_old_style_deprecation(self):


### PR DESCRIPTION
Additional changes in `errors.py` is to workaround issues with circular imports.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
