### PR TITLE
Support datetime types in `isinstance()`

### DIFF
--- a/docs/upcoming_changes/9455.improvement.rst
+++ b/docs/upcoming_changes/9455.improvement.rst
@@ -1,0 +1,5 @@
+Expand ``isinstance()`` support for NumPy datetime types
+--------------------------------------------------------
+
+Adds support of ``numpy.datetime64`` and ``numpy.timedelta64`` types in 
+``isinstance()``.

--- a/numba/cpython/builtins.py
+++ b/numba/cpython/builtins.py
@@ -779,7 +779,7 @@ def ol_isinstance(var, typs):
                         types.Function, types.ClassType, types.UnicodeType,
                         types.ClassInstanceType, types.NoneType, types.Array,
                         types.Boolean, types.Float, types.UnicodeCharSeq,
-                        types.Complex)
+                        types.Complex, types.NPDatetime, types.NPTimedelta,)
     if not isinstance(var_ty, supported_var_ty):
         msg = f'isinstance() does not support variables of type "{var_ty}".'
         raise NumbaTypeError(msg)
@@ -834,6 +834,9 @@ def ol_isinstance(var, typs):
             numba_typ = as_numba_type(key)
             if var_ty == numba_typ:
                 return true_impl
+            elif isinstance(numba_typ, (types.NPDatetime, types.NPTimedelta)):
+                if isinstance(var_ty, type(numba_typ)):
+                    return true_impl
             elif isinstance(numba_typ, types.ClassType) and \
                     isinstance(var_ty, types.ClassInstanceType) and \
                     var_ty.key == numba_typ.instance_type.key:

--- a/numba/tests/test_npdatetime.py
+++ b/numba/tests/test_npdatetime.py
@@ -1112,5 +1112,41 @@ class TestDatetimeArrayOps(TestCase):
         self._test_min_max(np.max, True, True)
 
 
+class TestDatetimeTypeOps(TestCase):
+    def test_isinstance_datetime(self):
+        @njit
+        def is_complex(a):
+            return isinstance(a, complex)
+        @njit
+        def is_datetime(a):
+            return isinstance(a, np.datetime64)
+        @njit
+        def is_timedelta(a):
+            return isinstance(a, np.timedelta64)
+
+        dt_a = np.datetime64(1, 'ns')
+        dt_b = np.datetime64(2, 'ns')
+        td_c = dt_b - dt_a
+
+        def check(jit_func, x):
+            with self.subTest(f'{jit_func.__name__}({type(x).__name__})'):
+                got = jit_func(x)
+                expect = jit_func.py_func(x)
+                self.assertEqual(got, expect)
+
+        fns = [
+            is_complex,
+            is_datetime,
+            is_timedelta,
+        ]
+        args = [
+            dt_a,
+            dt_b,
+            td_c,
+        ]
+        for fn, arg in itertools.product(fns, args):
+            check(fn, arg)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Discovered this as part of debugging #9427, `isinstance()` should support datetime types for either/both arguments in `isinstance()`. 