### PR TITLE
Remove `resolve_argument_type()` from typing context

### DIFF
--- a/numba/core/dispatcher.py
+++ b/numba/core/dispatcher.py
@@ -682,8 +682,6 @@ class _DispatcherBase(_dispatcher.Dispatcher):
         This is called from numba._dispatcher as a fallback if the native code
         cannot decide the type.
         """
-        # Not going through the resolve_argument_type() indirection
-        # can save a couple µs.
         try:
             tp = typeof(val, Purpose.argument)
         except ValueError:

--- a/numba/core/typing/context.py
+++ b/numba/core/typing/context.py
@@ -6,7 +6,6 @@ import threading
 import contextlib
 import operator
 
-import numba
 from numba.core import types, errors
 from numba.core.typeconv import Conversion, rules
 from numba.core.typing import templates
@@ -350,26 +349,6 @@ class BaseContext(object):
             return self.resolve_value_type(attrval)
         except ValueError:
             pass
-
-    def resolve_argument_type(self, val):
-        """
-        Return the numba type of a Python value that is being used
-        as a function argument.  Integer types will all be considered
-        int64, regardless of size.
-
-        ValueError is raised for unsupported types.
-        """
-        try:
-            return typeof(val, Purpose.argument)
-        except ValueError:
-            if numba.cuda.is_cuda_array(val):
-                # There's no need to synchronize on a stream when we're only
-                # determining typing - synchronization happens at launch time,
-                # so eliding sync here is safe.
-                return typeof(numba.cuda.as_cuda_array(val, sync=False),
-                              Purpose.argument)
-            else:
-                raise
 
     def resolve_value_type(self, val):
         """

--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -707,11 +707,11 @@ class CUDADispatcher(Dispatcher, serialize.ReduceMixin):
         Create a new instance of this dispatcher specialized for the given
         *args*.
         '''
-        cc = get_current_device().compute_capability
-        argtypes = tuple(
-            [self.typingctx.resolve_argument_type(a) for a in args])
         if self.specialized:
             raise RuntimeError('Dispatcher already specialized')
+
+        cc = get_current_device().compute_capability
+        argtypes = tuple(self.typeof_pyval(a) for a in args)
 
         specialization = self.specializations.get((cc, argtypes))
         if specialization:


### PR DESCRIPTION
It was only used by the CUDA target, and contained CUDA-specific code in the core of Numba, which was a bit of a violation of the target abstraction.

The CUDA target's `typeof_pyval()` implements the same logic anyway, so we can just reuse that in the CUDA target.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
