### PR TITLE
set annotation as empty in OverloadFunctionTemplate

### DIFF
--- a/docs/upcoming_changes/9572.bug_fix.rst
+++ b/docs/upcoming_changes/9572.bug_fix.rst
@@ -1,0 +1,5 @@
+set annotation as empty in OverloadFunctionTemplate
+---------------------------------------------------
+
+Given numba doesn't use python type hints for now, we can set annotation (i.e.,
+type hints) as empty in `OverloadFunctionTemplate` to avoid `TypingError`.

--- a/numba/core/typing/templates.py
+++ b/numba/core/typing/templates.py
@@ -535,7 +535,8 @@ class _OverloadFunctionTemplate(AbstractTemplate):
             kws = []
             args = []
             pos_arg = None
-            for x in sig.parameters.values():
+            for x_w_annotation in sig.parameters.values():
+                x = x_w_annotation.replace(annotation=utils.pyParameter.empty)
                 if x.default == utils.pyParameter.empty:
                     args.append(x)
                     if x.kind == utils.pyParameter.VAR_POSITIONAL:


### PR DESCRIPTION
fixes #9571 

gentle tag @guilhermeleobas 

Note for reviewers:

- does numba want to leverage python type hints? or have used somewhere?
- I assume numba doesn't care about type hints (i.e., annotation), so I just set it as empty for all parameters.