### PR TITLE
fix sigabrt in parfors tests

### DIFF
--- a/docs/source/release/0.60.0-notes.rst
+++ b/docs/source/release/0.60.0-notes.rst
@@ -242,6 +242,7 @@ Pull-Requests:
 * PR `#9549 <https://github.com/numba/numba/pull/9549>`_: Make new_style the default error capturing mode (`gmarkall <https://github.com/gmarkall>`_ `sklam <https://github.com/sklam>`_)
 * PR `#9558 <https://github.com/numba/numba/pull/9558>`_: Added 0.60.0 release notes (`kc611 <https://github.com/kc611>`_)
 * PR `#9559 <https://github.com/numba/numba/pull/9559>`_: Update version support table 0.60 (`esc <https://github.com/esc>`)
+* PR `#9568 <https://github.com/numba/numba/pull/9568>`_:  fix sigabrt in parfors tests (`esc <https://github.com/esc>` `stuartarchibald <https://github.com/stuartarchibald>`_)
 
 Authors:
 ~~~~~~~~

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -4444,7 +4444,7 @@ class TestPrangeSpecific(TestPrangeBase):
             return outputs[0][1][0]
 
         N = config.NUMBA_NUM_THREADS + 1
-        self.prange_tester(test_impl, [Dict.empty(key_type=types.int64, value_type=types.float64) for i in range(N)])
+        self.prange_tester(test_impl, [Dict.empty(key_type=types.int64, value_type=types.float64) for i in range(N)], patch_instance=[1])
 
     def test_call_hoisting(self):
         # issue9529
@@ -4458,7 +4458,7 @@ class TestPrangeSpecific(TestPrangeBase):
             return outputs[0][1][0]
 
         N = config.NUMBA_NUM_THREADS + 1
-        self.prange_tester(test_impl, [Dict.empty(key_type=types.int64, value_type=types.float64) for i in range(N)])
+        self.prange_tester(test_impl, [Dict.empty(key_type=types.int64, value_type=types.float64) for i in range(N)], patch_instance=[1])
 
     def test_record_array_setitem(self):
         # issue6704


### PR DESCRIPTION
This fixes a test, where a non-thread safe container is written to during testing

To reproduce on at least `linux-64` and `osx-arm64` (and probably others):

```
NUMBA_THREADING_LAYER=workqueue SUBPROC_TEST=1 ./runtests.py -m 32 numba.tests.test_parfors.TestPrangeSpecific.test_tuple_hoisting
```

On `linux-64`, this can be debugged with `gdb`:

```
(gdb) bt
0  0x00007ffff7c8018b in raise () from /lib/x86_64-linux-gnu/libc.so.6
1  0x00007ffff7c5f859 in abort () from /lib/x86_64-linux-gnu/libc.so.6
2  0x00007ffff7cca3ee in ?? () from /lib/x86_64-linux-gnu/libc.so.6
3  0x00007ffff7cd247c in ?? () from /lib/x86_64-linux-gnu/libc.so.6
4  0x00007ffff7cd412c in ?? () from /lib/x86_64-linux-gnu/libc.so.6
5  0x00007ffff7cd6105 in ?? () from /lib/x86_64-linux-gnu/libc.so.6
6  0x00007ffff7cd82d6 in realloc () from /lib/x86_64-linux-gnu/libc.so.6
7  0x00007fffe706de21 in NRT_Reallocate (ptr=0x224aef0, size=2552489952) at numba/core/runtime/nrt.cpp:539
8  0x00007fffe706dcf6 in NRT_MemInfo_varsize_realloc (mi=0x1fe9580, size=2552489952) at numba/core/runtime/nrt.cpp:498
9  0x00007fffdcabde0d in _3cdynamic_3e::__numba_parfor_gufunc_0x7fffdc60eb20[abi:v19][abi:c8tJTC_2fWQAliW1xhDEoY6EEMEUOEMISPGsAQMVj4QniQ4IXKQEMXwoMGLoQDDVsQR1NHAZtvoQrhyQ_2fKR8sTqKIYOQAmjYgkW7ADge6ERATM1UUQpZoA](Array<unsigned long long, 1, C, mutable, aligned>, list_28Tuple_28DictType_5bint64_2cfloat64_5d_3civ_3dNone_3e_2c_20array_28float64_2c_201d_2c_20C_29_29_29_3civ_3dNone_3e) (sched=...,
   closure____locals______listcomp____v15____v2build__list__0=...) at <string>:4438
10 0x00007fffdcab624e in __gufunc__._ZN13_3cdynamic_3e36__numba_parfor_gufunc_0x7fffdc60eb20B3v19B120c8tJTC_2fWQAliW1xhDEoY6EEMEUOEMISPGsAQMVj4QniQ4IXKQEMXwoMGLoQDDVsQR1NHAZtvoQrhyQ_2fKR8sTqKIYOQAmjYgkW7ADge6ERATM1UUQpZoAE5ArrayIyLi1E1C7mutable7alignedE119list_28Tuple_28DictType_5bint64_2cfloat64_5d_3civ_3dNone_3e_2c_20array_28float64_2c_201d_2c_20C_29_29_29_3civ_3dNone_3e ()
11 0x00007fffdc926a3b in thread_worker (arg=0x1bd49c0) at numba/np/ufunc/workqueue.c:567
12 0x00007ffff7f8f609 in start_thread () from /lib/x86_64-linux-gnu/libpthread.so.0
13 0x00007ffff7d5c293 in clone () from /lib/x86_64-linux-gnu/libc.so.6
```

On `osx-arm64` we can use `lldb`:

```
(lldb) run runtests.py -m 32 numba.tests.test_parfors.TestPrangeSpecific.test_tuple_hoisting
Process 13575 launched: '/Users/esc/miniconda3-arm64/envs/numba_3.9/bin/python3' (arm64)
Parallel: 0. Serial: 1
python3(13575,0x17025b000) malloc: Non-aligned pointer 0x600000256880 being freed (2)
python3(13575,0x17025b000) malloc: *** set a breakpoint in malloc_error_break to debug
Process 13575 stopped
* thread #18, stop reason = signal SIGABRT
    frame #0: 0x000000019c35c704 libsystem_kernel.dylib`__pthread_kill + 8
libsystem_kernel.dylib`:
->  0x19c35c704 <+8>:  b.lo   0x19c35c724               ; <+40>
    0x19c35c708 <+12>: pacibsp
    0x19c35c70c <+16>: stp    x29, x30, [sp, #-0x10]!
    0x19c35c710 <+20>: mov    x29, sp
Target 0: (python3) stopped.
(lldb) bt
* thread #18, stop reason = signal SIGABRT
  * frame #0: 0x000000019c35c704 libsystem_kernel.dylib`__pthread_kill + 8
    frame #1: 0x000000019c393c28 libsystem_pthread.dylib`pthread_kill + 288
    frame #2: 0x000000019c2a1ae8 libsystem_c.dylib`abort + 180
    frame #3: 0x000000019c1c2e28 libsystem_malloc.dylib`malloc_vreport + 908
    frame #4: 0x000000019c1d95d4 libsystem_malloc.dylib`malloc_zone_error + 104
    frame #5: 0x000000019c1ca620 libsystem_malloc.dylib`_szone_free + 628
    frame #6: 0x000000019c1b87f4 libsystem_malloc.dylib`nanov2_realloc + 356
    frame #7: 0x000000019c1b85a4 libsystem_malloc.dylib`malloc_zone_realloc + 112
    frame #8: 0x000000019c1b7110 libsystem_malloc.dylib`realloc + 388
    frame #9: 0x000000013a9ff0f8 _nrt_python.cpython-39-darwin.so`NRT_MemInfo_varsize_realloc + 60
    frame #10: 0x000000013d4f41e0
    frame #11: 0x000000019c393fa8 libsystem_pthread.dylib`_pthread_start + 148
```

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
