### PR TITLE
Add timing and junit xml output to testsuite

### DIFF
--- a/buildscripts/azure/azure-linux-macos.yml
+++ b/buildscripts/azure/azure-linux-macos.yml
@@ -49,3 +49,10 @@ jobs:
         export PATH=$HOME/miniconda3/bin:$PATH
         buildscripts/incremental/test.sh
       displayName: 'Test'
+
+    - task: PublishTestResults@2
+      condition: succeededOrFailed()
+      displayName: Publish Test Results
+      inputs:
+        testResultsFiles: 'junit_testsuites_*.xml'
+        mergeTestResults: true

--- a/buildscripts/azure/azure-linux-macos.yml
+++ b/buildscripts/azure/azure-linux-macos.yml
@@ -54,5 +54,5 @@ jobs:
       condition: succeededOrFailed()
       displayName: Publish Test Results
       inputs:
-        testResultsFiles: 'junit_testsuites_*.xml'
+        testResultsFiles: 'junit_numba_*.xml'
         mergeTestResults: true

--- a/buildscripts/azure/azure-windows.yml
+++ b/buildscripts/azure/azure-windows.yml
@@ -69,5 +69,5 @@ jobs:
       condition: succeededOrFailed()
       displayName: Publish Test Results
       inputs:
-        testResultsFiles: 'junit_testsuites_*.xml'
+        testResultsFiles: 'junit_numba_*.xml'
         mergeTestResults: true

--- a/buildscripts/azure/azure-windows.yml
+++ b/buildscripts/azure/azure-windows.yml
@@ -62,5 +62,12 @@ jobs:
         set NUMBA_CAPTURED_ERRORS=new_style
         set NUMBA_ENABLE_CUDASIM=1
         echo "Running shard of discovered tests: %TEST_START_INDEX%:%TEST_COUNT%"
-        python runtests.py -m 2 -b -j "%TEST_START_INDEX%:%TEST_COUNT%"  --exclude-tags='long_running'  -- numba.tests
+        python runtests.py -m 2 -b -j "%TEST_START_INDEX%:%TEST_COUNT%"  --exclude-tags='long_running' --junit -- numba.tests
       displayName: 'Test shard of test files'
+
+    - task: PublishTestResults@2
+      condition: succeededOrFailed()
+      displayName: Publish Test Results
+      inputs:
+        testResultsFiles: 'junit_testsuites_*.xml'
+        mergeTestResults: true

--- a/buildscripts/incremental/test.sh
+++ b/buildscripts/incremental/test.sh
@@ -136,16 +136,16 @@ echo "INFO: Running shard of discovered tests: ($TEST_START_INDEX:$TEST_COUNT)"
 if [ "$RUN_COVERAGE" == "yes" ]; then
     export PYTHONPATH=.
     coverage erase
-    $SEGVCATCH coverage run runtests.py -b -j "$TEST_START_INDEX:$TEST_COUNT" --exclude-tags='long_running' -m $TEST_NPROCS -- numba.tests
+    $SEGVCATCH coverage run runtests.py -b -j "$TEST_START_INDEX:$TEST_COUNT" --exclude-tags='long_running' -m $TEST_NPROCS --junit -- numba.tests
 elif [ "$RUN_TYPEGUARD" == "yes" ]; then
     echo "INFO: Running with typeguard"
-    NUMBA_USE_TYPEGUARD=1 NUMBA_ENABLE_CUDASIM=1 PYTHONWARNINGS="ignore:::typeguard" $SEGVCATCH python runtests.py -b -j "$TEST_START_INDEX:$TEST_COUNT" --exclude-tags='long_running' -m $TEST_NPROCS -- numba.tests
+    NUMBA_USE_TYPEGUARD=1 NUMBA_ENABLE_CUDASIM=1 PYTHONWARNINGS="ignore:::typeguard" $SEGVCATCH python runtests.py -b -j "$TEST_START_INDEX:$TEST_COUNT" --exclude-tags='long_running' -m $TEST_NPROCS --junit -- numba.tests
 else
-    NUMBA_ENABLE_CUDASIM=1 $SEGVCATCH python -m numba.runtests -b -j "$TEST_START_INDEX:$TEST_COUNT" --exclude-tags='long_running' -m $TEST_NPROCS -- numba.tests
+    NUMBA_ENABLE_CUDASIM=1 $SEGVCATCH python -m numba.runtests -b -j "$TEST_START_INDEX:$TEST_COUNT" --exclude-tags='long_running' -m $TEST_NPROCS --junit -- numba.tests
 fi
 
 # Now run with RVSDG enabled for a subset of tests
 if [[ "$TEST_RVSDG" == "yes" ]]; then
     echo "Running RVSDG tests..."
-    NUMBA_USE_RVSDG_FRONTEND=1 NUMBA_CAPTURED_ERRORS=new_style NUMBA_ENABLE_CUDASIM=1 $SEGVCATCH python -m numba.runtests -b -v -m $TEST_NPROCS -- numba.tests.test_usecases
+    NUMBA_USE_RVSDG_FRONTEND=1 NUMBA_CAPTURED_ERRORS=new_style NUMBA_ENABLE_CUDASIM=1 $SEGVCATCH python -m numba.runtests -b -v -m $TEST_NPROCS --junit -- numba.tests.test_usecases
 fi

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -214,6 +214,9 @@ instead. For example::
     $ NUMBA_USE_TYPEGUARD=1 python runtests.py
 
 
+See also: :ref:`Debugging the Test Suite <developer-testsuite>`
+
+
 Running coverage
 ''''''''''''''''
 

--- a/docs/source/developer/index.rst
+++ b/docs/source/developer/index.rst
@@ -27,6 +27,7 @@ Developer Manual
    literal.rst
    llvm_timings.rst
    debugging.rst
+   testsuite.rst
    event_api.rst
    target_extension.rst
    bytecode.rst

--- a/docs/source/developer/testsuite.rst
+++ b/docs/source/developer/testsuite.rst
@@ -4,6 +4,9 @@
 Debugging the Numba Test Suite
 ==============================
 
+.. note:: Features described here are only implemented for the parallel 
+          test runner (e.g. requires the ``-m`` flag).
+
 The Numba test suite provides some useful features for debugging test failures 
 or crashes.
 

--- a/docs/source/developer/testsuite.rst
+++ b/docs/source/developer/testsuite.rst
@@ -1,0 +1,77 @@
+.. _developer-testsuite:
+
+==============================
+Debugging the Numba Test Suite
+==============================
+
+The Numba test suite provides some useful features for debugging test failures 
+or crashes.
+
+Generating JUnit XML Output
+---------------------------
+
+You can generate a JUnit-compatible XML report by running the tests with the 
+``--junit`` flag:
+
+.. code-block:: bash
+
+    $ python -m numba.runtests <args> --junit
+
+This will produce a ``junit_numba_<timestamp>.xml`` file containing the test results.
+
+The XML contains some extra metadata as ``testcase`` properties:
+
+- ``pid``: The ID of the worker process running each test case
+- ``start_time``: The start time for each test case relative to when the worker 
+  process started
+
+
+Example of the XML file:
+
+.. code-block:: xml
+
+    <?xml version='1.0' encoding='utf-8'?>
+    <testsuites time="20.745398832">
+        <testsuite name="numba_testsuite">
+            <testcase name="TestUsecases.test_andor" classname="numba.tests.test_usecases"
+                time="1.7033392500000002">
+                <properties>
+                    <property name="pid" value="73274" />
+                    <property name="start_time" value="1.337771667" />
+                </properties>
+            </testcase>
+            <testcase name="TestUsecases.test_blackscholes_cnd" classname="numba.tests.test_usecases"
+                time="1.723800292">
+                <properties>
+                    <property name="pid" value="73275" />
+                    <property name="start_time" value="1.3350285" />
+                </properties>
+            </testcase>
+            ...
+        </testsuite>
+    </testsuites>
+
+
+Debugging Timeouts caused by Crashes
+------------------------------------
+
+If the test suite times out, it may indicate a crashed worker process. 
+In this case, the timeout error will show:
+
+- The active tests that didn't finish before the timeout
+- For each affected process ID, the list of tests that process was running
+
+For example:
+
+.. code-block:: none
+
+  TimeoutError: Active tests didn't finish before timeout:
+  - test_foo [PID 1234]
+
+  Tests ran by each affected process: 
+  - [PID 1234]: test_bar test_baz test_foo
+
+This information can help reproduce crashes that depend on the test execution 
+order or state within a process. You can retry just the tests that were running 
+in the crashed process.
+

--- a/numba/testing/main.py
+++ b/numba/testing/main.py
@@ -16,9 +16,9 @@ import re
 from functools import lru_cache
 from io import StringIO
 from unittest import result, runner, signals, suite, loader, case
+from datetime import datetime
 
 from .loader import TestLoader
-from numba.core import config
 
 try:
     from multiprocessing import TimeoutError
@@ -979,7 +979,8 @@ class ParallelTestRunner(runner.TextTestRunner):
             self.stream.write(f"Total test runtime (seconds): {result.test_runtime}\n")
         # Write junit xml
         if self.write_junit:
-            filename = f"junit_testsuites_{time.time()}.xml"
+            tstamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+            filename = f"junit_numba_{tstamp}.xml"
             print("Writing junit xml file:", filename)
             result.write_junit_xml(filename)
         return result

--- a/numba/testing/main.py
+++ b/numba/testing/main.py
@@ -900,7 +900,7 @@ class ParallelTestRunner(runner.TextTestRunner):
         # Write timing
         if self.show_timing:
             self.stream.write(f"Total test runtime (seconds): {result.test_runtime}\n")
-
+        # Write junit xml
         if self.write_junit:
             filename = f"junit_testsuites_{time.time()}.xml"
             print("Writing junit xml file:", filename)

--- a/numba/tests/test_runtests.py
+++ b/numba/tests/test_runtests.py
@@ -304,7 +304,7 @@ class TestCase(unittest.TestCase):
                       out)
         xml_filepath = m.group(1)
         self.assertTrue(pathlib.Path(xml_filepath).exists())
-        # If this raise the XML file is invalid
+        # If this raises, the XML file is invalid
         xml.etree.ElementTree.parse(xml_filepath)
 
 

--- a/numba/tests/test_runtests.py
+++ b/numba/tests/test_runtests.py
@@ -1,6 +1,10 @@
 import os
 import sys
 import subprocess
+import re
+import pathlib
+import xml.etree.ElementTree
+
 
 from numba import cuda
 import unittest
@@ -278,6 +282,30 @@ class TestCase(unittest.TestCase):
         subprocess.check_call(cmd,
                               stdout=subprocess.DEVNULL,
                               stderr=subprocess.DEVNULL,)
+
+    def test_show_timing(self):
+        cmd = [sys.executable, '-m', 'numba.runtests', '--show-timing', '-vm1',
+               'numba.tests.test_usecases.TestUsecases.test_sum1d']
+        out = subprocess.check_output(cmd, encoding='utf8',
+                                      stderr=subprocess.STDOUT)
+        self.assertIsNotNone(
+            re.search(r"Runtime \(seconds\): \d*\.\d*", out),
+        )
+        self.assertIsNotNone(
+            re.search(r"Total test runtime \(seconds\): \d*\.\d*", out),
+        )
+
+    def test_junit_output(self):
+        cmd = [sys.executable, '-m', 'numba.runtests', '--junit', '-vm1',
+               'numba.tests.test_usecases.TestUsecases.test_sum1d']
+        out = subprocess.check_output(cmd, encoding='utf8',
+                                      stderr=subprocess.STDOUT)
+        m = re.search(r"Writing junit xml file: (junit_numba_[0-9_-]+.xml)",
+                      out)
+        xml_filepath = m.group(1)
+        self.assertTrue(pathlib.Path(xml_filepath).exists())
+        # If this raise the XML file is invalid
+        xml.etree.ElementTree.parse(xml_filepath)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Changes testsuite to:
- Add custom logic to write junit xml output using `--junit`.
- Record test runtime and print them with `--show-timing`.
- Record PID and active tests per PID. Report these info at crash.