### PR TITLE
Fix `np.searchsorted` regression

### DIFF
--- a/docs/upcoming_changes/9448.performance.rst
+++ b/docs/upcoming_changes/9448.performance.rst
@@ -1,0 +1,5 @@
+Improvement to ``np.searchsorted``
+----------------------------------
+
+Fixed a performance regression introduced in Numba 0.59 which made
+``np.searchsorted`` considerably slower.


### PR DESCRIPTION
Fixes https://github.com/numba/numba/issues/9441

Note for the reviewer: Previous code would allocate an array (`np.array([v])`) when `v` was a scalar. This allocation caused the code to be 4x slower when compared to previous implementation. This fixes this by only allocating an array when `v` is a container (list, tuple, ndarray)

```python
import numba as nb
import numpy as np
import time

n_samples = 10000

segment_len = np.array([10_000] * n_samples)
stop_index = np.cumsum(segment_len, dtype=np.int64)
start_index = np.concatenate(([0], stop_index[:-1]))

upper_limit = 1000.0
lower_limit = 0.0

intensities = []
for i in range(n_samples):
    intensities.append(
        sorted(
            np.random.uniform(lower_limit, upper_limit, size=segment_len[i]).astype(np.int64)
        )
    )

intensities = np.concatenate(intensities)
search_values = np.random.uniform(lower_limit, upper_limit, size=n_samples).astype(np.int64)

@nb.njit(parallel=False, fastmath=True)
def test_np_search(search_values, intensities, start_index, stop_index):
    y = 0
    for i in range(n_samples):
        for search_value in search_values:
            y += np.searchsorted(intensities[start_index[i]:stop_index[i]], search_value, "left")

    return y

test_np_search(search_values, intensities, start_index, stop_index)

start = time.time()
test_np_search(search_values, intensities, start_index, stop_index)
end = time.time()

print(end - start)
```

Numba 0.58: 3.0s
Numba 0.59: 12s
This patch: 3.3s