### PR TITLE
Allow numba functions within zip files to be cached

### DIFF
--- a/docs/upcoming_changes/9630.improvement.rst
+++ b/docs/upcoming_changes/9630.improvement.rst
@@ -2,7 +2,7 @@ Allow caching of Numba functions within Zip files
 -------------------------------------------------
 
 This change enables numba functions imported from a file within a zip archive to
-be cached, by recognizing a zip file and using a user-wide cache directory
+be cached, by recognizing a Zip file and using a user-wide cache directory
 for the cache. Previously, numba would fail.
 
 For context, Zip archives are a supported-but-less-common way to distribute

--- a/docs/upcoming_changes/9630.improvement.rst
+++ b/docs/upcoming_changes/9630.improvement.rst
@@ -1,7 +1,7 @@
 Allow caching of Numba functions within Zip files
 -------------------------------------------------
 
-This change enables numba functions imported from a file within a zip archive to
+This change enables Numba functions imported from a file within a Zip archive to
 be cached, by recognizing a Zip file and using a user-wide cache directory
 for the cache. Previously, Numba would fail.
 

--- a/docs/upcoming_changes/9630.improvement.rst
+++ b/docs/upcoming_changes/9630.improvement.rst
@@ -1,4 +1,4 @@
-Allow caching of numba functions within zip files
+Allow caching of Numba functions within Zip files
 -------------------------------------------------
 
 This change enables numba functions imported from a file within a zip archive to

--- a/docs/upcoming_changes/9630.improvement.rst
+++ b/docs/upcoming_changes/9630.improvement.rst
@@ -1,0 +1,9 @@
+Allow caching of numba functions within zip files
+-------------------------------------------------
+
+This change enables numba functions imported from a file within a zip archive to
+be cached, by recognizing a zip file and using a user-wide cache directory
+for the cache. Previously, numba would fail.
+
+For context, Zip archives are a supported-but-less-common way to distribute
+python packages, and heavily used in PySpark.

--- a/docs/upcoming_changes/9630.improvement.rst
+++ b/docs/upcoming_changes/9630.improvement.rst
@@ -3,7 +3,7 @@ Allow caching of Numba functions within Zip files
 
 This change enables numba functions imported from a file within a zip archive to
 be cached, by recognizing a Zip file and using a user-wide cache directory
-for the cache. Previously, numba would fail.
+for the cache. Previously, Numba would fail.
 
 For context, Zip archives are a supported-but-less-common way to distribute
 python packages, and heavily used in PySpark.

--- a/docs/upcoming_changes/9630.improvement.rst
+++ b/docs/upcoming_changes/9630.improvement.rst
@@ -6,4 +6,4 @@ be cached, by recognizing a Zip file and using a user-wide cache directory
 for the cache. Previously, Numba would fail.
 
 For context, Zip archives are a supported-but-less-common way to distribute
-python packages, and heavily used in PySpark.
+Python packages, and heavily used in PySpark.

--- a/numba/core/caching.py
+++ b/numba/core/caching.py
@@ -335,16 +335,14 @@ class _ZipCacheLocator(_SourceFileBackedLocatorMixin, _CacheLocator):
                 zip_path = str(Path(*path.parts[: i + 1]))
                 internal_path = str(Path(*path.parts[i + 1 :]))
                 return zip_path, internal_path
-        return None, None
+        raise ValueError("No zip file found in path")
 
     def get_cache_path(self):
         return self._cache_path
 
     def get_source_stamp(self):
-        if self._zip_path:
-            st = os.stat(self._zip_path)
-            return st.st_mtime, st.st_size
-        return super().get_source_stamp()
+        st = os.stat(self._zip_path)
+        return st.st_mtime, st.st_size
 
     @classmethod
     def from_function(cls, py_func, py_file):

--- a/numba/core/caching.py
+++ b/numba/core/caching.py
@@ -17,6 +17,8 @@ import uuid
 import warnings
 
 from numba.misc.appdirs import AppDirs
+import zipfile
+from pathlib import Path
 
 import numba
 from numba.core.errors import NumbaWarning
@@ -308,6 +310,45 @@ class _IPythonCacheLocator(_CacheLocator):
         return self
 
 
+class _ZipCacheLocator(_SourceFileBackedLocatorMixin, _CacheLocator):
+    """
+    A locator for functions backed by Python modules within a zip archive.
+    """
+
+    def __init__(self, py_func, py_file):
+        self._py_file = py_file
+        self._lineno = py_func.__code__.co_firstlineno
+        self._zip_path, self._internal_path = self._split_zip_path(py_file)
+        appdirs = AppDirs(appname="numba", appauthor=False)
+        cache_dir = appdirs.user_cache_dir
+        cache_subpath = self.get_suitable_cache_subpath(py_file)
+        self._cache_path = os.path.join(cache_dir, cache_subpath)
+
+    @staticmethod
+    def _split_zip_path(py_file):
+        path = Path(py_file)
+        for i, part in enumerate(path.parts):
+            if part.endswith(".zip"):
+                zip_path = str(Path(*path.parts[: i + 1]))
+                internal_path = str(Path(*path.parts[i + 1 :]))
+                return zip_path, internal_path
+        return None, None
+
+    def get_cache_path(self):
+        return self._cache_path
+
+    def get_source_stamp(self):
+        if self._zip_path:
+            st = os.stat(self._zip_path)
+            return st.st_mtime, st.st_size
+        return super().get_source_stamp()
+
+    @classmethod
+    def from_function(cls, py_func, py_file):
+        if ".zip" not in py_file:
+            return None
+        return cls(py_func, py_file)
+
 class CacheImpl(metaclass=ABCMeta):
     """
     Provides the core machinery for caching.
@@ -315,10 +356,14 @@ class CacheImpl(metaclass=ABCMeta):
     - control the filename of the cache.
     - provide the cache locator
     """
-    _locator_classes = [_UserProvidedCacheLocator,
-                        _InTreeCacheLocator,
-                        _UserWideCacheLocator,
-                        _IPythonCacheLocator]
+
+    _locator_classes = [
+        _UserProvidedCacheLocator,
+        _InTreeCacheLocator,
+        _UserWideCacheLocator,
+        _IPythonCacheLocator,
+        _ZipCacheLocator,
+    ]
 
     def __init__(self, py_func):
         self._lineno = py_func.__code__.co_firstlineno

--- a/numba/core/caching.py
+++ b/numba/core/caching.py
@@ -319,6 +319,9 @@ class _ZipCacheLocator(_SourceFileBackedLocatorMixin, _CacheLocator):
         self._py_file = py_file
         self._lineno = py_func.__code__.co_firstlineno
         self._zip_path, self._internal_path = self._split_zip_path(py_file)
+        # We use AppDirs at the moment. A more advanced version of this could also allow
+        # a provided `cache_dir`, though that starts to create (cache location x source
+        # type) number of cache classes.
         appdirs = AppDirs(appname="numba", appauthor=False)
         cache_dir = appdirs.user_cache_dir
         cache_subpath = self.get_suitable_cache_subpath(py_file)

--- a/numba/tests/test_caching.py
+++ b/numba/tests/test_caching.py
@@ -748,9 +748,7 @@ def add(x, y):
 
         result1 = test_module.add(2, 3)
         self.assertEqual(result1, 5)
-        self.assertEqual(
-            test_module.add.stats.cache_hits[(type(None), type(None))], 0
-        )
+        self.check_hits(test_module.add, 0, 1)
 
         # Record the initial cache hits
         self.check_hits(test_module.add, 0)

--- a/numba/tests/test_caching.py
+++ b/numba/tests/test_caching.py
@@ -1,4 +1,5 @@
 import inspect
+from pathlib import Path
 import llvmlite.binding as ll
 import multiprocessing
 import numpy as np
@@ -771,7 +772,7 @@ def add(x, y):
 
         locator = _ZipCacheLocator.from_function(mock_func, zip_path)
         self.assertIsNotNone(locator)
-        self.assertEqual(locator._zip_path, "/path/to/archive.zip")
+        self.assertEqual(locator._zip_path, str(Path("/path/to/archive.zip")))
         self.assertEqual(locator._internal_path, "module.py")
 
     def test_zip_locator_non_zip_path(self):

--- a/numba/tests/test_caching.py
+++ b/numba/tests/test_caching.py
@@ -1,18 +1,19 @@
 import importlib
 import inspect
-from pathlib import Path
-import llvmlite.binding as ll
 import multiprocessing
-import numpy as np
 import os
-import stat
 import shutil
+import stat
 import subprocess
 import sys
 import traceback
 import unittest
 import warnings
 import zipfile
+from pathlib import Path
+
+import llvmlite.binding as ll
+import numpy as np
 
 from numba import njit
 from numba.core import codegen
@@ -20,8 +21,8 @@ from numba.core.caching import _UserWideCacheLocator, _ZipCacheLocator
 from numba.core.errors import NumbaWarning
 from numba.parfors import parfor
 from numba.tests.support import (
-    TestCase,
     SerialMixin,
+    TestCase,
     capture_cache_log,
     import_dynamic,
     override_config,
@@ -705,11 +706,11 @@ class TestCache(DispatcherCacheUsecasesTest):
         err = execute_with_input()
         self.assertIn("cache hits = 1", err.strip())
 
+
 class TestCacheZip(DispatcherCacheUsecasesTest):
 
     def setUp(self):
         super().setUp()
-
 
         # Create a simple Python module to be zipped
         mod_content = """
@@ -738,7 +739,8 @@ def add(x, y):
         sys.modules.pop("test_module", None)
 
     def test_zip_caching(self):
-        # (note that `self.import_module()` fails because its checks are incompatible
+        # (note that `self.import_module()` fails because its checks are
+        # incompatible
         # with the zip file, so we just use normal imports here)
 
         # First import and call
@@ -765,8 +767,11 @@ def add(x, y):
         # Check if the cache was hit
         self.check_hits(test_module.add, 1)
 
+
 class TestCacheZipLib(DispatcherCacheUsecasesTest):
-    """ZipCache tests that don't require the setup/teardown from `TestCacheZip`"""
+    """
+    ZipCache tests that don't require the setup/teardown from `TestCacheZip`
+    """
     def test_zip_locator_creation(self):
 
         def mock_func():


### PR DESCRIPTION
Numba doesn't currently allow `.zip` archives to contain numba functions when caching is enabled. This is all but required when using Spark.

This change enables that, by recognizing a zip file and using a user-wide cache directory for the cache. It closes (most of?) https://github.com/numba/numba/issues/4908#issuecomment-1161476166

I'm the maintainer of numbagg, but haven't contributed directly to numba, so please let me know if the contribution needs any work, happy to make changes.

FWIW — hoping to be helpful — I found it not _super_ easy to use the repo — I notice it doesn't use pytest / code formatters / etc. That does make contributions a bit harder for newcomers, though I'm sure it's for good reason...