### PR TITLE
give primitive types a faster key&value compare, copy, and zero methods in TypedDict

### DIFF
--- a/docs/upcoming_changes/9520.improvement.rst
+++ b/docs/upcoming_changes/9520.improvement.rst
@@ -1,0 +1,5 @@
+support primitive types faster compare, copy, and zero methods in dict
+----------------------------------------------------------------------
+
+Support primitive types to have faster key and value compare, copy, and zero
+methods in TypedDict. This is a performance optimization for TypedDict.

--- a/numba/cext/dictobject.c
+++ b/numba/cext/dictobject.c
@@ -451,7 +451,7 @@ value_copy(NB_DictKeys *dk, char *dst, const char *src){
     if ( dk->methods.value_copy ) {
         dk->methods.value_copy(dst, src);
     } else {
-        memcpy(dst, src, dk->key_size);
+        memcpy(dst, src, dk->val_size);
     }
 }
 

--- a/numba/cext/dictobject.c
+++ b/numba/cext/dictobject.c
@@ -433,7 +433,7 @@ value_zero(NB_DictKeys *dk, char *data){
     if ( dk->methods.value_zero ) {
         return dk->methods.value_zero(data);
     } else {
-        memset(data, 0, dk->key_size);
+        memset(data, 0, dk->val_size);
     }
 }
 

--- a/numba/cext/dictobject.c
+++ b/numba/cext/dictobject.c
@@ -455,6 +455,16 @@ value_copy(NB_DictKeys *dk, char *dst, const char *src){
     }
 }
 
+/* Returns -1 for error; 0 for not equal; 1 for equal */
+static int
+key_equal(NB_DictKeys *dk, const char *lhs, const char *rhs) {
+    if ( dk->methods.key_equal ) {
+        return dk->methods.key_equal(lhs, rhs);
+    } else {
+        return memcmp(lhs, rhs, dk->key_size) == 0;
+    }
+}
+
 static char *
 entry_get_key(NB_DictKeys *dk, NB_DictEntry* entry) {
     char * out = entry->keyvalue;
@@ -657,7 +667,7 @@ numba_dict_lookup(NB_Dict *d, const char *key_bytes, Py_hash_t hash, char *oldva
                 int cmp;
 
                 startkey = entry_get_key(dk, ep);
-                cmp = dk->methods.key_equal(startkey, key_bytes);
+                cmp = key_equal(dk, startkey, key_bytes);
                 if (cmp < 0) {
                     // error'ed in comparison
                     memset(oldval_bytes, 0, dk->val_size);

--- a/numba/cext/dictobject.h
+++ b/numba/cext/dictobject.h
@@ -12,15 +12,24 @@ typedef struct {
 
 
 typedef int (*dict_key_comparator_t)(const char *lhs, const char *rhs);
+typedef void (*dict_copy_op_t)(char *dst, const char *src);
+typedef void (*dict_zero_op_t)(char *data);
 typedef void (*dict_refcount_op_t)(const void*);
 
 
 typedef struct {
+    /* these five funcs are for all types */
     dict_key_comparator_t    key_equal;
+    dict_copy_op_t           key_copy;
+    dict_zero_op_t           key_zero;
+    dict_copy_op_t           value_copy;
+    dict_zero_op_t           value_zero;
+    /* if key or value is a container type, then need inc/dec ref */
     dict_refcount_op_t       key_incref;
     dict_refcount_op_t       key_decref;
     dict_refcount_op_t       value_incref;
     dict_refcount_op_t       value_decref;
+
 } type_based_methods_table;
 
 

--- a/numba/core/datamodel/models.py
+++ b/numba/core/datamodel/models.py
@@ -179,9 +179,8 @@ class OmittedArgDataModel(DataModel):
 @register_default(types.Boolean)
 @register_default(types.BooleanLiteral)
 class BooleanModel(DataModel):
-    _bit_type = ir.IntType(1)
+    be_type = _bit_type = ir.IntType(1)
     _byte_type = ir.IntType(8)
-    be_type = ir.IntType(1)
 
     def get_value_type(self):
         return self._bit_type

--- a/numba/core/datamodel/models.py
+++ b/numba/core/datamodel/models.py
@@ -181,6 +181,7 @@ class OmittedArgDataModel(DataModel):
 class BooleanModel(DataModel):
     _bit_type = ir.IntType(1)
     _byte_type = ir.IntType(8)
+    be_type = ir.IntType(1)
 
     def get_value_type(self):
         return self._bit_type

--- a/numba/typed/dictobject.py
+++ b/numba/typed/dictobject.py
@@ -310,7 +310,7 @@ def _dict_set_method_table(typingctx, dp, keyty, valty):
         dm_key = context.data_model_manager[keyty.instance_type]
         if dm_key.contains_nrt_meminfo():
             key_equal = _get_container_equal(
-                context, builder.module, dm_key, "dict_key")
+                context, builder.module, dm_key)
             key_incref, key_decref = _get_incref_decref(
                 context, builder.module, dm_key, "dict_key"
             )
@@ -334,7 +334,6 @@ def _dict_set_method_table(typingctx, dp, keyty, valty):
                 context,
                 builder.module,
                 dm_key,
-                "dict_key",
             )
             key_copy = _get_copy(
                 context,

--- a/numba/typed/dictobject.py
+++ b/numba/typed/dictobject.py
@@ -310,9 +310,9 @@ def _dict_set_method_table(typingctx, dp, keyty, valty):
         dm_key = context.data_model_manager[keyty.instance_type]
         if dm_key.contains_nrt_meminfo():
             key_equal = _get_container_equal(
-                context, builder.module, dm_key)
+                context, builder.module, dm_key, 'dict_key')
             key_incref, key_decref = _get_incref_decref(
-                context, builder.module, dm_key, "dict_key"
+                context, builder.module, dm_key, 'dict_key'
             )
             builder.store(
                 builder.bitcast(key_equal, key_equal_ptr.type.pointee),
@@ -363,7 +363,7 @@ def _dict_set_method_table(typingctx, dp, keyty, valty):
         dm_val = context.data_model_manager[valty.instance_type]
         if dm_val.contains_nrt_meminfo():
             val_incref, val_decref = _get_incref_decref(
-                context, builder.module, dm_val, "dict_value"
+                context, builder.module, dm_val, 'dict_value'
             )
             builder.store(
                 builder.bitcast(val_incref, value_incref_ptr.type.pointee),

--- a/numba/typed/dictobject.py
+++ b/numba/typed/dictobject.py
@@ -324,7 +324,8 @@ def _dict_set_method_table(typingctx, dp, keyty, valty):
                 builder.bitcast(key_decref, key_decref_ptr.type.pointee),
                 key_decref_ptr,
             )
-        else:
+
+        if isinstance(dm_key, models.PrimitiveModel):
             # dm_key is a primitive type, e.g., int64
             # generate key_equal, key_copy, key_zero
             key_equal = _get_primitive_equal(
@@ -371,7 +372,8 @@ def _dict_set_method_table(typingctx, dp, keyty, valty):
                 builder.bitcast(val_decref, value_decref_ptr.type.pointee),
                 value_decref_ptr,
             )
-        else:
+
+        if isinstance(dm_val, models.PrimitiveModel):
             # dm_val doesn't contain meminfo, is a primitive type, e.g., int64
             # generate value_copy, value_zero
             value_copy = _get_copy(

--- a/numba/typed/dictobject.py
+++ b/numba/typed/dictobject.py
@@ -36,7 +36,9 @@ from numba.core import typing
 from numba.typed.typedobjectutils import (_as_bytes, _cast, _nonoptional,
                                           _sentry_safe_cast_default,
                                           _get_incref_decref,
-                                          _get_equal, _container_get_data,)
+                                          _get_equal, _container_get_data,
+                                          _get_primitive_equal,
+                                          _get_copy, _get_zero,)
 
 ll_dict_type = cgutils.voidptr_t
 ll_dictiter_type = cgutils.voidptr_t
@@ -262,46 +264,56 @@ def _dict_new_sized(typingctx, n_keys, keyty, valty):
 
 @intrinsic
 def _dict_set_method_table(typingctx, dp, keyty, valty):
-    """Wrap numba_dict_set_method_table
-    """
+    """Wrap numba_dict_set_method_table"""
     resty = types.void
     sig = resty(dp, keyty, valty)
 
     def codegen(context, builder, sig, args):
-        vtablety = ir.LiteralStructType([
-            ll_voidptr_type,  # equal
-            ll_voidptr_type,  # key incref
-            ll_voidptr_type,  # key decref
-            ll_voidptr_type,  # val incref
-            ll_voidptr_type,  # val decref
-        ])
+        # correspond to type_based_methods_table in dictobject.h
+        vtablety = ir.LiteralStructType(
+            [
+                ll_voidptr_type,  # key equal
+                ll_voidptr_type,  # key copy
+                ll_voidptr_type,  # key zero
+                ll_voidptr_type,  # value copy
+                ll_voidptr_type,  # value zero
+                ll_voidptr_type,  # key incref
+                ll_voidptr_type,  # key decref
+                ll_voidptr_type,  # value incref
+                ll_voidptr_type,  # value decref
+            ]
+        )
         setmethod_fnty = ir.FunctionType(
-            ir.VoidType(),
-            [ll_dict_type, vtablety.as_pointer()]
+            ir.VoidType(), [ll_dict_type, vtablety.as_pointer()]
         )
         setmethod_fn = ir.Function(
             builder.module,
             setmethod_fnty,
-            name='numba_dict_set_method_table',
+            name="numba_dict_set_method_table",
         )
         dp = args[0]
         vtable = cgutils.alloca_once(builder, vtablety, zfill=True)
 
-        # install key incref/decref
+        # install type_based_methods_table
         key_equal_ptr = cgutils.gep_inbounds(builder, vtable, 0, 0)
-        key_incref_ptr = cgutils.gep_inbounds(builder, vtable, 0, 1)
-        key_decref_ptr = cgutils.gep_inbounds(builder, vtable, 0, 2)
-        val_incref_ptr = cgutils.gep_inbounds(builder, vtable, 0, 3)
-        val_decref_ptr = cgutils.gep_inbounds(builder, vtable, 0, 4)
+        key_copy_ptr = cgutils.gep_inbounds(builder, vtable, 0, 1)
+        key_zero_ptr = cgutils.gep_inbounds(builder, vtable, 0, 2)
+        value_copy_ptr = cgutils.gep_inbounds(builder, vtable, 0, 3)
+        value_zero_ptr = cgutils.gep_inbounds(builder, vtable, 0, 4)
+        # install inc/dec refs
+        key_incref_ptr = cgutils.gep_inbounds(builder, vtable, 0, 5)
+        key_decref_ptr = cgutils.gep_inbounds(builder, vtable, 0, 6)
+        value_incref_ptr = cgutils.gep_inbounds(builder, vtable, 0, 7)
+        value_decref_ptr = cgutils.gep_inbounds(builder, vtable, 0, 8)
 
         dm_key = context.data_model_manager[keyty.instance_type]
         if dm_key.contains_nrt_meminfo():
-            equal = _get_equal(context, builder.module, dm_key, 'dict_key')
+            key_equal = _get_equal(context, builder.module, dm_key, "dict_key")
             key_incref, key_decref = _get_incref_decref(
-                context, builder.module, dm_key, 'dict_key'
+                context, builder.module, dm_key, "dict_key"
             )
             builder.store(
-                builder.bitcast(equal, key_equal_ptr.type.pointee),
+                builder.bitcast(key_equal, key_equal_ptr.type.pointee),
                 key_equal_ptr,
             )
             builder.store(
@@ -312,19 +324,67 @@ def _dict_set_method_table(typingctx, dp, keyty, valty):
                 builder.bitcast(key_decref, key_decref_ptr.type.pointee),
                 key_decref_ptr,
             )
+        else:
+            # dm_key is a primitive type, e.g., int64
+            # generate key_equal, key_copy, key_zero
+            key_equal = _get_primitive_equal(
+                context,
+                builder.module,
+                dm_key,
+                "dict_key",
+            )
+            key_copy = _get_copy(
+                context,
+                builder.module,
+                dm_key,
+                "dict_key",
+            )
+            key_zero = _get_zero(
+                context,
+                builder.module,
+                dm_key,
+                "dict_key",
+            )
+            builder.store(
+                builder.bitcast(key_equal, key_equal_ptr.type.pointee),
+                key_equal_ptr,
+            )
+            builder.store(
+                builder.bitcast(key_copy, key_copy_ptr.type.pointee),
+                key_copy_ptr,
+            )
+            builder.store(
+                builder.bitcast(key_zero, key_zero_ptr.type.pointee),
+                key_zero_ptr,
+            )
 
         dm_val = context.data_model_manager[valty.instance_type]
         if dm_val.contains_nrt_meminfo():
             val_incref, val_decref = _get_incref_decref(
-                context, builder.module, dm_val, 'dict_value'
+                context, builder.module, dm_val, "dict_value"
             )
             builder.store(
-                builder.bitcast(val_incref, val_incref_ptr.type.pointee),
-                val_incref_ptr,
+                builder.bitcast(val_incref, value_incref_ptr.type.pointee),
+                value_incref_ptr,
             )
             builder.store(
-                builder.bitcast(val_decref, val_decref_ptr.type.pointee),
-                val_decref_ptr,
+                builder.bitcast(val_decref, value_decref_ptr.type.pointee),
+                value_decref_ptr,
+            )
+        else:
+            # dm_val doesn't contain meminfo, is a primitive type, e.g., int64
+            # generate value_copy, value_zero
+            value_copy = _get_copy(
+                context, builder.module, dm_val, "dict_value")
+            value_zero = _get_zero(
+                context, builder.module, dm_val, "dict_value")
+            builder.store(
+                builder.bitcast(value_copy, value_copy_ptr.type.pointee),
+                value_copy_ptr,
+            )
+            builder.store(
+                builder.bitcast(value_zero, value_zero_ptr.type.pointee),
+                value_zero_ptr,
             )
 
         builder.call(setmethod_fn, [dp, vtable])

--- a/numba/typed/dictobject.py
+++ b/numba/typed/dictobject.py
@@ -36,7 +36,8 @@ from numba.core import typing
 from numba.typed.typedobjectutils import (_as_bytes, _cast, _nonoptional,
                                           _sentry_safe_cast_default,
                                           _get_incref_decref,
-                                          _get_equal, _container_get_data,
+                                          _get_container_equal,
+                                          _container_get_data,
                                           _get_primitive_equal,
                                           _get_copy, _get_zero,)
 
@@ -308,7 +309,8 @@ def _dict_set_method_table(typingctx, dp, keyty, valty):
 
         dm_key = context.data_model_manager[keyty.instance_type]
         if dm_key.contains_nrt_meminfo():
-            key_equal = _get_equal(context, builder.module, dm_key, "dict_key")
+            key_equal = _get_container_equal(
+                context, builder.module, dm_key, "dict_key")
             key_incref, key_decref = _get_incref_decref(
                 context, builder.module, dm_key, "dict_key"
             )

--- a/numba/typed/typedobjectutils.py
+++ b/numba/typed/typedobjectutils.py
@@ -270,8 +270,8 @@ def _get_zero(context, module, datamodel, element_type):
     # this is a zero constant of the right type
     if hasattr(datamodel.fe_type, 'width'):
         width = datamodel.fe_type.width
-    elif hasattr(datamodel.fe_type, 'width'):
-        width = datamodel.fe_type.width
+    elif hasattr(datamodel.be_type, 'width'):
+        width = datamodel.be_type.width
     else:
         raise NumbaTypeError(f"Don't know the width of {datamodel}")
 

--- a/numba/typed/typedobjectutils.py
+++ b/numba/typed/typedobjectutils.py
@@ -149,7 +149,7 @@ def _get_incref_decref(context, module, datamodel, container_element_type):
     return incref_fn, decref_fn
 
 
-def _get_container_equal(context, module, datamodel):
+def _get_container_equal(context, module, datamodel, container_element_type):
     assert datamodel.contains_nrt_meminfo()
 
     fe_type = datamodel.fe_type
@@ -172,10 +172,11 @@ def _get_container_equal(context, module, datamodel):
         intres = context.cast(builder, res, types.boolean, types.int32)
         context.call_conv.return_value(builder, intres)
 
+    mangled_name = context.fndesc.mangled_name
     wrapfn = cgutils.get_or_insert_function(
         module,
         wrapfnty,
-        name=f".numba_{context.fndesc.mangled_name}.dict_key_equal.wrap",
+        name=f".numba_{mangled_name}.{container_element_type}_equal.wrap",
     )
     build_wrapper(wrapfn)
 
@@ -183,7 +184,7 @@ def _get_container_equal(context, module, datamodel):
     equal_fn = cgutils.get_or_insert_function(
         module,
         equal_fnty,
-        name=f".numba_{context.fndesc.mangled_name}.dict_key_equal",
+        name=f".numba_{mangled_name}.{container_element_type}_equal",
     )
     builder = ir.IRBuilder(equal_fn.append_basic_block())
     lhs = datamodel.load_from_data_pointer(builder, equal_fn.args[0])

--- a/numba/typed/typedobjectutils.py
+++ b/numba/typed/typedobjectutils.py
@@ -197,3 +197,77 @@ def _get_equal(context, module, datamodel, container_element_type):
     builder.ret(context.get_constant(types.int32, -1))
 
     return equal_fn
+
+
+def _get_primitive_equal(context, module, datamodel, container_element_type):
+    assert not datamodel.contains_nrt_meminfo()
+
+    data_ptr_ty = ir.IntType(8).as_pointer()
+    equal_fnty = ir.FunctionType(ir.IntType(32), [data_ptr_ty, data_ptr_ty])
+    equal_fn = cgutils.get_or_insert_function(
+        module,
+        equal_fnty,
+        name='.numba_{}.{}_equal'.format(context.fndesc.mangled_name,
+                                         container_element_type),
+    )
+    builder = ir.IRBuilder(equal_fn.append_basic_block())
+    lhs_ptr = builder.bitcast(equal_fn.args[0], datamodel.be_type.as_pointer())
+    lhs = builder.load(lhs_ptr)
+    rhs_ptr = builder.bitcast(equal_fn.args[1], datamodel.be_type.as_pointer())
+    rhs = builder.load(rhs_ptr)
+    if datamodel.fe_type.signed:
+        res = builder.icmp_signed('==', lhs, rhs)
+    else:
+        res = builder.icmp_unsigned('==', lhs, rhs)
+    with builder.if_else(res) as (then, orelse):
+        with then:
+            builder.ret(context.get_constant(types.int32, 1))
+        with orelse:
+            builder.ret(context.get_constant(types.int32, 0))
+
+    builder.ret(context.get_constant(types.int32, -1))
+
+    return equal_fn
+
+
+def _get_copy(context, module, datamodel, element_type):
+    # this is a char * ptr
+    data_ptr_ty = ir.IntType(8).as_pointer()
+    copy_fnty = ir.FunctionType(ir.VoidType(), [data_ptr_ty, data_ptr_ty])
+    copy_fn = cgutils.get_or_insert_function(
+        module,
+        copy_fnty,
+        '.numba_{}.{}_copy'.format(context.fndesc.mangled_name, element_type),
+    )
+    builder = ir.IRBuilder(copy_fn.append_basic_block())
+    # this is a pointer to the right type
+    casted_dst_ptr = builder.bitcast(
+        copy_fn.args[0], datamodel.be_type.as_pointer())
+    casted_src_ptr = builder.bitcast(
+        copy_fn.args[1], datamodel.be_type.as_pointer())
+    # this is a zero constant of the right type
+    src_value = builder.load(casted_src_ptr)
+    builder.store(src_value, casted_dst_ptr)
+    builder.ret_void()
+    return copy_fn
+
+
+def _get_zero(context, module, datamodel, element_type):
+    # this is a char * ptr
+    data_ptr_ty = ir.IntType(8).as_pointer()
+    zero_fnty = ir.FunctionType(ir.VoidType(), [data_ptr_ty])
+    zero_fn = cgutils.get_or_insert_function(
+        module,
+        zero_fnty,
+        '.numba_{}.{}_zero'.format(context.fndesc.mangled_name,
+                                   element_type),
+    )
+    builder = ir.IRBuilder(zero_fn.append_basic_block())
+    # this is a pointer to the right type
+    casted_data_ptr = builder.bitcast(
+        zero_fn.args[0], datamodel.be_type.as_pointer())
+    # this is a zero constant of the right type
+    zero_constant = ir.IntType(datamodel.be_type.width)(0)
+    builder.store(zero_constant, casted_data_ptr)
+    builder.ret_void()
+    return zero_fn

--- a/numba/typed/typedobjectutils.py
+++ b/numba/typed/typedobjectutils.py
@@ -221,11 +221,11 @@ def _get_primitive_equal(context, module, datamodel, element_type):
         res = builder.icmp_unsigned('==', lhs, rhs)
     with builder.if_else(res) as (then, orelse):
         with then:
-            builder.ret(context.get_constant(types.int32, 1))
+            builder.ret(context.get_constant_generic(builder, types.int32, 1))
         with orelse:
-            builder.ret(context.get_constant(types.int32, 0))
+            builder.ret(context.get_constant_generic(builder, types.int32, 0))
 
-    builder.ret(context.get_constant(types.int32, -1))
+    builder.ret(context.get_constant_generic(builder, types.int32, -1))
 
     return equal_fn
 

--- a/numba/typed/typedobjectutils.py
+++ b/numba/typed/typedobjectutils.py
@@ -206,8 +206,7 @@ def _get_primitive_equal(context, module, datamodel, func_name_suffix):
     equal_fn = cgutils.get_or_insert_function(
         module,
         equal_fnty,
-        name='.numba_{}.{}_equal'.format(
-            context.fndesc.mangled_name, func_name_suffix),
+        name=f".numba_{context.fndesc.mangled_name}.{func_name_suffix}_equal",
     )
 
     # populate the body of equal_fn
@@ -240,8 +239,7 @@ def _get_copy(context, module, datamodel, func_name_suffix):
     copy_fn = cgutils.get_or_insert_function(
         module,
         copy_fnty,
-        '.numba_{}.{}_copy'.format(context.fndesc.mangled_name,
-                                   func_name_suffix),
+        name=f".numba_{context.fndesc.mangled_name}.{func_name_suffix}_copy",
     )
 
     # populate the body of copy_fn
@@ -264,8 +262,7 @@ def _get_zero(context, module, datamodel, func_name_suffix):
     zero_fn = cgutils.get_or_insert_function(
         module,
         zero_fnty,
-        '.numba_{}.{}_zero'.format(context.fndesc.mangled_name,
-                                   func_name_suffix),
+        name=f".numba_{context.fndesc.mangled_name}.{func_name_suffix}_zero",
     )
 
     # populate the body of zero_fn

--- a/numba/typed/typedobjectutils.py
+++ b/numba/typed/typedobjectutils.py
@@ -10,8 +10,7 @@ from numba.core import typing
 from numba.core.registry import cpu_target
 from numba.core.typeconv import Conversion
 from numba.core.extending import intrinsic
-from numba.core.errors import (NumbaTypeError, TypingError,
-                               NumbaTypeSafetyWarning)
+from numba.core.errors import TypingError, NumbaTypeSafetyWarning
 
 
 def _as_bytes(builder, ptr):
@@ -268,14 +267,8 @@ def _get_zero(context, module, datamodel, element_type):
     casted_data_ptr = builder.bitcast(
         zero_fn.args[0], datamodel.be_type.as_pointer())
     # this is a zero constant of the right type
-    if hasattr(datamodel.fe_type, 'width'):
-        width = datamodel.fe_type.width
-    elif hasattr(datamodel.be_type, 'width'):
-        width = datamodel.be_type.width
-    else:
-        raise NumbaTypeError(f"Don't know the width of {datamodel}")
-
-    zero_constant = ir.IntType(width)(0)
+    zero_constant = context.get_constant_generic(
+        builder, datamodel.fe_type, 0)
     builder.store(zero_constant, casted_data_ptr)
     builder.ret_void()
     return zero_fn

--- a/numba/typed/typedobjectutils.py
+++ b/numba/typed/typedobjectutils.py
@@ -199,7 +199,7 @@ def _get_equal(context, module, datamodel, container_element_type):
     return equal_fn
 
 
-def _get_primitive_equal(context, module, datamodel, container_element_type):
+def _get_primitive_equal(context, module, datamodel, element_type):
     assert not datamodel.contains_nrt_meminfo()
 
     data_ptr_ty = ir.IntType(8).as_pointer()
@@ -207,8 +207,8 @@ def _get_primitive_equal(context, module, datamodel, container_element_type):
     equal_fn = cgutils.get_or_insert_function(
         module,
         equal_fnty,
-        name='.numba_{}.{}_equal'.format(context.fndesc.mangled_name,
-                                         container_element_type),
+        name='.numba_{}.{}_equal'.format(
+            context.fndesc.mangled_name, element_type),
     )
     builder = ir.IRBuilder(equal_fn.append_basic_block())
     lhs_ptr = builder.bitcast(equal_fn.args[0], datamodel.be_type.as_pointer())


### PR DESCRIPTION
fixes #9519 