### PR TITLE
dynamic override of user-defined overload functions/methods

### DIFF
--- a/numba/core/extending.py
+++ b/numba/core/extending.py
@@ -60,7 +60,7 @@ _overload_default_jit_options = {'no_cpython_wrapper': True,
 
 
 def overload(func, jit_options={}, strict=True, inline='never',
-             prefer_literal=False, **kwargs):
+             prefer_literal=False, override=False, **kwargs):
     """
     A decorator marking the decorated function as typing and implementing
     *func* in nopython mode.
@@ -128,7 +128,8 @@ def overload(func, jit_options={}, strict=True, inline='never',
 
     def decorate(overload_func):
         template = make_overload_template(func, overload_func, opts, strict,
-                                          inline, prefer_literal, **kwargs)
+                                          inline, prefer_literal=prefer_literal,
+                                          override=override, **kwargs)
         infer(template)
         if callable(func):
             infer_global(func, types.Function(template))

--- a/numba/core/types/functions.py
+++ b/numba/core/types/functions.py
@@ -269,6 +269,9 @@ class BaseFunction(Callable):
         so as to support more input types.
         """
         if type(other) is type(self) and other.typing_key == self.typing_key:
+            # If len(self.templates) > 1 or len(other.templates) > 1?
+            if len(other.templates) == 1 and other.templates[0].override:
+                return other
             return type(self)(self.templates + other.templates)
 
     def get_impl_key(self, sig):

--- a/numba/core/typing/context.py
+++ b/numba/core/typing/context.py
@@ -493,6 +493,8 @@ class BaseContext(object):
                 if newty is None:
                     raise TypeError("cannot augment %s with %s"
                                     % (existing, gty))
+                # if "foo" in str(gv):
+                #     print(f"# Augmented global {gv} with {gty} to {newty}")
                 self._remove_global(gv)
                 self._insert_global(gv, newty)
 
@@ -524,6 +526,8 @@ class BaseContext(object):
         except TypeError:
             pass
         self._globals[gv] = gty
+        # if "foo" in str(gv):
+        #     print(f"# Inserted global {gv} with {gty}")
 
     def _remove_global(self, gv):
         """
@@ -545,6 +549,9 @@ class BaseContext(object):
     def insert_function(self, ft):
         key = ft.key
         self._functions[key].append(ft)
+        # if "foo" in str(key):
+        #     print(f"# Inserted function {key}"
+        #           f"size={len(self._functions[key])}")
 
     def insert_user_function(self, fn, ft):
         """Insert a user function.

--- a/numba/core/typing/templates.py
+++ b/numba/core/typing/templates.py
@@ -262,6 +262,7 @@ class FunctionTemplate(ABC):
     # non-literals.
     # subclass overide-able
     prefer_literal = False
+    override = False
     # metadata
     metadata = {}
 
@@ -704,11 +705,13 @@ class _OverloadFunctionTemplate(AbstractTemplate):
         cache_key = self.context, tuple(args), tuple(kws.items()), flags
         try:
             impl, args = self._impl_cache[cache_key]
+            # print("# get impl  : impl_cache hit")
             return impl, args
         except KeyError:
             # pass and try outside the scope so as to not have KeyError with a
             # nested addition error in the case the _build_impl fails
             pass
+        # print(f"# build impl: overload_func={self._overload_func}")
         impl, args = self._build_impl(cache_key, args, kws)
         return impl, args
 
@@ -877,7 +880,8 @@ class _OverloadFunctionTemplate(AbstractTemplate):
 
 
 def make_overload_template(func, overload_func, jit_options, strict,
-                           inline, prefer_literal=False, **kwargs):
+                           inline, prefer_literal=False,
+                           override=False, **kwargs):
     """
     Make a template class for function *func* overloaded by *overload_func*.
     Compiler options are passed as a dictionary to *jit_options*.
@@ -889,7 +893,7 @@ def make_overload_template(func, overload_func, jit_options, strict,
                _impl_cache={}, _compiled_overloads={}, _jit_options=jit_options,
                _strict=strict, _inline=staticmethod(InlineOptions(inline)),
                _inline_overloads={}, prefer_literal=prefer_literal,
-               metadata=kwargs)
+               override=override, metadata=kwargs)
     return type(base)(name, (base,), dct)
 
 


### PR DESCRIPTION
A potential way to 
fix #5043 

Notes:

1. add `override` option for `overload` decorator
2. handle this `override` request by modifying the behavior of `Function` type's `argument` method

Test code:
```python
""""""
from numba import njit, types
from numba.extending import overload, overload_method

def foo():
    raise NotImplementedError

@overload(foo, override=False)
def ol_foo0():
    def foo_impl0():
        return 0
    return foo_impl0

@njit
def goo():
    return foo()

print(goo())

@overload(foo, override=True)
def ol_foo1():
    def foo_impl1():
        return 1
    return foo_impl1

@njit
def hoo():
    return foo()

print(hoo())

@overload_method(types.Integer, "ad")
def ol_ad(i):
    def impl(i):
        return i + 1
    return impl

@njit
def joo(i):
    return i.ad()

print(joo(1))

@overload_method(types.Integer, "ad")
def ol_ad2(i):
    def impl2(i):
        return i + 2
    return impl2

@njit
def koo(i):
    return i.ad()

print(koo(1))
```
With the PR, output:
```
0
1
2
3
```
All is wanted.