### PR TITLE
Disable AVX for nocona

### DIFF
--- a/numba/core/config.py
+++ b/numba/core/config.py
@@ -404,8 +404,8 @@ class _EnvReloader(object):
                 disabled_cpus = {'corei7-avx', 'core-avx-i',
                                  'sandybridge', 'ivybridge'}
                 # Disable known baseline CPU names that virtual machines may
-                # incorrectly report has AVX support.
-                # This can problems with SVML-pass use of AVX512.
+                # incorrectly report as having AVX support.
+                # This can cause problems with the SVML-pass's use of AVX512.
                 # See https://github.com/numba/numba/issues/9582
                 disabled_cpus |= {'nocona'}
                 return cpu_name not in disabled_cpus

--- a/numba/core/config.py
+++ b/numba/core/config.py
@@ -400,9 +400,15 @@ class _EnvReloader(object):
                 # on some CPUs (list at
                 # http://llvm.org/bugs/buglist.cgi?quicksearch=avx).
                 # For now we'd rather disable it, since it can pessimize code
-                cpu_name = ll.get_host_cpu_name()
-                return cpu_name not in ('corei7-avx', 'core-avx-i',
-                                        'sandybridge', 'ivybridge')
+                cpu_name = CPU_NAME or ll.get_host_cpu_name()
+                disabled_cpus = {'corei7-avx', 'core-avx-i',
+                                 'sandybridge', 'ivybridge'}
+                # Disable known baseline CPU names that virtual machines may
+                # incorrectly report has AVX support.
+                # This can problems with SVML-pass use of AVX512.
+                # See https://github.com/numba/numba/issues/9582
+                disabled_cpus |= {'nocona'}
+                return cpu_name not in disabled_cpus
 
         ENABLE_AVX = _readenv("NUMBA_ENABLE_AVX", int, avx_default)
 

--- a/numba/tests/test_config.py
+++ b/numba/tests/test_config.py
@@ -137,6 +137,34 @@ class TestConfig(TestCase):
         ex_expected = "----> new_style"
         self.assertIn(ex_expected, out_msg, msg=err_msg)
 
+    @unittest.skipUnless(config.ENABLE_AVX,
+                         "test expects NUMBA_ENABLE_AVX==True")
+    def test_nocona_disables_avx(self):
+        # test with nocona
+        new_env = os.environ.copy()
+        new_env.pop('NUMBA_ENABLE_AVX', None)  # clear NUMBA_ENABLE_AVX
+
+        new_env['NUMBA_CPU_NAME'] = 'nocona'
+        code = ("from numba.core import config\n"
+                "print('---->', bool(config.ENABLE_AVX))\n"
+                "assert not config.ENABLE_AVX")
+        out, err = run_in_subprocess(dedent(code), env=new_env)
+        err_msg = err.decode('utf-8')
+        out_msg = out.decode('utf-8')
+        ex_expected = "----> False"
+        self.assertIn(ex_expected, out_msg, msg=err_msg)
+
+        # test with skylake-avx512
+        new_env['NUMBA_CPU_NAME'] = 'skylake-avx512'
+        code = ("from numba.core import config\n"
+                "print('---->', bool(config.ENABLE_AVX))\n"
+                "assert config.ENABLE_AVX")
+        out, err = run_in_subprocess(dedent(code), env=new_env)
+        err_msg = err.decode('utf-8')
+        out_msg = out.decode('utf-8')
+        ex_expected = "----> True"
+        self.assertIn(ex_expected, out_msg, msg=err_msg)
+
 
 class TestNumbaOptLevel(TestCase):
     # Tests that the setting of NUMBA_OPT influences the "cheap" module pass.


### PR DESCRIPTION
Maybe a fix for #9582

Because VMs may report nocona as the cpu-name but has AVX512 support. This seems to cause the LLVM SVML-pass incorrectly use `<8 x double>` vectors.

---

Update. user confirmed.
Fixes #9582 