### PR TITLE
Gain more vectorization opportunities

### DIFF
--- a/numba/core/codegen.py
+++ b/numba/core/codegen.py
@@ -757,10 +757,14 @@ class CPUCodeLibrary(CodeLibrary):
                     library._get_module_for_linking(), preserve=True,
                 )
 
-        # For Better Vectorization
+        # Two Tactics below For Better Vectorization
+        # 1. change fn.linkage
         for fn in self._final_module.functions:
             if fn.linkage == ll.Linkage.linkonce_odr:
                 fn.linkage = "internal"
+
+        # 2. call _optimize_functions once more
+        self._optimize_functions(self._final_module)
 
         # Optimize the module after all dependences are linked in above,
         # to allow for inlining.

--- a/numba/core/codegen.py
+++ b/numba/core/codegen.py
@@ -757,14 +757,10 @@ class CPUCodeLibrary(CodeLibrary):
                     library._get_module_for_linking(), preserve=True,
                 )
 
-        # Two Tactics below For Better Vectorization
-        # 1. change fn.linkage
+        # For Better Vectorization
         for fn in self._final_module.functions:
             if fn.linkage == ll.Linkage.linkonce_odr:
                 fn.linkage = "internal"
-
-        # 2. call _optimize_functions once more
-        self._optimize_functions(self._final_module)
 
         # Optimize the module after all dependences are linked in above,
         # to allow for inlining.


### PR DESCRIPTION
This PR includes the 2nd idea, which comes from [Discourse: Compilation pipeline, compile time and vectorization](https://numba.discourse.group/t/compilation-pipeline-compile-time-and-vectorization/1716)

Just want to let numba CI test this.

In some cases, this PR can bring more vectorization chances and give users a better performance. 
In my personal test case, the perf benefit is 10~20%.

Known issues:
- [ ] It doesn't work well with `cache=True`, error msg: `'module already added to this engine'`
- [ ] After setting `cache=False`, error msg: `Symbol _ZN5numba2np8arrayobj15_call_allocator... not linked properly'`

Unknown issues:

- [ ] It removes `_mpm_cheap` in `Codegen`, does it have some unknown effect?
- [ ] It removes some specific optimisation passes added for LLVM 11 and 14. Does it have a thing?