### PR TITLE
Add  `pinned` and `as_cuda_array` to cudasim mode

### DIFF
--- a/numba/cuda/simulator/cudadrv/devicearray.py
+++ b/numba/cuda/simulator/cudadrv/devicearray.py
@@ -402,13 +402,7 @@ def auto_device(ary, stream=0, copy=True):
     return to_device(ary, stream, copy), True
 
 def as_cuda_array(obj, sync=True):
-    """Does nothing and returns the same input object.
-    
-    Primarily used as a simulated substitue of the real `as_cuda_array`
-    function for testing numba code, when GPU isn't available. 
-    
-    See :ref:`cuda array interface <cuda-array-interface>`.
-    """
+    "Do nothing, and return the same object"
     return obj
 
 

--- a/numba/cuda/simulator/cudadrv/devicearray.py
+++ b/numba/cuda/simulator/cudadrv/devicearray.py
@@ -401,6 +401,16 @@ def auto_device(ary, stream=0, copy=True):
             subok=True)
     return to_device(ary, stream, copy), True
 
+def as_cuda_array(obj, sync=True):
+    """Does nothing and returns the same input object.
+    
+    Primarily used as a simulated substitue of the real `as_cuda_array`
+    function for testing numba code, when GPU isn't available. 
+    
+    See :ref:`cuda array interface <cuda-array-interface>`.
+    """
+    return obj
+
 
 def is_cuda_ndarray(obj):
     "Check if an object is a CUDA ndarray"

--- a/numba/cuda/simulator/cudadrv/devicearray.py
+++ b/numba/cuda/simulator/cudadrv/devicearray.py
@@ -316,7 +316,7 @@ def to_device(ary, stream=0, copy=True, to=None):
 
 
 @contextmanager
-def pinned(arg):
+def pinned(*arylist):
     yield
 
 


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->


I'm working with a small [cuda kernel project](https://github.com/tornikeo/cosine-similarity), and when testing my code with numba sim, I see that `cuda.pinned` has different arglist (single arg, instead of variadic *args) in these two modes for no good reason.

So, here's a small tweak to make it consistent. 