### PR TITLE
Make Numba's deprecation warnings subclasses of the builtin ones.

### DIFF
--- a/docs/upcoming_changes/9347.improvement.rst
+++ b/docs/upcoming_changes/9347.improvement.rst
@@ -1,0 +1,9 @@
+Numba deprecation warning classes are now subclasses of builtin ones
+====================================================================
+
+To help users manage and suppress deprecation warnings from Numba, the
+``NumbaDeprecationWarning`` and ``NumbaPendingDeprecationWarning`` classes are
+now subclasses of the builtin ``DeprecationWarning`` and
+``PendingDeprecationWarning`` respectively. Therefore, warning filters on
+``DeprecationWarning`` and ``PendingDeprecationWarning`` will apply to Numba
+deprecation warnings.

--- a/numba/core/errors.py
+++ b/numba/core/errors.py
@@ -47,13 +47,13 @@ class NumbaPerformanceWarning(NumbaWarning):
     """
 
 
-class NumbaDeprecationWarning(NumbaWarning):
+class NumbaDeprecationWarning(NumbaWarning, DeprecationWarning):
     """
     Warning category for use of a deprecated feature.
     """
 
 
-class NumbaPendingDeprecationWarning(NumbaWarning):
+class NumbaPendingDeprecationWarning(NumbaWarning, PendingDeprecationWarning):
     """
     Warning category for use of a feature that is pending deprecation.
     """

--- a/numba/tests/test_warnings.py
+++ b/numba/tests/test_warnings.py
@@ -6,7 +6,12 @@ import numpy as np
 
 import unittest
 from numba import jit
-from numba.core.errors import NumbaWarning, deprecated, NumbaDeprecationWarning
+from numba.core.errors import (
+    NumbaWarning,
+    deprecated,
+    NumbaDeprecationWarning,
+    NumbaPendingDeprecationWarning,
+)
 from numba.core import errors
 from numba.tests.support import ignore_internal_warnings
 
@@ -233,6 +238,49 @@ class TestBuiltins(unittest.TestCase):
         popen = subprocess.Popen([sys.executable, "-c", parallel_code], env=env)
         out, err = popen.communicate()
         self.assertEqual(popen.returncode, not_found_ret_code)
+
+    def test_filter_deprecation_warnings(self):
+        # Filter on base classes of deprecation warnings should apply to Numba's
+        # deprecation warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter('error')
+            warnings.simplefilter('ignore', category=DeprecationWarning)
+            warnings.simplefilter('ignore', category=PendingDeprecationWarning)
+            warnings.warn(DeprecationWarning("this is ignored"))
+            warnings.warn(PendingDeprecationWarning("this is ignored"))
+            warnings.warn(NumbaDeprecationWarning("this is ignored"))
+            warnings.warn(NumbaPendingDeprecationWarning("this is ignored"))
+            with self.assertRaises(NumbaWarning):
+                warnings.warn(NumbaWarning("this is not ignored"))
+
+    def test_filter_ignore_numba_deprecation_only(self):
+        # Make a filter that ignore Numba's deprecation warning but raises
+        # other deprecation warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', category=DeprecationWarning)
+            warnings.simplefilter('error', category=PendingDeprecationWarning)
+            warnings.simplefilter('ignore', category=NumbaDeprecationWarning)
+            warnings.simplefilter('ignore',
+                                  category=NumbaPendingDeprecationWarning)
+
+            with self.assertRaises(DeprecationWarning):
+                warnings.warn(DeprecationWarning("this is not ignored"))
+            with self.assertRaises(PendingDeprecationWarning):
+                warnings.warn(PendingDeprecationWarning("this is not ignored"))
+
+            warnings.warn(NumbaDeprecationWarning("this is ignored"))
+            warnings.warn(NumbaPendingDeprecationWarning("this is ignored"))
+
+            # now even Numba ones are raising
+            warnings.simplefilter('error', category=NumbaDeprecationWarning)
+            warnings.simplefilter('error',
+                                  category=NumbaPendingDeprecationWarning)
+
+            with self.assertRaises(DeprecationWarning):
+                warnings.warn(NumbaDeprecationWarning("this is not ignored"))
+            with self.assertRaises(PendingDeprecationWarning):
+                warnings.warn(NumbaPendingDeprecationWarning(
+                    "this is not ignored"))
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_warnings.py
+++ b/numba/tests/test_warnings.py
@@ -254,7 +254,7 @@ class TestBuiltins(unittest.TestCase):
                 warnings.warn(NumbaWarning("this is not ignored"))
 
     def test_filter_ignore_numba_deprecation_only(self):
-        # Make a filter that ignore Numba's deprecation warning but raises
+        # Make a filter that ignores Numba's deprecation warnings but raises on
         # other deprecation warnings
         with warnings.catch_warnings():
             warnings.simplefilter('error', category=DeprecationWarning)
@@ -271,7 +271,7 @@ class TestBuiltins(unittest.TestCase):
             warnings.warn(NumbaDeprecationWarning("this is ignored"))
             warnings.warn(NumbaPendingDeprecationWarning("this is ignored"))
 
-            # now even Numba ones are raising
+            # now make it so that Numba deprecation warnings are raising
             warnings.simplefilter('error', category=NumbaDeprecationWarning)
             warnings.simplefilter('error',
                                   category=NumbaPendingDeprecationWarning)


### PR DESCRIPTION
This will allow filter to be set to suppress all `DeprecationWarning`s including the one from Numba.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
