### PR TITLE
Add CUDA target implementation to sysinfo and module

### DIFF
--- a/numba/cuda/__init__.py
+++ b/numba/cuda/__init__.py
@@ -10,6 +10,11 @@ else:
 from numba.cuda.compiler import (compile, compile_for_current_device,
                                  compile_ptx, compile_ptx_for_current_device)
 
+# Are we the numba.cuda built in to upstream Numba, or the out-of-tree
+# NVIDIA-maintained target?
+implementation = "Built-in"
+
+
 def test(*args, **kwargs):
     if not is_available():
         raise cuda_error()

--- a/numba/misc/numba_sysinfo.py
+++ b/numba/misc/numba_sysinfo.py
@@ -55,6 +55,7 @@ _python_locale = 'Python Locale'
 _llvmlite_version = 'llvmlite Version'
 _llvm_version = 'LLVM Version'
 # CUDA info
+_cu_target_impl = 'CUDA Target Impl'
 _cu_dev_init = 'CUDA Device Init'
 _cu_drv_ver = 'CUDA Driver Version'
 _cu_rt_ver = 'CUDA Runtime Version'
@@ -333,6 +334,13 @@ def get_sysinfo():
 
     # CUDA information
     try:
+        sys_info[_cu_target_impl] = cu.implementation
+    except AttributeError:
+        # On the offchance an out-of-tree target did not set the
+        # implementation, we can try to continue
+        pass
+
+    try:
         cu.list_devices()[0]  # will a device initialise?
     except Exception as e:
         sys_info[_cu_dev_init] = False
@@ -594,6 +602,7 @@ def display_sysinfo(info=None, sep_pos=45):
         ("LLVM Version", info.get(_llvm_version, '?')),
         ("",),
         ("__CUDA Information__",),
+        ("CUDA Target Implementation", info.get(_cu_target_impl, '?')),
         ("CUDA Device Initialized", info.get(_cu_dev_init, '?')),
         ("CUDA Driver Version", info.get(_cu_drv_ver, '?')),
         ("CUDA Runtime Version", info.get(_cu_rt_ver, '?')),


### PR DESCRIPTION
In preparation for a time when the CUDA target is maintained out of the core Numba tree, this adds the name of the target to the Numba sysinfo. The name for the existing in-tree `numba.cuda` module is "Built-in", whereas an out-of-tree implementation might be called "NVIDIA", for example.

If there is an out-of-tree target in use that does not provide its name, we display `'?'` as the implementation name.

The name is also available programmatically under
`numba.cuda.implementation`.

This should aid in determining the source of problems / where to direct users for further support when an external target is in use.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
