### PR TITLE
math.nextafter for cuda

### DIFF
--- a/docs/source/cuda/cudapysupported.rst
+++ b/docs/source/cuda/cudapysupported.rst
@@ -221,6 +221,7 @@ The following functions from the :mod:`math` module are supported:
 * :func:`math.log2`
 * :func:`math.log10`
 * :func:`math.log1p`
+* :func:`math.nextafter`
 * :func:`math.sqrt`
 * :func:`math.remainder`
 * :func:`math.pow`

--- a/docs/upcoming_changes/9541.cuda.rst
+++ b/docs/upcoming_changes/9541.cuda.rst
@@ -1,0 +1,4 @@
+Support math.nextafter in CUDA
+------------------------------
+
+CUDA target now supports ``math.nextafter`` for FP32 and FP64, FP16 still missing.

--- a/numba/cuda/cudamath.py
+++ b/numba/cuda/cudamath.py
@@ -79,6 +79,7 @@ class Math_hypot(ConcreteTemplate):
 
 @infer_global(math.copysign)
 @infer_global(math.fmod)
+@infer_global(math.nextafter)
 class Math_binary(ConcreteTemplate):
     cases = [
         signature(types.float32, types.float32, types.float32),

--- a/numba/cuda/mathimpl.py
+++ b/numba/cuda/mathimpl.py
@@ -60,9 +60,11 @@ binarys += [('pow', 'powf', math.pow)]
 binarys += [('fmod', 'fmodf', math.fmod)]
 binarys += [('hypot', 'hypotf', math.hypot)]
 binarys += [('remainder', 'remainderf', math.remainder)]
+binarys += [('nextafter', 'nextafterf', math.nextafter)]
 
 binarys_fastmath = {}
 binarys_fastmath['powf'] = 'fast_powf'
+binarys_fastmath['nextafterf'] = 'fast_nextafterf'
 
 
 @lower(math.isinf, types.Integer)

--- a/numba/cuda/tests/cudapy/test_math.py
+++ b/numba/cuda/tests/cudapy/test_math.py
@@ -158,9 +158,9 @@ def math_floor(A, B):
     B[i] = math.floor(A[i])
 
 
-def math_nextafter(A, B):
+def math_nextafter(A, B, C):
     i = cuda.grid(1)
-    B[i] = math.nextafter(A[i])
+    C[i] = math.nextafter(A[i], B[i])
 
 
 def math_copysign(A, B, C):

--- a/numba/cuda/tests/cudapy/test_math.py
+++ b/numba/cuda/tests/cudapy/test_math.py
@@ -660,8 +660,8 @@ class TestCudaMath(CUDATestCase):
     #---------------------------------------------------------------------------
     # test_math_nextafter
     def test_math_nextafter(self):
-        self.unary_template_float32(math_nextafter, np.nextafter)
-        self.unary_template_float64(math_nextafter, np.nextafter)
+        self.binary_template_float32(math_nextafter, np.nextafter)
+        self.binary_template_float64(math_nextafter, np.nextafter)
 
     #---------------------------------------------------------------------------
     # test_math_trunc

--- a/numba/cuda/tests/cudapy/test_math.py
+++ b/numba/cuda/tests/cudapy/test_math.py
@@ -398,7 +398,6 @@ class TestCudaMath(CUDATestCase):
         self.unary_template_float16(math_sqrt, np.sqrt)
         self.unary_template_float16(math_ceil, np.ceil)
         self.unary_template_float16(math_floor, np.floor)
-        self.unary_template_float16(math_nextafter, np.next_after)
 
     @skip_on_cudasim("numpy does not support trunc for float16")
     @skip_unless_cc_53

--- a/numba/cuda/tests/cudapy/test_math.py
+++ b/numba/cuda/tests/cudapy/test_math.py
@@ -158,6 +158,11 @@ def math_floor(A, B):
     B[i] = math.floor(A[i])
 
 
+def math_nextafter(A, B):
+    i = cuda.grid(1)
+    B[i] = math.nextafter(A[i])
+
+
 def math_copysign(A, B, C):
     i = cuda.grid(1)
     C[i] = math.copysign(A[i], B[i])
@@ -393,6 +398,7 @@ class TestCudaMath(CUDATestCase):
         self.unary_template_float16(math_sqrt, np.sqrt)
         self.unary_template_float16(math_ceil, np.ceil)
         self.unary_template_float16(math_floor, np.floor)
+        self.unary_template_float16(math_nextafter, np.next_after)
 
     @skip_on_cudasim("numpy does not support trunc for float16")
     @skip_unless_cc_53
@@ -650,6 +656,12 @@ class TestCudaMath(CUDATestCase):
         self.unary_template_float64(math_floor, np.floor)
         self.unary_template_int64(math_floor, np.floor)
         self.unary_template_uint64(math_floor, np.floor)
+
+    #---------------------------------------------------------------------------
+    # test_math_nextafter
+    def test_math_nextafter(self):
+        self.unary_template_float32(math_nextafter, np.nextafter)
+        self.unary_template_float64(math_nextafter, np.nextafter)
 
     #---------------------------------------------------------------------------
     # test_math_trunc


### PR DESCRIPTION
This PR adds support for `math.nextafter` for CUDA. Partially fixes #9435 (no support for `numpy.nextafter`), related to #9424 and #9438.