### PR TITLE
Added inline_closurecall as an import during registry loading

### DIFF
--- a/numba/core/cpu.py
+++ b/numba/core/cpu.py
@@ -71,7 +71,7 @@ class CPUContext(BaseContext):
                                    listobj, numbers, rangeobj, # noqa F401
                                    setobj, slicing, tupleobj, # noqa F401
                                    unicode,) # noqa F401
-        from numba.core import optional # noqa F401
+        from numba.core import optional, inline_closurecall # noqa F401
         from numba.misc import gdb_hook, literal # noqa F401
         from numba.np import linalg, arraymath, arrayobj # noqa F401
         from numba.np.random import generator_core, generator_methods # noqa F401

--- a/numba/tests/test_closure.py
+++ b/numba/tests/test_closure.py
@@ -491,6 +491,17 @@ class TestInlinedClosure(TestCase):
         # so allclose should be sufficient for comparison here.
         np.testing.assert_allclose(consume(), 4 + 1.1)
 
+    @TestCase.run_test_in_subprocess
+    def test_issue_9577(self):
+        @njit
+        def _inner():
+            range_start = 0
+            for _ in range(1):
+                np.array([1 for _ in range(range_start, 7)])
+                range_start = 0
+
+        _inner()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

Fixes: #9577

This PR intends to fix the import issue caused by a `0.60.0rc1` regression introduced in #9437.