### PR TITLE
Support pep695 type param syntax

### DIFF
--- a/docs/upcoming_changes/9459.bug_fix.rst
+++ b/docs/upcoming_changes/9459.bug_fix.rst
@@ -1,0 +1,6 @@
+Allow use of Python 3.12 PEP-695 type parameter syntax
+------------------------------------------------------
+
+A patch is added to properly parse the PEP 695 syntax. While Numba 
+does not yet take advantage of type parameters, it will no longer erroneously 
+reject functions defined with the new Python 3.12 syntax. 

--- a/numba/core/ir.py
+++ b/numba/core/ir.py
@@ -26,7 +26,7 @@ class Loc(object):
     """Source location
 
     """
-    _defmatcher = re.compile(r'def\s+(\w+)\s*\[.*\]\s*\(.*')
+    _defmatcher = re.compile(r'def\s+(\w+)\s*[\[\(]')
 
     def __init__(self, filename, line, col=None, maybe_decorator=False):
         """ Arguments:
@@ -82,10 +82,11 @@ class Loc(object):
     def _raw_function_name(self):
         defn = self._find_definition()
         if defn:
-            return self._defmatcher.match(defn.strip()).groups()[0]
-        else:
-            # Probably exec(<string>) or REPL.
-            return None
+            m = self._defmatcher.match(defn.strip())
+            if m:
+                return m.groups()[0]
+        # Probably exec(<string>) or REPL.
+        return None
 
     def get_lines(self):
         if self.lines is None:

--- a/numba/core/ir.py
+++ b/numba/core/ir.py
@@ -26,7 +26,7 @@ class Loc(object):
     """Source location
 
     """
-    _defmatcher = re.compile(r'def\s+(\w+)\s*[\[\(]')
+    _defmatcher = re.compile(r'def\s+(\w+)')
 
     def __init__(self, filename, line, col=None, maybe_decorator=False):
         """ Arguments:

--- a/numba/core/ir.py
+++ b/numba/core/ir.py
@@ -26,7 +26,7 @@ class Loc(object):
     """Source location
 
     """
-    _defmatcher = re.compile(r'def\s+(\w+)\(.*')
+    _defmatcher = re.compile(r'def\s+(\w+)\s*\[.*\]\s*\(.*')
 
     def __init__(self, filename, line, col=None, maybe_decorator=False):
         """ Arguments:


### PR DESCRIPTION
Fix #9443. 

Patch simply adjusts regex to accept the syntax. 
This should be considered for 0.59.1 to unbreak support of Python 3.12 only syntax.
