### PR TITLE
Fix release notes link in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -22,7 +22,8 @@ Before submitting a bug report please ensure that you can check off these boxes:
 -->
 
 - [ ] I have tried using the latest released version of Numba (most recent is
- visible in the change log (https://github.com/numba/numba/blob/main/CHANGE_LOG).
+  visible in the release notes
+  (https://numba.readthedocs.io/en/stable/release-notes-overview.html).
 - [ ] I have included a self contained code sample to reproduce the problem.
   i.e. it's possible to run as 'python bug.py'.
 


### PR DESCRIPTION
The bug report template points to the old change log - this PR updates it to point to the release notes in the docs.

Fixes #9365.