### PR TITLE
Optimize functions taking non-contiguous arrays

### DIFF
--- a/numba/core/cgutils.py
+++ b/numba/core/cgutils.py
@@ -960,12 +960,12 @@ def pointer_add(builder, ptr, offset, return_type=None):
     Note the computation is done in bytes, and ignores the width of
     the pointed item type.
     """
-    base_type = ptr.type
+    return_type = ptr.type if return_type is None else return_type
     arrayi8 = builder.bitcast(ptr, int8_t.as_pointer())
     if isinstance(offset, int):
         offset = intp_t(offset)
     offsetted = builder.gep(arrayi8, [offset])
-    return builder.bitcast(offsetted, base_type)
+    return builder.bitcast(offsetted, return_type)
 
 
 def memset(builder, ptr, size, value):

--- a/numba/core/cgutils.py
+++ b/numba/core/cgutils.py
@@ -960,11 +960,12 @@ def pointer_add(builder, ptr, offset, return_type=None):
     Note the computation is done in bytes, and ignores the width of
     the pointed item type.
     """
-    intptr = builder.ptrtoint(ptr, intp_t)
+    base_type = ptr.type
+    arrayi8 = builder.bitcast(ptr, int8_t.as_pointer())
     if isinstance(offset, int):
         offset = intp_t(offset)
-    intptr = builder.add(intptr, offset)
-    return builder.inttoptr(intptr, return_type or ptr.type)
+    offsetted = builder.gep(arrayi8, [offset])
+    return builder.bitcast(offsetted, base_type)
 
 
 def memset(builder, ptr, size, value):


### PR DESCRIPTION
... when the caller passes in a contiguous array.

This enables simd-vectorization when the callee takes a "A" layout array and the caller passes in "C" or "F" arrays.


Demo: 

- before notebook: https://gist.github.com/sklam/b86f06a1fb41ab02c185231cd5c12004#file-beforepatch_pr9624-ipynb
- after notebook: https://gist.github.com/sklam/b86f06a1fb41ab02c185231cd5c12004#file-test_pr9624-ipynb