### PR TITLE
[WIP] Improve typed dict KeyError traceback

### DIFF
--- a/numba/typed/dictobject.py
+++ b/numba/typed/dictobject.py
@@ -775,7 +775,7 @@ def impl_getitem(d, key):
         castedkey = _cast(key, keyty)
         ix, val = _dict_lookup(d, castedkey, hash(castedkey))
         if ix == DKIX.EMPTY:
-            raise KeyError()
+            raise KeyError(f"Key \"{key}\" of type {keyty} not found in dict")
         elif ix < DKIX.EMPTY:
             raise AssertionError("internal dict error during lookup")
         else:


### PR DESCRIPTION
While coding a parallel implementation with Numba that used typed dict, I had a lot of trouble debugging because the KeyError exception did not return any information. I made a small change in the dictobject.py to return the key value and type on the traceback, and it helped a lot. This commit includes this modification.
However, it would have been better if the traceback pointed to the actual python line where the KeyError occurred, though I don't know if this is possible, or how to do it. I'm creating this PR as WIP in hope I can get some insight on this viability.