### PR TITLE
Fix skipped test stderr change for Python 3.12.1.

### DIFF
--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -588,7 +588,12 @@ class TestCase(unittest.TestCase):
         streams = (f'\ncaptured stdout: {status.stdout}\n'
                    f'captured stderr: {status.stderr}')
         self.assertEqual(status.returncode, 0, streams)
-        self.assertIn('OK', status.stderr)
+        # Python 3.12.1 report
+        no_tests_ran = "NO TESTS RAN"
+        if no_tests_ran in status.stderr:
+            self.skipTest(no_tests_ran)
+        else:
+            self.assertIn('OK', status.stderr)
 
     def run_test_in_subprocess(maybefunc=None, timeout=60, envvars=None):
         """Runs the decorated test in a subprocess via invoking numba's test

--- a/numba/tests/test_gdb_bindings.py
+++ b/numba/tests/test_gdb_bindings.py
@@ -3,6 +3,7 @@ Tests gdb bindings
 """
 import os
 import platform
+import re
 import subprocess
 import sys
 import threading
@@ -193,6 +194,11 @@ class TestGdbBinding(TestCase):
         def test_template(self):
             o, e = self.run_test_in_separate_process(injected_method)
             dbgmsg = f'\nSTDOUT={o}\nSTDERR={e}\n'
+            # If the test was skipped in the subprocess, then mark this as a
+            # skipped test.
+            m = re.search(r"\.\.\. skipped '(.*?)'", e)
+            if m is not None:
+                self.skipTest(m.group(1))
             self.assertIn('GNU gdb', o, msg=dbgmsg)
             self.assertIn('OK', e, msg=dbgmsg)
             self.assertNotIn('FAIL', e, msg=dbgmsg)

--- a/numba/tests/test_num_threads.py
+++ b/numba/tests/test_num_threads.py
@@ -603,12 +603,14 @@ class TestNumThreadsBackends(TestInSubprocess, TestCase):
                                                      num_threads)
             if self._DEBUG:
                 print('stdout:\n "%s"\n stderr:\n "%s"' % (o, e))
+            # If the test was skipped in the subprocess, then mark this as a
+            # skipped test.
+            m = re.search(r"\.\.\. skipped '(.*?)'", e)
+            if m is not None:
+                self.skipTest(m.group(1))
             self.assertIn('OK', e)
             self.assertTrue('FAIL' not in e)
             self.assertTrue('ERROR' not in e)
-            m = re.search(r"\.\.\. skipped '(.*?)'", e)
-            if m:
-                self.skipTest(m.group(1))
 
         injected_test = "%s_%s_%s_threads" % (name[1:], backend, num_threads)
         setattr(cls, injected_test,

--- a/numba/tests/test_parallel_backend.py
+++ b/numba/tests/test_parallel_backend.py
@@ -8,6 +8,7 @@ import itertools
 import multiprocessing
 import os
 import random
+import re
 import subprocess
 import sys
 import textwrap
@@ -396,6 +397,11 @@ class TestSpecificBackend(TestInSubprocess, TestParallelBackendBase):
             o, e = self.run_test_in_separate_process(injected_method, backend)
             if self._DEBUG:
                 print('stdout:\n "%s"\n stderr:\n "%s"' % (o, e))
+            # If the test was skipped in the subprocess, then mark this as a
+            # skipped test.
+            m = re.search(r"\.\.\. skipped '(.*?)'", e)
+            if m is not None:
+                self.skipTest(m.group(1))
             self.assertIn('OK', e)
             self.assertTrue('FAIL' not in e)
             self.assertTrue('ERROR' not in e)


### PR DESCRIPTION
Python 3.12.1 fixed an issue with the exit code `unittest` reported for skipped tests and also changed the string sent to stderr. Numba was using this string as part of its testing and so was susceptible to this change, this patch fixes Numba's tests.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
