### PR TITLE
Don't attempt to register overloads that aren't for this target in `BaseContext` and related fixes

### DIFF
--- a/numba/core/errors.py
+++ b/numba/core/errors.py
@@ -720,6 +720,12 @@ class InternalTargetMismatchError(InternalError):
         super().__init__(msg)
 
 
+class NonexistentTargetError(InternalError):
+    """For signalling that a target that does not exist was requested.
+    """
+    pass
+
+
 class RequireLiteralValue(TypingError):
     """
     For signalling that a function's typing requires a constant value for

--- a/numba/core/extending.py
+++ b/numba/core/extending.py
@@ -190,7 +190,7 @@ def overload_attribute(typ, attr, **kwargs):
     def decorate(overload_func):
         template = make_overload_attribute_template(
             typ, attr, overload_func,
-            inline=kwargs.get('inline', 'never'),
+            **kwargs
         )
         infer_getattr(template)
         overload(overload_func, **kwargs)(overload_func)

--- a/numba/core/target_extension.py
+++ b/numba/core/target_extension.py
@@ -1,7 +1,8 @@
 from abc import ABC, abstractmethod
 from numba.core.registry import DelayedRegistry, CPUDispatcher
 from numba.core.decorators import jit
-from numba.core.errors import InternalTargetMismatchError, NumbaValueError
+from numba.core.errors import (InternalTargetMismatchError,
+                               NonexistentTargetError)
 from threading import local as tls
 
 
@@ -18,7 +19,7 @@ class _TargetRegistry(DelayedRegistry):
             msg = "No target is registered against '{}', known targets:\n{}"
             known = '\n'.join([f"{k: <{10}} -> {v}"
                                for k, v in target_registry.items()])
-            raise NumbaValueError(msg.format(item, known)) from None
+            raise NonexistentTargetError(msg.format(item, known)) from None
 
 
 # Registry mapping target name strings to Target classes

--- a/numba/core/typing/templates.py
+++ b/numba/core/typing/templates.py
@@ -16,7 +16,6 @@ from numba.core import types, utils, targetconfig
 from numba.core.errors import (
     TypingError,
     InternalError,
-    InternalTargetMismatchError,
 )
 from numba.core.cpu_options import InlineOptions
 
@@ -1096,24 +1095,18 @@ class _OverloadMethodTemplate(_OverloadAttributeTemplate):
         """
         attr = self._attr
 
-        try:
-            registry = self._get_target_registry('method')
-        except InternalTargetMismatchError:
-            # Target mismatch. Do not register attribute lookup here.
-            pass
-        else:
-            lower_builtin = registry.lower
+        registry = self._get_target_registry('method')
 
-            @lower_builtin((self.key, attr), self.key, types.VarArg(types.Any))
-            def method_impl(context, builder, sig, args):
-                typ = sig.args[0]
-                typing_context = context.typing_context
-                fnty = self._get_function_type(typing_context, typ)
-                sig = self._get_signature(typing_context, fnty, sig.args, {})
-                call = context.get_function(fnty, sig)
-                # Link dependent library
-                context.add_linking_libs(getattr(call, 'libs', ()))
-                return call(builder, args)
+        @registry.lower((self.key, attr), self.key, types.VarArg(types.Any))
+        def method_impl(context, builder, sig, args):
+            typ = sig.args[0]
+            typing_context = context.typing_context
+            fnty = self._get_function_type(typing_context, typ)
+            sig = self._get_signature(typing_context, fnty, sig.args, {})
+            call = context.get_function(fnty, sig)
+            # Link dependent library
+            context.add_linking_libs(getattr(call, 'libs', ()))
+            return call(builder, args)
 
     def _resolve(self, typ, attr):
         if self._attr != attr:

--- a/numba/core/typing/templates.py
+++ b/numba/core/typing/templates.py
@@ -1155,7 +1155,7 @@ class _OverloadMethodTemplate(_OverloadAttributeTemplate):
         return types.BoundFunction(MethodTemplate, typ)
 
 
-def make_overload_attribute_template(typ, attr, overload_func, inline,
+def make_overload_attribute_template(typ, attr, overload_func, inline='never',
                                      prefer_literal=False,
                                      base=_OverloadAttributeTemplate,
                                      **kwargs):

--- a/numba/cuda/tests/cudapy/test_overload.py
+++ b/numba/cuda/tests/cudapy/test_overload.py
@@ -1,8 +1,8 @@
 from numba import cuda, njit, types
 from numba.core.errors import TypingError
 from numba.core.extending import overload, overload_attribute
+from numba.core.typing.typeof import typeof
 from numba.cuda.testing import CUDATestCase, skip_on_cudasim, unittest
-from numba.tests.test_extending import mydummy_type, MyDummyType
 import numpy as np
 
 
@@ -297,6 +297,9 @@ class TestOverload(CUDATestCase):
         self.check_overload_cpu(kernel, expected)
 
     def test_overload_attribute_target(self):
+        MyDummy, MyDummyType = self.make_dummy_type()
+        mydummy_type = typeof(MyDummy())
+
         @overload_attribute(MyDummyType, 'cuda_only', target='cuda')
         def ov_dummy_cuda_attr(obj):
             def imp(obj):
@@ -308,7 +311,7 @@ class TestOverload(CUDATestCase):
         # CPU, and that an appropriate typing error is raised
         with self.assertRaisesRegex(TypingError,
                                     "Unknown attribute 'cuda_only'"):
-            @njit(types.void(mydummy_type))
+            @njit(types.int64(mydummy_type))
             def illegal_target_attr_use(x):
                 return x.cuda_only
 

--- a/numba/cuda/tests/cudapy/test_overload.py
+++ b/numba/cuda/tests/cudapy/test_overload.py
@@ -1,7 +1,8 @@
-from numba import cuda, njit
-from numba.core.extending import overload
+from numba import cuda, njit, types
+from numba.core.errors import TypingError
+from numba.core.extending import overload, overload_attribute
 from numba.cuda.testing import CUDATestCase, skip_on_cudasim, unittest
-
+from numba.tests.test_extending import mydummy_type, MyDummyType
 import numpy as np
 
 
@@ -294,6 +295,29 @@ class TestOverload(CUDATestCase):
         # Also check that the CPU overloads are used on the CPU
         expected = GENERIC_TARGET_OL_CALLS_TARGET_OL * GENERIC_TARGET_OL
         self.check_overload_cpu(kernel, expected)
+
+    def test_overload_attribute_target(self):
+        @overload_attribute(MyDummyType, 'cuda_only', target='cuda')
+        def ov_dummy_cuda_attr(obj):
+            def imp(obj):
+                return 42
+
+            return imp
+
+        # Ensure that we cannot use the CUDA target-specific attribute on the
+        # CPU, and that an appropriate typing error is raised
+        with self.assertRaisesRegex(TypingError,
+                                    "Unknown attribute 'cuda_only'"):
+            @njit(types.void(mydummy_type))
+            def illegal_target_attr_use(x):
+                return x.cuda_only
+
+        # Ensure that the CUDA target-specific attribute is usable and works
+        # correctly when the target is CUDA - note eager compilation via
+        # signature
+        @cuda.jit(types.void(types.int64[::1], mydummy_type))
+        def cuda_target_attr_use(res, dummy):
+            res[0] = dummy.cuda_only
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_target_extension.py
+++ b/numba/tests/test_target_extension.py
@@ -520,7 +520,7 @@ class TestTargetHierarchySelection(TestCase):
 
     def test_invalid_target_jit(self):
 
-        with self.assertRaises(errors.NumbaValueError) as raises:
+        with self.assertRaises(errors.NonexistentTargetError) as raises:
             @njit(_target='invalid_silicon')
             def foo():
                 pass
@@ -537,7 +537,7 @@ class TestTargetHierarchySelection(TestCase):
 
         # This is a typing error at present as it fails during typing when the
         # overloads are walked.
-        with self.assertRaises(errors.TypingError) as raises:
+        with self.assertRaises(errors.NonexistentTargetError) as raises:
             @overload(bar, target='invalid_silicon')
             def ol_bar():
                 return lambda : None

--- a/numba/tests/test_target_extension.py
+++ b/numba/tests/test_target_extension.py
@@ -323,8 +323,6 @@ class djit(JitDecorator):
         if "nopython" in self._kwargs:
             topt["nopython"] = True
 
-        topt['target_backend'] = 'dpu'
-
         # It would be easy to specialise the default compilation pipeline for
         # this target here.
         pipeline_class = compiler.Compiler

--- a/numba/tests/test_target_extension.py
+++ b/numba/tests/test_target_extension.py
@@ -33,6 +33,7 @@ from numba.core import callconv
 from numba.core.codegen import CPUCodegen, JITCodeLibrary
 from numba.core.callwrapper import PyCallWrapper
 from numba.core.imputils import RegistryLoader, Registry
+from numba.core.typing.typeof import typeof
 from numba import _dynfunc
 import llvmlite.binding as ll
 from llvmlite import ir as llir
@@ -42,7 +43,6 @@ from numba.core import compiler
 from numba.core.compiler import CompilerBase, DefaultPassBuilder
 from numba.core.compiler_machinery import FunctionPass, register_pass
 from numba.core.typed_passes import PreLowerStripPhis
-from numba.tests.test_extending import mydummy_type, MyDummyType
 
 # Define a new target, this target extends GPU, this places the DPU in the
 # target hierarchy as a type of GPU.
@@ -711,6 +711,9 @@ class TestTargetHierarchySelection(TestCase):
         self.assertIsInstance(r, nrt.MemInfo)
 
     def test_overload_attribute_target(self):
+        MyDummy, MyDummyType = self.make_dummy_type()
+        mydummy_type = typeof(MyDummy())
+
         @overload_attribute(MyDummyType, 'dpu_only', target='dpu')
         def ov_dummy_dpu_attr(obj):
             def imp(obj):
@@ -722,7 +725,7 @@ class TestTargetHierarchySelection(TestCase):
         # CPU, and that an appropriate typing error is raised
         with self.assertRaisesRegex(errors.TypingError,
                                     "Unknown attribute 'dpu_only'"):
-            @njit(types.void(mydummy_type))
+            @njit(types.int64(mydummy_type))
             def illegal_target_attr_use(x):
                 return x.dpu_only
 

--- a/numba/tests/test_target_extension.py
+++ b/numba/tests/test_target_extension.py
@@ -283,6 +283,10 @@ dpu_target = DPUTarget("dpu")
 class DPUDispatcher(Dispatcher):
     targetdescr = dpu_target
 
+    def compile(self, sig):
+        with target_override('dpu'):
+            return super().compile(sig)
+
 
 # Register a dispatcher for the DPU target, a lot of the code uses this
 # internally to work out what to do RE compilation
@@ -318,6 +322,8 @@ class djit(JitDecorator):
         topt = {}
         if "nopython" in self._kwargs:
             topt["nopython"] = True
+
+        topt['target_backend'] = 'dpu'
 
         # It would be easy to specialise the default compilation pipeline for
         # this target here.


### PR DESCRIPTION
Fixes a cascading plethora of issues discovered as a result of looking into #9432. See individual commit messages for details of fixes - the pattern is generally that each fix exposed a new issue, resolved by a subsequent commit.