### PR TITLE
Float Inf support

### DIFF
--- a/numba/core/typing/builtins.py
+++ b/numba/core/typing/builtins.py
@@ -996,17 +996,23 @@ class Float(AbstractTemplate):
         [arg] = args
 
         if arg not in types.number_domain:
-            raise errors.NumbaTypeError("float() only support for numbers")
+            raise errors.NumbaTypeError("float() only supports numbers")
 
         if arg in types.complex_domain:
             raise errors.NumbaTypeError("float() does not support complex")
 
-        if arg in types.integer_domain:
+        if arg == types.float64:
+            # Handle the case of float("inf")
+            if isinstance(arg, types.Const) and arg.value == float("inf"):
+                return signature(types.float64, arg)
+
+            return signature(arg, arg)
+        
+        elif arg in types.integer_domain:
             return signature(types.float64, arg)
 
         elif arg in types.real_domain:
             return signature(arg, arg)
-
 
 @infer_global(complex)
 class Complex(AbstractTemplate):

--- a/numba/cpython/builtins.py
+++ b/numba/cpython/builtins.py
@@ -294,8 +294,15 @@ def round_impl_binary(context, builder, sig, args):
 def int_impl(context, builder, sig, args):
     [ty] = sig.args
     [val] = args
-    res = context.cast(builder, val, ty, sig.return_type)
-    return impl_ret_untracked(context, builder, sig.return_type, res)
+
+    if ty == types.float64 and isinstance(val, types.Const) and val.value == float("inf"):
+        # Handle the case of float("inf")
+        result = context.get_constant(types.float64, float("inf"))
+    else:
+        # Standard conversion for other cases
+        result = context.cast(builder, val, ty, sig.return_type)
+
+    return impl_ret_untracked(context, builder, sig.return_type, result)
 
 
 @lower_builtin(complex, types.VarArg(types.Any))

--- a/numba/tests/test_floatinf.py
+++ b/numba/tests/test_floatinf.py
@@ -1,0 +1,40 @@
+import unittest
+from numba import types, errors
+from numba.templating.templates import AbstractTemplate, signature
+from numba.core.typing.builtins import Float  
+class TestFloatTemplate(unittest.TestCase):
+
+    def test_float_template(self):
+        float_template = Float()
+
+        # Test case 1: Test with a float argument
+        float_arg = types.float64
+        result_signature = float_template.generic([float_arg], {})
+        expected_signature = signature(float_arg, float_arg)
+        self.assertEqual(result_signature, expected_signature)
+
+        # Test case 2: Test with an integer argument
+        int_arg = types.int32
+        result_signature = float_template.generic([int_arg], {})
+        expected_signature = signature(types.float64, int_arg)
+        self.assertEqual(result_signature, expected_signature)
+
+        # Test case 3: Test with a complex argument
+        complex_arg = types.complex128
+        with self.assertRaises(errors.NumbaTypeError):
+            float_template.generic([complex_arg], {})
+
+        # Test case 4: Test with a non-numeric argument
+        non_numeric_arg = types.StringLiteral('abc')
+        with self.assertRaises(errors.NumbaTypeError):
+            float_template.generic([non_numeric_arg], {})
+
+        # Test case 5: Test with float("inf")
+        inf_arg = types.float64
+        inf_arg_const = types.Const(float("inf"), inf_arg)
+        result_signature = float_template.generic([inf_arg_const], {})
+        expected_signature = signature(types.float64, inf_arg_const)
+        self.assertEqual(result_signature, expected_signature)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!--
Hi!
Ive added the workaround to numba/core/typing/builtins.py and numba/cpython/builtins.py. 
Description:
This modification checks if the argument arg is a types.Const representing float("inf"). If it is, it returns a signature with the inferred type as types.float64. Otherwise, it proceeds with the existing logic.

I've also added the test case. Kindly review it and let me know any changes to be made.
Richa :)
-->
