### PR TITLE
Implement ndarray.byteswap

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -310,6 +310,7 @@ The following methods of NumPy arrays are supported:
 * :meth:`~numpy.ndarray.argsort` (``kind`` key word argument supported for
   values ``'quicksort'`` and ``'mergesort'``)
 * :meth:`~numpy.ndarray.astype` (only the 1-argument form)
+* :meth:`~numpy.ndarray.byteswap` (only for numbers and booleans)
 * :meth:`~numpy.ndarray.copy` (without arguments)
 * :meth:`~numpy.ndarray.dot` (only the 1-argument form)
 * :meth:`~numpy.ndarray.flatten` (no order argument; 'C' order only)

--- a/docs/upcoming_changes/99999.np_support.rst
+++ b/docs/upcoming_changes/99999.np_support.rst
@@ -1,0 +1,5 @@
+Added support for byteswap.
+===========================
+
+Support is added for the numpy ``byteswap`` method on numbers, booleans, and
+arrays thereof.

--- a/numba/cpython/numbers.py
+++ b/numba/cpython/numbers.py
@@ -13,7 +13,7 @@ from numba.core.imputils import (lower_builtin, lower_getattr,
                                     impl_ret_untracked)
 from numba.core import typing, types, utils, errors, cgutils, optional
 from numba.core.extending import intrinsic, overload_method
-from numba.cpython.unsafe.numbers import viewer
+from numba.cpython.unsafe.numbers import viewer, byteswap
 
 def _int_arith_flags(rettype):
     """
@@ -1202,6 +1202,17 @@ def number_item_impl(context, builder, sig, args):
     The no-op .item() method on booleans and numbers.
     """
     return args[0]
+
+
+@overload_method(types.Boolean, "byteswap")
+@overload_method(types.Number, "byteswap")
+def number_byteswap(a, inplace=False):
+    def number_byteswap_impl(a, inplace=False):
+        if inplace:
+            raise ValueError("cannot byteswap a scalar in-place")
+        return byteswap(a)
+
+    return number_byteswap_impl
 
 
 #------------------------------------------------------------------------------

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -2739,6 +2739,16 @@ def array_view(context, builder, sig, args):
     return impl_ret_borrowed(context, builder, sig.return_type, res)
 
 
+@overload_method(types.Array, 'byteswap')
+def array_byteswap(arr, inplace=False):
+    def impl(arr, inplace=False):
+        out = arr if inplace else np.empty_like(arr)
+        for index in np.ndindex(arr.shape):
+            out[index] = arr[index].byteswap()
+        return out
+    return impl
+
+
 # ------------------------------------------------------------------------------
 # Array attributes
 

--- a/numba/tests/test_numbers.py
+++ b/numba/tests/test_numbers.py
@@ -88,3 +88,37 @@ class TestViewIntFloat(TestCase):
     def test_exceptions64(self):
         for pair in ((np.int32, np.int64), (np.int64, np.int32)):
             self.do_testing_exceptions(pair)
+
+
+@njit
+def swap(x):
+    return x.byteswap()
+
+
+class TestByteswap(TestCase):
+    """Test the 'byteswap' method on NumPy scalars."""
+
+    def do_test(self, x):
+        self.assertEqual(swap(x), x.byteswap())
+
+    def test_int(self):
+        self.do_test(np.int8(123))
+        self.do_test(np.uint8(234))
+        self.do_test(np.int16(0x0102))
+        self.do_test(np.uint16(0xcafe))
+        self.do_test(np.int32(0x01020304))
+        self.do_test(np.uint32(0xdeadcafe))
+        self.do_test(np.int64(0x0102030405060708))
+        self.do_test(np.uint64(0xdeadcafe01020304))
+
+    def test_float(self):
+        self.do_test(np.float32(123.4))
+        self.do_test(np.float64(-123.45))
+
+    def test_bool(self):
+        self.do_test(np.bool_(False))
+        self.do_test(np.bool_(True))
+
+    def test_complex(self):
+        self.do_test(np.complex64(123.4 - 567.8j))
+        self.do_test(np.complex128(123.4 - 567.8j))


### PR DESCRIPTION
It's implemented for numbers (including complex) and boolean.

On a 1D array it's about 7x faster than numpy. For higher dimensions it is slower, and it is much slower for Fortran-order arrays, for the same reasons as in #9400.

This is my first PR for number and I'm pretty new to LLVM as well, so I've got a few questions:

- I've kept the code smaller by unconditionally bit-casting to and from a suitably-sized integer type. If it's already an integer type (probably the common case) that's unnecessary LLVM IR instructions, but I'm assuming that's harmless.
- In numpy, `byteswap` on a scalar with `inplace=True` raises an exception, and I've mirrored that behaviour. Since numba is statically typed, an alternative is to simply not support that useless parameter, which would move the error to compile time (generally a good thing) but be less compatible with numpy. Any thoughts?
- Is there a better way to handle the array iteration? I looked into wrapping the `@intrinsic` scalar function into a ufunc and calling that (which uses a sensible iteration order for Fortran-order arrays), but ran into some cyclic import problems.