### PR TITLE
Fix ``np.MachAr`` warning matching in test.

### DIFF
--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -6239,8 +6239,9 @@ def foo():
         # typing part of the `np.MachAr` overload, which may already have been
         # executed for the given types and so an empty in memory cache is
         # needed.
-        msg = r'`np.MachAr` is deprecated \(NumPy 1.22\)'
+        msg = r'.*`np.MachAr` is deprecated \(NumPy 1.22\)'
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('ignore')  # override warning behavior
             warnings.filterwarnings("always", message=msg,
                                     category=NumbaDeprecationWarning,)
             f = njit(lambda : np.MachAr().eps)


### PR DESCRIPTION
Somehow #9347 changed the behavior of the filter.
The invisible characters from termcolor highlight now matters. But comparing the warning message before and after that PR does not reveal any visible difference.

Also added a `simplefilter("ignore")` to suppress any warning config from `PYTHONWARNINGS` in the python process.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
