### PR TITLE
Fix #9585: Correct exceptions raised by NumPy dtype typing and catch them

### DIFF
--- a/numba/core/dispatcher.py
+++ b/numba/core/dispatcher.py
@@ -405,7 +405,7 @@ class _DispatcherBase(_dispatcher.Dispatcher):
                 val = arg.value if isinstance(arg, OmittedArg) else arg
                 try:
                     tp = typeof(val, Purpose.argument)
-                except ValueError as typeof_exc:
+                except (errors.NumbaValueError, ValueError) as typeof_exc:
                     failed_args.append((i, str(typeof_exc)))
                 else:
                     if tp is None:
@@ -686,7 +686,7 @@ class _DispatcherBase(_dispatcher.Dispatcher):
         # can save a couple µs.
         try:
             tp = typeof(val, Purpose.argument)
-        except ValueError:
+        except (errors.NumbaValueError, ValueError):
             tp = types.pyobject
         else:
             if tp is None:

--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -8,7 +8,7 @@ from numba.core import config, serialize, sigutils, types, typing, utils
 from numba.core.caching import Cache, CacheImpl
 from numba.core.compiler_lock import global_compiler_lock
 from numba.core.dispatcher import Dispatcher
-from numba.core.errors import NumbaPerformanceWarning
+from numba.core.errors import NumbaPerformanceWarning, NumbaValueError
 from numba.core.typing.typeof import Purpose, typeof
 
 from numba.cuda.api import get_current_device
@@ -693,7 +693,7 @@ class CUDADispatcher(Dispatcher, serialize.ReduceMixin):
         # the CUDA Array Interface.
         try:
             return typeof(val, Purpose.argument)
-        except ValueError:
+        except (NumbaValueError, ValueError):
             if cuda.is_cuda_array(val):
                 # When typing, we don't need to synchronize on the array's
                 # stream - this is done when the kernel is launched.

--- a/numba/np/numpy_support.py
+++ b/numba/np/numpy_support.py
@@ -46,14 +46,14 @@ sizeof_unicode_char = np.dtype('U1').itemsize
 def _from_str_dtype(dtype):
     m = re_typestr.match(dtype.str)
     if not m:
-        raise NotImplementedError(dtype)
+        raise errors.NumbaNotImplementedError(dtype)
     groups = m.groups()
     typecode = groups[0]
     if typecode == 'U':
         # unicode
         if dtype.byteorder not in '=|':
-            raise NotImplementedError("Does not support non-native "
-                                      "byteorder")
+            msg = "Does not support non-native byteorder"
+            raise errors.NumbaNotImplementedError(msg)
         count = dtype.itemsize // sizeof_unicode_char
         assert count == int(groups[1]), "Unicode char size mismatch"
         return types.UnicodeCharSeq(count)
@@ -65,13 +65,13 @@ def _from_str_dtype(dtype):
         return types.CharSeq(count)
 
     else:
-        raise NotImplementedError(dtype)
+        raise errors.NumbaNotImplementedError(dtype)
 
 
 def _from_datetime_dtype(dtype):
     m = re_datetimestr.match(dtype.str)
     if not m:
-        raise NotImplementedError(dtype)
+        raise errors.NumbaNotImplementedError(dtype)
     groups = m.groups()
     typecode = groups[0]
     unit = groups[2] or ''
@@ -80,13 +80,13 @@ def _from_datetime_dtype(dtype):
     elif typecode == 'M':
         return types.NPDatetime(unit)
     else:
-        raise NotImplementedError(dtype)
+        raise errors.NumbaNotImplementedError(dtype)
 
 
 def from_dtype(dtype):
     """
     Return a Numba Type instance corresponding to the given Numpy *dtype*.
-    NotImplementedError is raised on unsupported Numpy dtypes.
+    NumbaNotImplementedError is raised on unsupported Numpy dtypes.
     """
     if type(dtype) is type and issubclass(dtype, np.generic):
         dtype = np.dtype(dtype)

--- a/numba/tests/test_npdatetime.py
+++ b/numba/tests/test_npdatetime.py
@@ -1175,6 +1175,15 @@ class TestDatetimeTypeOps(TestCase):
         for fn, arg in itertools.product(fns, args):
             check(fn, arg)
 
+class TestDatetimeIssues(TestCase):
+    @unittest.expectedFailure
+    def test_10y_issue_9585(self):
+        @njit
+        def f(x):
+            return x + 1
+
+        arr = np.array('2010', dtype='datetime64[10Y]')
+        f(arr)
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/tests/test_npdatetime.py
+++ b/numba/tests/test_npdatetime.py
@@ -1175,15 +1175,26 @@ class TestDatetimeTypeOps(TestCase):
         for fn, arg in itertools.product(fns, args):
             check(fn, arg)
 
+
 class TestDatetimeIssues(TestCase):
-    @unittest.expectedFailure
     def test_10y_issue_9585(self):
         @njit
         def f(x):
             return x + 1
 
         arr = np.array('2010', dtype='datetime64[10Y]')
-        f(arr)
+
+        with self.assertRaises(TypingError) as e:
+            f(arr)
+
+        message = e.exception.args[0]
+
+        argument_index = "argument 0"
+        self.assertIn(argument_index, message)
+
+        unsupported_type = "Unsupported array dtype: datetime64[10Y]"
+        self.assertIn(unsupported_type, message)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This should address inconsistencies in the exceptions raised by `numpy_support.from_dtype()` and ensure that we catch its exceptions. I wonder whether we ever need to catch a `ValueError` - perhaps we should only be catching `NumbaValueError` instances - I can't quite remember what rules to expect / follow for this.

Waiting for CI in case this creates / turns up other issues.