### PR TITLE
Fix test isolation for stateful configurations in the testsuite

### DIFF
--- a/numba/tests/test_caching.py
+++ b/numba/tests/test_caching.py
@@ -266,9 +266,11 @@ class DispatcherCacheUsecasesTest(BaseCacheTest):
             mod.self_test()
             """ % dict(tempdir=self.tempdir, modname=self.modname)
 
+        subp_env = os.environ.copy()
+        subp_env.update(envvars)
         popen = subprocess.Popen([sys.executable, "-c", code],
                                  stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                                 env=envvars)
+                                 env={**os.environ, **envvars})
         out, err = popen.communicate()
         if popen.returncode != 0:
             raise AssertionError(

--- a/numba/tests/test_caching.py
+++ b/numba/tests/test_caching.py
@@ -270,7 +270,7 @@ class DispatcherCacheUsecasesTest(BaseCacheTest):
         subp_env.update(envvars)
         popen = subprocess.Popen([sys.executable, "-c", code],
                                  stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                                 env={**os.environ, **envvars})
+                                 env=subp_env)
         out, err = popen.communicate()
         if popen.returncode != 0:
             raise AssertionError(

--- a/numba/tests/test_caching.py
+++ b/numba/tests/test_caching.py
@@ -21,7 +21,6 @@ from numba.tests.support import (
     capture_cache_log,
     import_dynamic,
     override_config,
-    override_env_config,
     run_in_new_process_caching,
     skip_if_typeguard,
     skip_parfors_unsupported,
@@ -255,7 +254,7 @@ class DispatcherCacheUsecasesTest(BaseCacheTest):
     usecases_file = os.path.join(here, "cache_usecases.py")
     modname = "dispatcher_caching_test_fodder"
 
-    def run_in_separate_process(self):
+    def run_in_separate_process(self, *, envvars={}):
         # Cached functions can be run from a distinct process.
         # Also stresses issue #1603: uncached function calling cached function
         # shouldn't fail compiling.
@@ -268,7 +267,8 @@ class DispatcherCacheUsecasesTest(BaseCacheTest):
             """ % dict(tempdir=self.tempdir, modname=self.modname)
 
         popen = subprocess.Popen([sys.executable, "-c", code],
-                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                 env=envvars)
         out, err = popen.communicate()
         if popen.returncode != 0:
             raise AssertionError(
@@ -745,8 +745,7 @@ class TestCacheWithCpuSetting(DispatcherCacheUsecasesTest):
 
         mtimes = self.get_cache_mtimes()
         # Change CPU name to generic
-        with override_env_config('NUMBA_CPU_NAME', 'generic'):
-            self.run_in_separate_process()
+        self.run_in_separate_process(envvars={'NUMBA_CPU_NAME': 'generic'})
 
         self.check_later_mtimes(mtimes)
         self.assertGreater(len(self.cache_contents()), cache_size)
@@ -778,8 +777,9 @@ class TestCacheWithCpuSetting(DispatcherCacheUsecasesTest):
         system_features = codegen.get_host_cpu_features()
 
         self.assertNotEqual(system_features, my_cpu_features)
-        with override_env_config('NUMBA_CPU_FEATURES', my_cpu_features):
-            self.run_in_separate_process()
+        self.run_in_separate_process(
+            envvars={'NUMBA_CPU_FEATURES': my_cpu_features},
+        )
         self.check_later_mtimes(mtimes)
         self.assertGreater(len(self.cache_contents()), cache_size)
         # Check cache index

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -4624,6 +4624,7 @@ class TestParforsVectorizer(TestPrangeBase):
             return asm
 
     @linux_only
+    @TestCase.run_test_in_subprocess
     def test_vectorizer_fastmath_asm(self):
         """ This checks that if fastmath is set and the underlying hardware
         is suitable, and the function supplied is amenable to fastmath based

--- a/numba/tests/test_vectorization.py
+++ b/numba/tests/test_vectorization.py
@@ -25,6 +25,7 @@ class TestVectorization(TestCase):
             jitted = njit(args_tuple, fastmath=fastmath)(func)
             return jitted.inspect_llvm(args_tuple)
 
+    @TestCase.run_test_in_subprocess()
     def test_nditer_loop(self):
         # see https://github.com/numba/numba/issues/5033
         def do_sum(x):
@@ -54,6 +55,7 @@ class TestVectorization(TestCase):
         llvm_ir = self.gen_ir(foo, ((ty,) * 4 + (ty[::1],)), fastmath=True)
         self.assertIn("2 x double", llvm_ir)
 
+    @TestCase.run_test_in_subprocess()
     def test_instcombine_effect(self):
         # Without instcombine running ahead of refprune, the IR has refops that
         # are trivially prunable (same BB) but the arguments are obfuscated


### PR DESCRIPTION
This fixes a SIGILL detected in https://github.com/conda-forge/numba-feedstock/pull/131 by adding needed isolation to test that changes the target machine.

Minimal reproducer is: 
```bash
python runtests.py numba.tests.test_vectorization.TestVectorization.test_nditer_loop numba.tests.test_withlifting.TestLiftObj.test_case02_mutate_array_ahead_of_ctx
```