### PR TITLE
Introduce `context.call_overload` and raise dynamic exception in `guard_match_core_dims`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -69,7 +69,6 @@ exclude =
     numba/core/options.py
     numba/cpython/printimpl.py
     numba/cpython/cmathimpl.py
-    numba/cpython/tupleobj.py
     numba/cpython/mathimpl.py
     numba/core/registry.py
     numba/core/imputils.py

--- a/.flake8
+++ b/.flake8
@@ -70,6 +70,7 @@ exclude =
     numba/cpython/printimpl.py
     numba/cpython/cmathimpl.py
     numba/cpython/mathimpl.py
+    numba/cpython/tupleobj.py
     numba/core/registry.py
     numba/core/imputils.py
     numba/cpython/builtins.py

--- a/docs/upcoming_changes/9524.new_feature.rst
+++ b/docs/upcoming_changes/9524.new_feature.rst
@@ -1,6 +1,5 @@
-Introduce ``context.call_overload`` and update exc message raised in gufunc
----------------------------------------------------------------------------
+Introduce ``context.call_overload`` and update the exception message raised in ``@guvectorize``
+-----------------------------------------------------------------------------------------------
 
-Previously, ``guard_match_core_dim`` would raise a generic exception message.
-With the usage of ``context.call_overload``, it can raise a dynamic exception
-with a meaningful message.
+Previously, ``@guvectorize`` would raise a generic exception message. Now, the
+exception is raised with a meaningful message.

--- a/docs/upcoming_changes/9524.new_feature.rst
+++ b/docs/upcoming_changes/9524.new_feature.rst
@@ -1,0 +1,6 @@
+Introduce ``context.call_overload`` and update exc message raised in gufunc
+---------------------------------------------------------------------------
+
+Previously, ``guard_match_core_dim`` would raise a generic exception message.
+With the usage of ``context.call_overload``, it can raise a dynamic exception
+with a meaningful message.

--- a/numba/core/base.py
+++ b/numba/core/base.py
@@ -908,6 +908,9 @@ class BaseContext(object):
         """
         Like compile_internal but for overloads
         """
+        # For functions defined in an inner scope, Numba needs to refresh the
+        # typing context to add new definitions
+        self.typing_context.refresh()
         fnty = self.typing_context.resolve_value_type(impl)
         impl_sig = fnty.get_call_type(self.typing_context, (*sig.args,), {})
         impl = self.get_function(fnty, impl_sig)

--- a/numba/core/base.py
+++ b/numba/core/base.py
@@ -909,9 +909,10 @@ class BaseContext(object):
         Like compile_internal but for overloads
         """
         fnty = self.typing_context.resolve_value_type(impl)
-        sig = fnty.get_call_type(self.typing_context, (*sig.args,), {})
-        impl = self.get_function(fnty, sig)
-        return impl(builder, args)
+        impl_sig = fnty.get_call_type(self.typing_context, (*sig.args,), {})
+        impl = self.get_function(fnty, impl_sig)
+        res = impl(builder, args)
+        return self.cast(builder, res, impl_sig.return_type, sig.return_type)
 
     def call_unresolved(self, builder, name, sig, args):
         """

--- a/numba/core/base.py
+++ b/numba/core/base.py
@@ -904,6 +904,15 @@ class BaseContext(object):
                                                    sig.args, args)
         return status, res
 
+    def call_overload(self, builder, impl, sig, args):
+        """
+        Like compile_internal but for overloads
+        """
+        fnty = self.typing_context.resolve_value_type(impl)
+        sig = fnty.get_call_type(self.typing_context, (*sig.args,), {})
+        impl = self.get_function(fnty, sig)
+        return impl(builder, args)
+
     def call_unresolved(self, builder, name, sig, args):
         """
         Insert a function call to an unresolved symbol with the given *name*.

--- a/numba/cpython/tupleobj.py
+++ b/numba/cpython/tupleobj.py
@@ -410,3 +410,12 @@ def tuple_index(tup, value):
 def in_seq_empty_tuple(x, y):
     if isinstance(x, types.Tuple) and not x.types:
         return lambda x, y: False
+
+
+@overload_method(types.UniTuple, '__str__')
+def ol_tuple_str(tup):
+    if isinstance(tup.dtype, types.Integer):
+        def impl(tup):
+            seq = ", ".join(map(str, tup))
+            return f"({seq})"
+        return impl

--- a/numba/cpython/tupleobj.py
+++ b/numba/cpython/tupleobj.py
@@ -5,11 +5,11 @@ Implementation of tuple objects
 import operator
 
 from numba.core.imputils import (lower_builtin, lower_getattr_generic,
-                                 lower_cast, lower_constant, iternext_impl,
-                                 impl_ret_borrowed, impl_ret_untracked,
-                                 RefType)
+                                    lower_cast, lower_constant, iternext_impl,
+                                    impl_ret_borrowed, impl_ret_untracked,
+                                    RefType)
 from numba.core import typing, types, cgutils
-from numba.core.extending import overload_method, overload
+from numba.core.extending import overload_method, overload, intrinsic
 
 
 @lower_builtin(types.NamedTupleClass, types.VarArg(types.Any))
@@ -26,14 +26,12 @@ def namedtuple_constructor(context, builder, sig, args):
     # The tuple's contents are borrowed
     return impl_ret_borrowed(context, builder, sig.return_type, res)
 
-
 @lower_builtin(operator.add, types.BaseTuple, types.BaseTuple)
 def tuple_add(context, builder, sig, args):
     left, right = [cgutils.unpack_tuple(builder, x) for x in args]
     res = context.make_tuple(builder, sig.return_type, left + right)
     # The tuple's contents are borrowed
     return impl_ret_borrowed(context, builder, sig.return_type, res)
-
 
 def tuple_cmp_ordered(context, builder, op, sig, args):
     tu, tv = sig.args
@@ -43,7 +41,7 @@ def tuple_cmp_ordered(context, builder, op, sig, args):
     for i, (ta, tb) in enumerate(zip(tu.types, tv.types)):
         a = builder.extract_value(u, i)
         b = builder.extract_value(v, i)
-        not_equal = context.generic_compare(builder, operator.ne, (ta, tb), (a, b))  # noqa: E501
+        not_equal = context.generic_compare(builder, operator.ne, (ta, tb), (a, b))
         with builder.if_then(not_equal):
             pred = context.generic_compare(builder, op, (ta, tb), (a, b))
             builder.store(pred, res)
@@ -72,30 +70,25 @@ def tuple_eq(context, builder, sig, args):
         res = builder.and_(res, pred)
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
-
 @lower_builtin(operator.ne, types.BaseTuple, types.BaseTuple)
 def tuple_ne(context, builder, sig, args):
     res = builder.not_(tuple_eq(context, builder, sig, args))
     return impl_ret_untracked(context, builder, sig.return_type, res)
-
 
 @lower_builtin(operator.lt, types.BaseTuple, types.BaseTuple)
 def tuple_lt(context, builder, sig, args):
     res = tuple_cmp_ordered(context, builder, operator.lt, sig, args)
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
-
 @lower_builtin(operator.le, types.BaseTuple, types.BaseTuple)
 def tuple_le(context, builder, sig, args):
     res = tuple_cmp_ordered(context, builder, operator.le, sig, args)
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
-
 @lower_builtin(operator.gt, types.BaseTuple, types.BaseTuple)
 def tuple_gt(context, builder, sig, args):
     res = tuple_cmp_ordered(context, builder, operator.gt, sig, args)
     return impl_ret_untracked(context, builder, sig.return_type, res)
-
 
 @lower_builtin(operator.ge, types.BaseTuple, types.BaseTuple)
 def tuple_ge(context, builder, sig, args):
@@ -103,7 +96,6 @@ def tuple_ge(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 # for hashing see hashing.py
-
 
 @lower_getattr_generic(types.BaseNamedTuple)
 def namedtuple_getattr(context, builder, typ, value, attr):
@@ -127,10 +119,9 @@ def unituple_constant(context, builder, ty, pyval):
         context, builder, ty, cgutils.pack_array(builder, consts),
     )
 
-
 @lower_constant(types.Tuple)
 @lower_constant(types.NamedTuple)
-def unituple_constant_(context, builder, ty, pyval):
+def unituple_constant(context, builder, ty, pyval):
     """
     Create a heterogeneous tuple constant.
     """
@@ -206,7 +197,6 @@ def getitem_literal_idx(tup, idx):
         return None
 
     idx_val = idx.literal_value
-
     def getitem_literal_idx_impl(tup, idx):
         return tup[idx_val]
 
@@ -240,7 +230,7 @@ def getitem_typed(context, builder, sig, args):
 
         with builder.goto_block(bbelse):
             context.call_conv.return_user_exc(builder, IndexError,
-                                              errmsg_oob)
+                                            errmsg_oob)
 
         lrtty = context.get_value_type(sig.return_type)
         voidptrty = context.get_value_type(types.voidptr)
@@ -276,13 +266,13 @@ def getitem_typed(context, builder, sig, args):
                 # prior to store, again, that type inference has permitted it
                 # suggests this is safe.
                 # End Dragon warning...
-                DOCAST = context.typing_context.unify_types(
-                    sig.args[0][i], sig.return_type) == sig.return_type
+                DOCAST = context.typing_context.unify_types(sig.args[0][i],
+                                        sig.return_type) == sig.return_type
                 if DOCAST:
                     value_slot = builder.alloca(lrtty,
                                                 name="TYPED_VALUE_SLOT%s" % i)
-                    casted = context.cast(
-                        builder, value, sig.args[0][i], sig.return_type)
+                    casted = context.cast(builder, value, sig.args[0][i],
+                                        sig.return_type)
                     builder.store(casted, value_slot)
                 else:
                     value_slot = builder.alloca(value.type,
@@ -387,7 +377,7 @@ def static_getitem_tuple(context, builder, sig, args):
 @lower_cast(types.BaseTuple, types.BaseTuple)
 def tuple_to_tuple(context, builder, fromty, toty, val):
     if (isinstance(fromty, types.BaseNamedTuple)
-            or isinstance(toty, types.BaseNamedTuple)):
+        or isinstance(toty, types.BaseNamedTuple)):
         # Disallowed by typing layer
         raise NotImplementedError
 

--- a/numba/cpython/tupleobj.py
+++ b/numba/cpython/tupleobj.py
@@ -5,11 +5,11 @@ Implementation of tuple objects
 import operator
 
 from numba.core.imputils import (lower_builtin, lower_getattr_generic,
-                                    lower_cast, lower_constant, iternext_impl,
-                                    impl_ret_borrowed, impl_ret_untracked,
-                                    RefType)
+                                 lower_cast, lower_constant, iternext_impl,
+                                 impl_ret_borrowed, impl_ret_untracked,
+                                 RefType)
 from numba.core import typing, types, cgutils
-from numba.core.extending import overload_method, overload, intrinsic
+from numba.core.extending import overload_method, overload
 
 
 @lower_builtin(types.NamedTupleClass, types.VarArg(types.Any))
@@ -26,12 +26,14 @@ def namedtuple_constructor(context, builder, sig, args):
     # The tuple's contents are borrowed
     return impl_ret_borrowed(context, builder, sig.return_type, res)
 
+
 @lower_builtin(operator.add, types.BaseTuple, types.BaseTuple)
 def tuple_add(context, builder, sig, args):
     left, right = [cgutils.unpack_tuple(builder, x) for x in args]
     res = context.make_tuple(builder, sig.return_type, left + right)
     # The tuple's contents are borrowed
     return impl_ret_borrowed(context, builder, sig.return_type, res)
+
 
 def tuple_cmp_ordered(context, builder, op, sig, args):
     tu, tv = sig.args
@@ -41,7 +43,7 @@ def tuple_cmp_ordered(context, builder, op, sig, args):
     for i, (ta, tb) in enumerate(zip(tu.types, tv.types)):
         a = builder.extract_value(u, i)
         b = builder.extract_value(v, i)
-        not_equal = context.generic_compare(builder, operator.ne, (ta, tb), (a, b))
+        not_equal = context.generic_compare(builder, operator.ne, (ta, tb), (a, b))  # noqa: E501
         with builder.if_then(not_equal):
             pred = context.generic_compare(builder, op, (ta, tb), (a, b))
             builder.store(pred, res)
@@ -70,25 +72,30 @@ def tuple_eq(context, builder, sig, args):
         res = builder.and_(res, pred)
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
+
 @lower_builtin(operator.ne, types.BaseTuple, types.BaseTuple)
 def tuple_ne(context, builder, sig, args):
     res = builder.not_(tuple_eq(context, builder, sig, args))
     return impl_ret_untracked(context, builder, sig.return_type, res)
+
 
 @lower_builtin(operator.lt, types.BaseTuple, types.BaseTuple)
 def tuple_lt(context, builder, sig, args):
     res = tuple_cmp_ordered(context, builder, operator.lt, sig, args)
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
+
 @lower_builtin(operator.le, types.BaseTuple, types.BaseTuple)
 def tuple_le(context, builder, sig, args):
     res = tuple_cmp_ordered(context, builder, operator.le, sig, args)
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
+
 @lower_builtin(operator.gt, types.BaseTuple, types.BaseTuple)
 def tuple_gt(context, builder, sig, args):
     res = tuple_cmp_ordered(context, builder, operator.gt, sig, args)
     return impl_ret_untracked(context, builder, sig.return_type, res)
+
 
 @lower_builtin(operator.ge, types.BaseTuple, types.BaseTuple)
 def tuple_ge(context, builder, sig, args):
@@ -96,6 +103,7 @@ def tuple_ge(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 # for hashing see hashing.py
+
 
 @lower_getattr_generic(types.BaseNamedTuple)
 def namedtuple_getattr(context, builder, typ, value, attr):
@@ -119,9 +127,10 @@ def unituple_constant(context, builder, ty, pyval):
         context, builder, ty, cgutils.pack_array(builder, consts),
     )
 
+
 @lower_constant(types.Tuple)
 @lower_constant(types.NamedTuple)
-def unituple_constant(context, builder, ty, pyval):
+def unituple_constant_(context, builder, ty, pyval):
     """
     Create a heterogeneous tuple constant.
     """
@@ -197,6 +206,7 @@ def getitem_literal_idx(tup, idx):
         return None
 
     idx_val = idx.literal_value
+
     def getitem_literal_idx_impl(tup, idx):
         return tup[idx_val]
 
@@ -230,7 +240,7 @@ def getitem_typed(context, builder, sig, args):
 
         with builder.goto_block(bbelse):
             context.call_conv.return_user_exc(builder, IndexError,
-                                            errmsg_oob)
+                                              errmsg_oob)
 
         lrtty = context.get_value_type(sig.return_type)
         voidptrty = context.get_value_type(types.voidptr)
@@ -266,13 +276,13 @@ def getitem_typed(context, builder, sig, args):
                 # prior to store, again, that type inference has permitted it
                 # suggests this is safe.
                 # End Dragon warning...
-                DOCAST = context.typing_context.unify_types(sig.args[0][i],
-                                        sig.return_type) == sig.return_type
+                DOCAST = context.typing_context.unify_types(
+                    sig.args[0][i], sig.return_type) == sig.return_type
                 if DOCAST:
                     value_slot = builder.alloca(lrtty,
                                                 name="TYPED_VALUE_SLOT%s" % i)
-                    casted = context.cast(builder, value, sig.args[0][i],
-                                        sig.return_type)
+                    casted = context.cast(
+                        builder, value, sig.args[0][i], sig.return_type)
                     builder.store(casted, value_slot)
                 else:
                     value_slot = builder.alloca(value.type,
@@ -377,7 +387,7 @@ def static_getitem_tuple(context, builder, sig, args):
 @lower_cast(types.BaseTuple, types.BaseTuple)
 def tuple_to_tuple(context, builder, fromty, toty, val):
     if (isinstance(fromty, types.BaseNamedTuple)
-        or isinstance(toty, types.BaseNamedTuple)):
+            or isinstance(toty, types.BaseNamedTuple)):
         # Disallowed by typing layer
         raise NotImplementedError
 

--- a/numba/np/npyimpl.py
+++ b/numba/np/npyimpl.py
@@ -306,7 +306,6 @@ class _ArrayGUHelper(namedtuple('_ArrayHelper', ('context', 'builder',
         )
         tup = (context.make_tuple(builder, sig.args[0], self.shape),
                context.make_tuple(builder, sig.args[1], other.shape),)
-        context.typing_context.refresh()
         context.call_overload(builder, raise_impl, sig, tup)
 
 

--- a/numba/tests/npyufunc/test_gufunc.py
+++ b/numba/tests/npyufunc/test_gufunc.py
@@ -736,9 +736,6 @@ class TestGUVectorizeJit(TestCase):
 
         with self.assertRaises(ValueError) as raises:
             foo(x, y, res)
-        msg = ('operand 0 has a mismatch with operand 1 one of its core '
-               'dimension(s), with bar signature (n),(n) -> () '
-               '(shape (5, 3, 2) is different from (3))')
         self.assertIn(msg, str(raises.exception))
 
     def test_mismatch_inner_dimensions_input_output(self):
@@ -765,9 +762,6 @@ class TestGUVectorizeJit(TestCase):
 
         with self.assertRaises(ValueError) as raises:
             foo(x, y, res)
-        msg = ('operand 0 has a mismatch with operand 2 one of its core '
-               'dimension(s), with bar signature (n),(m) -> (n) '
-               '(shape (5, 3, 2) is different from (5, 3))')
         self.assertIn(msg, str(raises.exception))
 
     def test_mismatch_inner_dimensions_output(self):
@@ -796,9 +790,6 @@ class TestGUVectorizeJit(TestCase):
 
         with self.assertRaises(ValueError) as raises:
             foo(x, y, res, out)
-        msg = ('operand 1 has a mismatch with operand 2 one of its core '
-               'dimension(s), with bar signature (n),(m) -> (m),(m) '
-               '(shape (3) is different from (2))')
         self.assertIn(msg, str(raises.exception))
 
     def test_mismatch_loop_shape(self):

--- a/numba/tests/npyufunc/test_gufunc.py
+++ b/numba/tests/npyufunc/test_gufunc.py
@@ -736,7 +736,9 @@ class TestGUVectorizeJit(TestCase):
 
         with self.assertRaises(ValueError) as raises:
             foo(x, y, res)
-        msg = ('Operand has a mismatch in one of its core dimensions')
+        msg = ('operand 0 has a mismatch with operand 1 one of its core '
+               'dimension(s), with bar signature (n),(n) -> () '
+               '(shape (5, 3, 2) is different from (3))')
         self.assertIn(msg, str(raises.exception))
 
     def test_mismatch_inner_dimensions_input_output(self):
@@ -763,7 +765,9 @@ class TestGUVectorizeJit(TestCase):
 
         with self.assertRaises(ValueError) as raises:
             foo(x, y, res)
-        msg = ('Operand has a mismatch in one of its core dimensions')
+        msg = ('operand 0 has a mismatch with operand 2 one of its core '
+               'dimension(s), with bar signature (n),(m) -> (n) '
+               '(shape (5, 3, 2) is different from (5, 3))')
         self.assertIn(msg, str(raises.exception))
 
     def test_mismatch_inner_dimensions_output(self):
@@ -792,7 +796,9 @@ class TestGUVectorizeJit(TestCase):
 
         with self.assertRaises(ValueError) as raises:
             foo(x, y, res, out)
-        msg = ('Operand has a mismatch in one of its core dimensions')
+        msg = ('operand 1 has a mismatch with operand 2 one of its core '
+               'dimension(s), with bar signature (n),(m) -> (m),(m) '
+               '(shape (3) is different from (2))')
         self.assertIn(msg, str(raises.exception))
 
     def test_mismatch_loop_shape(self):

--- a/numba/tests/test_tuples.py
+++ b/numba/tests/test_tuples.py
@@ -44,6 +44,9 @@ def tuple_slice3(tup):
 def len_usecase(tup):
     return len(tup)
 
+def str_usecase(tup):
+    return str(tup)
+
 def add_usecase(a, b):
     return a + b
 
@@ -209,6 +212,16 @@ class TestTuplePassing(TestCase):
 
 
 class TestOperations(TestCase):
+
+    def test_str(self):
+        pyfunc = str_usecase
+        tups = [
+            (1, 2, 3),
+            (types.int32(1), types.int32(-1)),
+        ]
+        for tup in tups:
+            cfunc = njit(pyfunc)
+            self.assertEqual(cfunc(tup), pyfunc(tup))
 
     def test_len(self):
         pyfunc = len_usecase


### PR DESCRIPTION
PR is separated into four commits:

* 02d0d45: Add `overload_method(UniTuple, '__str__')` and tests
* 0be554f: Add `context.call_overload`
* 2c4324e: Update `guard_match_core_dims` to call an overload that can emit a dynamic exception
* cd14d40: remove `tupleobj.py` from `.flake8` 