### PR TITLE
Optimize `range()` to enable more auto-vectorization

### DIFF
--- a/numba/core/datamodel/models.py
+++ b/numba/core/datamodel/models.py
@@ -1133,10 +1133,18 @@ class ZipType(StructModel):
 class RangeIteratorType(StructModel):
     def __init__(self, dmm, fe_type):
         int_type = fe_type.yield_type
-        members = [('iter', types.EphemeralPointer(int_type)),
-                   ('stop', int_type),
-                   ('step', int_type),
-                   ('count', types.EphemeralPointer(int_type))]
+        members = [
+            # The iter state. a counter from 0.
+            ('iter', types.EphemeralPointer(int_type)),
+            # The start offset.
+            ('start', int_type),
+            # Adjusted stop for iter. Valid range is 0 < iter < adj_stop.
+            ('adj_stop', int_type),
+            # For scaling iter to indvar
+            ('scale', int_type),
+            # Count. e.g. len(iter(range())).
+            ('count', types.EphemeralPointer(int_type)),
+        ]
         super(RangeIteratorType, self).__init__(dmm, fe_type, members)
 
 

--- a/numba/core/datamodel/models.py
+++ b/numba/core/datamodel/models.py
@@ -1142,7 +1142,7 @@ class RangeIteratorType(StructModel):
             ('adj_stop', int_type),
             # For scaling iter to indvar
             ('scale', int_type),
-            # Count. e.g. len(iter(range())).
+            # Count. e.g. length_of_iterator(iter(range())).
             ('count', types.EphemeralPointer(int_type)),
         ]
         super(RangeIteratorType, self).__init__(dmm, fe_type, members)

--- a/numba/cpython/rangeobj.py
+++ b/numba/cpython/rangeobj.py
@@ -207,6 +207,12 @@ def make_range_impl(int_type, range_state_type, range_iter_type):
                     ),
                 )
                 builder.store(next_indvar, self.iter)
+                # update count
+                count = builder.load(self.count)
+                builder.store(
+                    builder.sub(count, count.type(1), flags=["nsw"]),
+                    self.count,
+                )
 
 
 range_impl_map = {

--- a/numba/tests/test_range.py
+++ b/numba/tests/test_range.py
@@ -44,6 +44,17 @@ def range_iter_len1(a):
 def range_iter_len2(a):
     return length_of_iterator(iter(a))
 
+def range_iter_len3():
+    it = iter(range(3))
+    a = length_of_iterator(it)
+    next(it)
+    b = length_of_iterator(it)
+    next(it)
+    c = length_of_iterator(it)
+    next(it)
+    d = length_of_iterator(it)
+    return a, b, c, d
+
 def range_attrs(start, stop, step):
     r1 = range(start)
     r2 = range(start, stop)
@@ -133,6 +144,10 @@ class TestRange(unittest.TestCase):
         cfunc = njit((types.List(types.intp, reflected=True),))(range_iter_func)
         arglist = [1, 2, 3, 4, 5]
         self.assertEqual(cfunc(arglist), len(arglist))
+
+    def test_range_iter_len3(self):
+        out = njit(range_iter_len3)()
+        self.assertEqual(out, (3, 2, 1, 0))
 
     def test_range_attrs(self):
         pyfunc = range_attrs


### PR DESCRIPTION
It is known that Numba's `range()` implementation is not optimal for LLVM loop optimizers. Even when one manually unroll loop for a constant loop bound, the way `range()` is implemented prohibits the loop-vectorizer to compute the loop bounds; thus failing to auto-vectorize in many cases. 

This patch focuses on adjusting the ind-var computation to avoid computing reminders and instead relies mainly on additions, multiplications and floordiv which are common in low-level address computations.

There is still a reminder computation only if user ask for `length_of_iterator(iter(range()))`, but it is a rare use-case. LLVM is able to optimize-away that reminder (and the storage of `range_iterator_type.count`)

Here's a notebook with a use-case I used to optimize `range()`: https://gist.github.com/sklam/6beddb2041580ceea4f25e0e496f50a0/420bc173da75996a307465f134c23bb3f4bb6562.
