### PR TITLE
Add math.nextafter support for nopython mode.

### DIFF
--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -1076,6 +1076,7 @@ The following functions from the :mod:`math` module are supported:
 * :func:`math.log`
 * :func:`math.log10`
 * :func:`math.log1p`
+* :func:`math.nextafter`
 * :func:`math.pow`
 * :func:`math.radians`
 * :func:`math.sin`

--- a/docs/upcoming_changes/9438.new_feature.rst
+++ b/docs/upcoming_changes/9438.new_feature.rst
@@ -1,4 +1,4 @@
 Add math.nextafter support for nopython mode.
-------------------------------------------------
+---------------------------------------------
 
 Support ``math.nextafter`` in nopython mode.

--- a/docs/upcoming_changes/9438.new_feature.rst
+++ b/docs/upcoming_changes/9438.new_feature.rst
@@ -1,0 +1,4 @@
+Add math.nextafter support for nopython mode.
+=============================================
+
+Support ``math.nextafter`` in nopython mode.

--- a/docs/upcoming_changes/9438.new_feature.rst
+++ b/docs/upcoming_changes/9438.new_feature.rst
@@ -1,4 +1,4 @@
 Add math.nextafter support for nopython mode.
-=============================================
+------------------------------------------------
 
 Support ``math.nextafter`` in nopython mode.

--- a/numba/core/typing/mathdecl.py
+++ b/numba/core/typing/mathdecl.py
@@ -1,5 +1,4 @@
 import math
-import sys
 from numba.core import types, utils
 from numba.core.typing.templates import (AttributeTemplate, ConcreteTemplate,
                                          signature, Registry)
@@ -87,15 +86,12 @@ class Math_hypot(ConcreteTemplate):
     ]
 
 
-if sys.hexversion >= 0x03090000:
-    @infer_global(math.nextafter)
-    class Math_nextafter(ConcreteTemplate):
-        cases = [
-            signature(types.float64, types.float64, types.float64),
-            signature(types.float32, types.float32, types.float32),
-            signature(types.float64, types.int64, types.int64),
-            signature(types.float64, types.uint64, types.uint64)
-        ]
+@infer_global(math.nextafter)
+class Math_nextafter(ConcreteTemplate):
+    cases = [
+        signature(types.float64, types.float64, types.float64),
+        signature(types.float32, types.float32, types.float32),
+    ]
 
 
 @infer_global(math.isinf)

--- a/numba/core/typing/mathdecl.py
+++ b/numba/core/typing/mathdecl.py
@@ -1,4 +1,5 @@
 import math
+import sys
 from numba.core import types, utils
 from numba.core.typing.templates import (AttributeTemplate, ConcreteTemplate,
                                          signature, Registry)
@@ -84,6 +85,17 @@ class Math_hypot(ConcreteTemplate):
         signature(types.float32, types.float32, types.float32),
         signature(types.float64, types.float64, types.float64),
     ]
+
+
+if sys.hexversion >= 0x03090000:
+    @infer_global(math.nextafter)
+    class Math_nextafter(ConcreteTemplate):
+        cases = [
+            signature(types.float64, types.float64, types.float64),
+            signature(types.float32, types.float32, types.float32),
+            signature(types.float64, types.int64, types.int64),
+            signature(types.float64, types.uint64, types.uint64)
+        ]
 
 
 @infer_global(math.isinf)

--- a/numba/cpython/mathimpl.py
+++ b/numba/cpython/mathimpl.py
@@ -409,7 +409,6 @@ def pow_impl(context, builder, sig, args):
 @lower(math.nextafter, types.Float, types.Float)
 def nextafter_impl(context, builder, sig, args):
     assert len(args) == 2
-    mod = builder.module
     ty = sig.args[0]
     lty = context.get_value_type(ty)
     func_name = {

--- a/numba/cpython/mathimpl.py
+++ b/numba/cpython/mathimpl.py
@@ -199,8 +199,6 @@ tanh_impl = unary_math_extern(math.tanh, "tanhf", "tanh")
 log2_impl = unary_math_extern(math.log2, "log2f", "log2")
 ceil_impl = unary_math_extern(math.ceil, "ceilf", "ceil", True)
 floor_impl = unary_math_extern(math.floor, "floorf", "floor", True)
-if sys.hexversion >= 0x03090000:
-    nextafter_impl = unary_math_extern(math.nextafter, "nextafterf", "nextafter")
 
 gamma_impl = unary_math_extern(math.gamma, "numba_gammaf", "numba_gamma") # work-around
 sqrt_impl = unary_math_extern(math.sqrt, "sqrtf", "sqrt")
@@ -408,6 +406,13 @@ def pow_impl(context, builder, sig, args):
 
 # -----------------------------------------------------------------------------
 
+@lower(math.nextafter, types.Float, types.Float)
+@lower(math.nextafter, types.Integer, types.Integer)
+def nextafter_impl(context, builder, sig, args):
+    impl = context.get_function(math.nextafter, sig)
+    return impl(builder, args)
+
+# -----------------------------------------------------------------------------
 
 def _unsigned(T):
     """Convert integer to unsigned integer of equivalent width."""

--- a/numba/cpython/mathimpl.py
+++ b/numba/cpython/mathimpl.py
@@ -199,7 +199,8 @@ tanh_impl = unary_math_extern(math.tanh, "tanhf", "tanh")
 log2_impl = unary_math_extern(math.log2, "log2f", "log2")
 ceil_impl = unary_math_extern(math.ceil, "ceilf", "ceil", True)
 floor_impl = unary_math_extern(math.floor, "floorf", "floor", True)
-nextafter_impl = unary_math_extern(math.nextafter, "nextafterf", "nextafter")
+if sys.hexversion >= 0x03090000:
+    nextafter_impl = unary_math_extern(math.nextafter, "nextafterf", "nextafter")
 
 gamma_impl = unary_math_extern(math.gamma, "numba_gammaf", "numba_gamma") # work-around
 sqrt_impl = unary_math_extern(math.sqrt, "sqrtf", "sqrt")

--- a/numba/cpython/mathimpl.py
+++ b/numba/cpython/mathimpl.py
@@ -199,6 +199,7 @@ tanh_impl = unary_math_extern(math.tanh, "tanhf", "tanh")
 log2_impl = unary_math_extern(math.log2, "log2f", "log2")
 ceil_impl = unary_math_extern(math.ceil, "ceilf", "ceil", True)
 floor_impl = unary_math_extern(math.floor, "floorf", "floor", True)
+nextafter_impl = unary_math_extern(math.nextafter, "nextafterf", "nextafter")
 
 gamma_impl = unary_math_extern(math.gamma, "numba_gammaf", "numba_gamma") # work-around
 sqrt_impl = unary_math_extern(math.sqrt, "sqrtf", "sqrt")

--- a/numba/cpython/mathimpl.py
+++ b/numba/cpython/mathimpl.py
@@ -407,10 +407,19 @@ def pow_impl(context, builder, sig, args):
 # -----------------------------------------------------------------------------
 
 @lower(math.nextafter, types.Float, types.Float)
-@lower(math.nextafter, types.Integer, types.Integer)
 def nextafter_impl(context, builder, sig, args):
-    impl = context.get_function(math.nextafter, sig)
-    return impl(builder, args)
+    assert len(args) == 2
+    mod = builder.module
+    ty = sig.args[0]
+    lty = context.get_value_type(ty)
+    func_name = {
+        types.float32: "nextafterf",
+        types.float64: "nextafter"
+        }[ty]
+    fnty = llvmlite.ir.FunctionType(lty, (lty, lty))
+    fn = cgutils.insert_pure_function(builder.module, fnty, name=func_name)
+    res = builder.call(fn, args)
+    return impl_ret_untracked(context, builder, sig.return_type, res)
 
 # -----------------------------------------------------------------------------
 

--- a/numba/tests/test_mathlib.py
+++ b/numba/tests/test_mathlib.py
@@ -119,6 +119,10 @@ def hypot(x, y):
     return math.hypot(x, y)
 
 
+def nextafter(x, y):
+    return math.nextafter(x, y)
+
+
 def degrees(x):
     return math.degrees(x)
 
@@ -427,6 +431,14 @@ class TestMathLib(TestCase):
                 self.assertRaisesRegex(RuntimeWarning,
                                         'overflow encountered in .*scalar',
                                         naive_hypot, val, val)
+
+    def test_nextafter(self):
+        pyfunc = nextafter
+        x_types = [types.int64, types.uint64,
+                   types.float32, types.float64]
+        x_values = [0, 0.0, 3, 4, .21, .34]
+        y_values = [x + 2 for x in x_values]
+        self.run_binary(pyfunc, x_types, x_values, y_values)
 
     def test_degrees(self):
         pyfunc = degrees

--- a/numba/tests/test_mathlib.py
+++ b/numba/tests/test_mathlib.py
@@ -434,9 +434,8 @@ class TestMathLib(TestCase):
 
     def test_nextafter(self):
         pyfunc = nextafter
-        x_types = [types.int64, types.uint64,
-                   types.float32, types.float64]
-        x_values = [0, 0.0, 3, 4, .21, .34]
+        x_types = [types.float32, types.float64]
+        x_values = [0.0, .21, .34, 1005382.042, -25.328]
         y_values = [x + 2 for x in x_values]
         self.run_binary(pyfunc, x_types, x_values, y_values)
 

--- a/numba/tests/test_mathlib.py
+++ b/numba/tests/test_mathlib.py
@@ -438,8 +438,16 @@ class TestMathLib(TestCase):
         x_values = [0.0, .21, .34, 1005382.042, -25.328]
         y1_values = [x + 2 for x in x_values]
         y2_values = [x - 2 for x in x_values]
+
         self.run_binary(pyfunc, x_types, x_values, y1_values)
         self.run_binary(pyfunc, x_types, x_values, y2_values)
+
+        # Test using pos/neg inf
+        self.run_binary(pyfunc, x_types, [0.0, -.5, .5], [math.inf]*3)
+        self.run_binary(pyfunc, x_types, [0.0, -.5, .5], [-math.inf]*3)
+
+        # if both args to nextafter are equal, then it is returned unchanged.
+        self.run_binary(pyfunc, x_types, x_values, x_values)
 
     def test_degrees(self):
         pyfunc = degrees

--- a/numba/tests/test_mathlib.py
+++ b/numba/tests/test_mathlib.py
@@ -434,7 +434,9 @@ class TestMathLib(TestCase):
 
     def test_nextafter(self):
         pyfunc = nextafter
-        x_types = [types.float32, types.float64]
+        x_types = [types.float32, types.float64,
+                   types.int32, types.int64,
+                   types.uint32, types.uint64]
         x_values = [0.0, .21, .34, 1005382.042, -25.328]
         y1_values = [x + 2 for x in x_values]
         y2_values = [x - 2 for x in x_values]

--- a/numba/tests/test_mathlib.py
+++ b/numba/tests/test_mathlib.py
@@ -436,8 +436,10 @@ class TestMathLib(TestCase):
         pyfunc = nextafter
         x_types = [types.float32, types.float64]
         x_values = [0.0, .21, .34, 1005382.042, -25.328]
-        y_values = [x + 2 for x in x_values]
-        self.run_binary(pyfunc, x_types, x_values, y_values)
+        y1_values = [x + 2 for x in x_values]
+        y2_values = [x - 2 for x in x_values]
+        self.run_binary(pyfunc, x_types, x_values, y1_values)
+        self.run_binary(pyfunc, x_types, x_values, y2_values)
 
     def test_degrees(self):
         pyfunc = degrees


### PR DESCRIPTION
Resolves #9424 

Add nopython support for math.nextafter on supported versions of Python (>=3.9).

Is there a preferred style for checking the version of the interpreter?
```python
if hasattr(math, 'nextafter'):
    ...
# or 
if sys.hexversion >= 0x03090000:
   ...
# or something else?
```