### PR TITLE
Support return `int` rather than always `Optional` in `dct.get(key, default)`

### DIFF
--- a/docs/upcoming_changes/9481.improvement.rst
+++ b/docs/upcoming_changes/9481.improvement.rst
@@ -1,0 +1,4 @@
+Support return `int` rather than always `Optional` in `dct.get(key, default)`
+-----------------------------------------------------------------------------
+
+Supports return `int` rather than always `Optional` in `dct.get(key, default)`.

--- a/numba/tests/test_dicts.py
+++ b/numba/tests/test_dicts.py
@@ -229,5 +229,21 @@ class TestCompiledDict(TestCase):
             str(raises.exception),
         )
 
+    def test_dict_get_with_default_value(self):
+        # Test dict.get() with default value, then use the value as arr index
+        @njit
+        def goo(arr):
+            d = {0: 0, 1: 1}
+            d[0] = 0
+            v1 = d.get(0, 0)
+            arr[v1] = -1
+            v2 = d.get(2, 9)
+            arr[v2] = -2
+            _ = d.get(3)
+            return arr
+
+        arr = np.arange(10)
+        np.testing.assert_array_equal(goo.py_func(arr.copy()), goo(arr.copy()))
+
 if __name__ == '__main__':
     unittest.main()

--- a/numba/typed/dictobject.py
+++ b/numba/typed/dictobject.py
@@ -746,11 +746,14 @@ def impl_get(dct, key, default=None):
     keyty = dct.key_type
     valty = dct.value_type
     _sentry_safe_cast_default(default, valty)
+    use_optional = cgutils.is_nonelike(default)
 
     def impl(dct, key, default=None):
         castedkey = _cast(key, keyty)
         ix, val = _dict_lookup(dct, castedkey, hash(castedkey))
         if ix > DKIX.EMPTY:
+            if not use_optional:
+                val = _nonoptional(val)
             return val
         return default
 


### PR DESCRIPTION
A hacky/flaky way to
fix #9473 

This test case can pass:
```python
import numpy as np
from numba import njit
from numba.core import types
from numba.typed import Dict

@njit
def goo(arr):
    d = Dict.empty(types.int64, value_type=types.int64)
    d[0] = 0
    v1 = d.get(0, 0)
    arr[v1] = -1
    v2 = d.get(2, 9)
    arr[v2] = -2
    v3 = d.get(3)
    return arr, v3

arr = np.arange(10)
print(goo(arr))
```