### PR TITLE
fix `TypeError: '_DeviceContextManager' object is not callable`

### DIFF
--- a/docs/source/cuda-reference/host.rst
+++ b/docs/source/cuda-reference/host.rst
@@ -50,9 +50,9 @@ Numba maintains a list of supported CUDA-capable devices:
 
 Alternatively, the current device can be obtained:
 
-.. function:: numba.cuda.gpus.current
+.. attribute:: numba.cuda.gpus.current
 
-   Return the currently-selected device.
+   The currently-selected device.
 
 Getting a device through :attr:`numba.cuda.gpus` always provides an instance of
 :class:`numba.cuda.cudadrv.devices._DeviceContextManager`, which acts as a

--- a/docs/upcoming_changes/9394.doc.rst
+++ b/docs/upcoming_changes/9394.doc.rst
@@ -1,0 +1,5 @@
+``numba.cuda.gpus.current`` documentation correction
+====================================================
+
+``numba.cuda.gpus.current`` was erroneously described
+as a function, is now described as an attribute.


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
This is a change to documentation, [which currently shows](https://numba.pydata.org/numba-doc/dev/cuda-reference/host.html#id1) 
`numba.cuda.gpus.current` as a _function_, but
```
TypeError: '_DeviceContextManager' object is not callable
```

