### PR TITLE
[RFC] Support for `__array__()`

### DIFF
--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -325,7 +325,10 @@ numba_adapt_ndarray(PyObject *obj, arystruct_t* arystruct) {
     npy_intp *p;
 
     if (!PyArray_Check(obj)) {
-        return -1;
+        obj = PyObject_CallMethod(obj, "__array__", NULL);
+        if (!obj) {
+            return -1;
+        }
     }
 
     ndary = (PyArrayObject*)obj;

--- a/numba/core/dispatcher.py
+++ b/numba/core/dispatcher.py
@@ -687,7 +687,10 @@ class _DispatcherBase(_dispatcher.Dispatcher):
         try:
             tp = typeof(val, Purpose.argument)
         except ValueError:
-            tp = types.pyobject
+            if hasattr(val, '__array__'):
+                tp = typeof(val.__array__(), Purpose.argument)
+            else:
+                tp = types.pyobject
         else:
             if tp is None:
                 tp = types.pyobject

--- a/numba/core/runtime/_nrt_python.c
+++ b/numba/core/runtime/_nrt_python.c
@@ -279,7 +279,10 @@ NRT_adapt_ndarray_from_python(PyObject *obj, arystruct_t* arystruct) {
     void *data;
 
     if (!PyArray_Check(obj)) {
-        return -1;
+        obj = PyObject_CallMethod(obj, "__array__", NULL);
+        if (!obj) {
+            return -1;
+        }
     }
 
     ndary = (PyArrayObject*)obj;

--- a/numba/tests/test_array_func.py
+++ b/numba/tests/test_array_func.py
@@ -1,0 +1,24 @@
+from numba import njit
+from numba.tests.support import TestCase, MemoryLeakMixin
+
+import numpy as np
+
+
+class ArrayWrapper:
+    def __init__(self, wrapped):
+        self.wrapped = wrapped
+
+    def __array__(self):
+        return self.wrapped
+
+
+class TestArrayFunc(MemoryLeakMixin, TestCase):
+    def test_array_func(self):
+        @njit
+        def add(x, y):
+            return x + y
+
+        N = 5
+        x = ArrayWrapper(np.arange(N))
+        y = ArrayWrapper(np.ones(N))
+        np.testing.assert_equal(add(x, y), np.add(x, y))


### PR DESCRIPTION
Pushing this up early to request comments / feedback - I think this is one way to solve rapidsai/cudf#15694, with broad applicability to other use cases - this should allow Numba-jitted functions to be called on anything that has an `__array__()` function, much like CUDA kernels can be called on anything that supports the CUDA Array Interface.

The implementation handles typing and unboxing by falling back to using `__array__()` only if treating the object as an `ndarray` fails - therefore, it should not impact the fastest path through dispatch - the code additions here are only executed in cases where the dispatch would otherwise have failed.

One minimal test case is added to demonstrate the idea. Additional tests I think would be needed:

- Testing with and without NRT enabled, though I'm not sure we still have a way to disable NRT. If we can't disable NRT anymore, then there's some dead code like `numba_adapt_ndarray` that can be deleted.
- Testing with a mix of `__array__()` and `ndarray` arguments.
- Testing that this doesn't cause any errors in reference counting / memory leaks (not that I expect it should, but having a test to prove it would be nice)

cc @brandon-b-miller @AjayThorve