### PR TITLE
Fix incorrect cycle detection

### DIFF
--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -3848,17 +3848,30 @@ def get_reduce_nodes(reduction_node, nodes, func_ir):
     reduce_nodes = None
     defs = {}
 
-    def lookup(var, varonly=True, start=None):
-        val = defs.get(var.name, None)
-        if isinstance(val, ir.Var):
+    def cyclic_lookup(var, varonly=True, start=None):
+        """Lookup definition of ``var``.
+        Returns ``None`` if variable definition forms a cycle.
+        """
+        lookedup_var = defs.get(var.name, None)
+        if isinstance(lookedup_var, ir.Var):
             if start is None:
-                start = val
-            elif start == var:
+                start = lookedup_var
+            elif start == lookedup_var:
                 # cycle detected
                 return None
-            return lookup(val, start=start)
+            return cyclic_lookup(lookedup_var, start=start)
         else:
-            return var if (varonly or val is None) else val
+            return var if (varonly or lookedup_var is None) else lookedup_var
+
+    def noncyclic_lookup(*args, **kwargs):
+        """Similar to cyclic_lookup but raise AssertionError if a cycle is
+        detected.
+        """
+        res = cyclic_lookup(*args, **kwargs)
+        if res is None:
+            raise AssertionError("unexpected cycle in lookup()")
+        return res
+
     name = reduction_node.name
     unversioned_name = reduction_node.unversioned_name
     for i, stmt in enumerate(nodes):
@@ -3866,9 +3879,10 @@ def get_reduce_nodes(reduction_node, nodes, func_ir):
         rhs = stmt.value
         defs[lhs.name] = rhs
         if isinstance(rhs, ir.Var) and rhs.name in defs:
-            rhs = lookup(rhs)
+            rhs = cyclic_lookup(rhs)
         if isinstance(rhs, ir.Expr):
-            in_vars = set(lookup(v, True).name for v in rhs.list_vars())
+            in_vars = set(noncyclic_lookup(v, True).name
+                          for v in rhs.list_vars())
             if name in in_vars:
                 # reductions like sum have an assignment afterwards
                 # e.g. $2 = a + $1; a = $2
@@ -3923,7 +3937,8 @@ def get_reduce_nodes(reduction_node, nodes, func_ir):
                 if not supported_reduction(rhs, func_ir):
                     raise ValueError(("Use of reduction variable " + unversioned_name +
                                       " in an unsupported reduction function."))
-                args = [ (x.name, lookup(x, True)) for x in get_expr_args(rhs) ]
+                args = [(x.name, noncyclic_lookup(x, True))
+                        for x in get_expr_args(rhs) ]
                 non_red_args = [ x for (x, y) in args if y.name != name ]
                 assert len(non_red_args) == 1
                 args = [ (x, y) for (x, y) in args if x != y.name ]

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -3278,6 +3278,22 @@ class TestParforsMisc(TestParforsBase):
             )
         )
 
+    def test_lookup_cycle_detection(self):
+        # This test is added due to a bug discovered in the PR 9244 patch.
+        # The cyclic detection was incorrectly flagging cycles.
+        @njit(parallel=True)
+        def foo():
+            # The following `acc` variable is used in the `lookup()` function
+            # in parfor's reduction code.
+            acc = 0
+            for n in prange(1):
+                for i in range(1):
+                    for j in range(1):
+                        acc += 1
+            return acc
+
+        self.assertEqual(foo(), foo.py_func())
+
 
 @skip_parfors_unsupported
 class TestParforsDiagnostics(TestParforsBase):


### PR DESCRIPTION
Bug is reported in:

- https://numba.discourse.group/t/hard-to-debug-new-errors-under-0-59rc1/2375
- https://github.com/numba/numba/pull/9244#issuecomment-1819169614

Defensive changes were added:

- to clearly label variable to avoid misreading `val` vs `var`;
- to avoid accidental use of `lookup()` without checking the return value is `None`  (cycle detected).

Added a new test written by @stuartarchibald as a minimal reproducer of the problem reported in Discourse.