### PR TITLE
Explicitly state that `del` is unsupported

### DIFF
--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -51,6 +51,7 @@ Below is a quick reference for the support level of Python constructs.
 - class definition: ``class`` (except for :ref:`@jitclass <jitclass>`)
 - set, dict and generator comprehensions
 - generator delegation: ``yield from``
+- Deletion with ``del`` statements
 
 Functions
 ---------


### PR DESCRIPTION
In Issue #9590 a user reports that `del` causes an error message referring to illegal IR - I note that we don't explicitly state that `del` is not supported.