### PR TITLE
add `emit_excinfo_store_with_md` for all `excinfo`-related `store` instructions

### DIFF
--- a/docs/upcoming_changes/9551.bug_fix.rst
+++ b/docs/upcoming_changes/9551.bug_fix.rst
@@ -1,0 +1,5 @@
+add `emit_excinfo_store_with_md` for all `excinfo`-related `store` instructions
+-------------------------------------------------------------------------------
+
+This bug is introduced between numba upgraded to llvm14 (#8535) and
+added the dynamic exception info feature (#8134).


### PR DESCRIPTION
fixes #9550 

This bug is introduced between numba upgraded to llvm14 (https://github.com/numba/numba/pull/8535) and added the dynamic exception info feature (https://github.com/numba/numba/pull/8134).