### PR TITLE
AzureCI changes. RVSDG test config should still test its assigned test slice

### DIFF
--- a/buildscripts/incremental/test.sh
+++ b/buildscripts/incremental/test.sh
@@ -148,3 +148,4 @@ fi
 if [[ "$TEST_RVSDG" == "yes" ]]; then
     echo "Running RVSDG tests..."
     NUMBA_USE_RVSDG_FRONTEND=1 NUMBA_CAPTURED_ERRORS=new_style NUMBA_ENABLE_CUDASIM=1 $SEGVCATCH python -m numba.runtests -b -v -m $TEST_NPROCS -- numba.tests.test_usecases
+fi

--- a/buildscripts/incremental/test.sh
+++ b/buildscripts/incremental/test.sh
@@ -119,32 +119,32 @@ if [[ $(uname) == "Darwin" ]]; then
     export SDKROOT=`pwd`/MacOSX10.10.sdk
 fi
 
+# First run Numba's Power-On-Self-Test to make sure testing will likely work
+python -m numba.misc.POST
+
+# Now run tests based on the changes identified via git
+NUMBA_ENABLE_CUDASIM=1 $SEGVCATCH python -m numba.runtests -b -v -g -m $TEST_NPROCS -- numba.tests
+
+# List the tests found
+echo "INFO: All discovered tests:"
+python -m numba.runtests -l
+
+# Now run the Numba test suite with sharding
+# Note that coverage is run from the checkout dir to match the "source"
+# directive in .coveragerc
+echo "INFO: Running shard of discovered tests: ($TEST_START_INDEX:$TEST_COUNT)"
+if [ "$RUN_COVERAGE" == "yes" ]; then
+    export PYTHONPATH=.
+    coverage erase
+    $SEGVCATCH coverage run runtests.py -b -j "$TEST_START_INDEX:$TEST_COUNT" --exclude-tags='long_running' -m $TEST_NPROCS -- numba.tests
+elif [ "$RUN_TYPEGUARD" == "yes" ]; then
+    echo "INFO: Running with typeguard"
+    NUMBA_USE_TYPEGUARD=1 NUMBA_ENABLE_CUDASIM=1 PYTHONWARNINGS="ignore:::typeguard" $SEGVCATCH python runtests.py -b -j "$TEST_START_INDEX:$TEST_COUNT" --exclude-tags='long_running' -m $TEST_NPROCS -- numba.tests
+else
+    NUMBA_ENABLE_CUDASIM=1 $SEGVCATCH python -m numba.runtests -b -j "$TEST_START_INDEX:$TEST_COUNT" --exclude-tags='long_running' -m $TEST_NPROCS -- numba.tests
+fi
+
+# Now run with RVSDG enabled for a subset of tests
 if [[ "$TEST_RVSDG" == "yes" ]]; then
     echo "Running RVSDG tests..."
     NUMBA_USE_RVSDG_FRONTEND=1 NUMBA_CAPTURED_ERRORS=new_style NUMBA_ENABLE_CUDASIM=1 $SEGVCATCH python -m numba.runtests -b -v -m $TEST_NPROCS -- numba.tests.test_usecases
-else
-    # First run Numba's Power-On-Self-Test to make sure testing will likely work
-    python -m numba.misc.POST
-
-    # Now run tests based on the changes identified via git
-    NUMBA_ENABLE_CUDASIM=1 $SEGVCATCH python -m numba.runtests -b -v -g -m $TEST_NPROCS -- numba.tests
-
-    # List the tests found
-    echo "INFO: All discovered tests:"
-    python -m numba.runtests -l
-
-    # Now run the Numba test suite with sharding
-    # Note that coverage is run from the checkout dir to match the "source"
-    # directive in .coveragerc
-    echo "INFO: Running shard of discovered tests: ($TEST_START_INDEX:$TEST_COUNT)"
-    if [ "$RUN_COVERAGE" == "yes" ]; then
-        export PYTHONPATH=.
-        coverage erase
-        $SEGVCATCH coverage run runtests.py -b -j "$TEST_START_INDEX:$TEST_COUNT" --exclude-tags='long_running' -m $TEST_NPROCS -- numba.tests
-    elif [ "$RUN_TYPEGUARD" == "yes" ]; then
-        echo "INFO: Running with typeguard"
-        NUMBA_USE_TYPEGUARD=1 NUMBA_ENABLE_CUDASIM=1 PYTHONWARNINGS="ignore:::typeguard" $SEGVCATCH python runtests.py -b -j "$TEST_START_INDEX:$TEST_COUNT" --exclude-tags='long_running' -m $TEST_NPROCS -- numba.tests
-    else
-        NUMBA_ENABLE_CUDASIM=1 $SEGVCATCH python -m numba.runtests -b -j "$TEST_START_INDEX:$TEST_COUNT" --exclude-tags='long_running' -m $TEST_NPROCS -- numba.tests
-    fi
-fi


### PR DESCRIPTION
Without the patch, a test slice is skipped entirely.