### PR TITLE
Made Python 3.12 support rst note more verbose

### DIFF
--- a/docs/upcoming_changes/9246.highlight.rst
+++ b/docs/upcoming_changes/9246.highlight.rst
@@ -5,7 +5,7 @@ The standout feature of this release is the official support for Python 3.12
 in Numba.
 
 Please note that profiling support is temporarily disabled in 
-this release and several known issues have been identified 
+this release (for Python 3.12) and several known issues have been identified 
 during development. The Numba team is actively working on resolving them. 
 Please refer to the respective issue pages 
 (`Numba #9289 <https://github.com/numba/numba/pull/9289>`_ and 

--- a/docs/upcoming_changes/9246.highlight.rst
+++ b/docs/upcoming_changes/9246.highlight.rst
@@ -1,4 +1,14 @@
 Python 3.12 Support
 """""""""""""""""""
 
-Support is added for Python 3.12.
+The standout feature of this release is the official support for Python 3.12 
+in Numba, along with various performance enhancements and bug fixes.
+
+Please note that profiling support is temporarily disabled in 
+this release along with several known issues that have been identified 
+during development. Numba team is actively working on resolving them. 
+Do refer to the respective issue pages 
+(`Numba #9289 <https://github.com/numba/numba/pull/9289>`_ and 
+`Numba #9291 <https://github.com/numba/numba/pull/9291>`_) 
+for a list of ongoing issues and 
+updates on our progress.

--- a/docs/upcoming_changes/9246.highlight.rst
+++ b/docs/upcoming_changes/9246.highlight.rst
@@ -2,13 +2,12 @@ Python 3.12 Support
 """""""""""""""""""
 
 The standout feature of this release is the official support for Python 3.12 
-in Numba, along with various performance enhancements and bug fixes.
+in Numba.
 
 Please note that profiling support is temporarily disabled in 
-this release along with several known issues that have been identified 
-during development. Numba team is actively working on resolving them. 
-Do refer to the respective issue pages 
+this release and several known issues have been identified 
+during development. The Numba team is actively working on resolving them. 
+Please refer to the respective issue pages 
 (`Numba #9289 <https://github.com/numba/numba/pull/9289>`_ and 
 `Numba #9291 <https://github.com/numba/numba/pull/9291>`_) 
-for a list of ongoing issues and 
-updates on our progress.
+for a list of ongoing issues and updates on progress.


### PR DESCRIPTION
As titled, this PR adds a little more details in the Python 3.12 release note rst snippet.