### PR TITLE
follow the NVVM IR form: not use `.` in global identifier

### DIFF
--- a/docs/upcoming_changes/9642.bug_fix.rst
+++ b/docs/upcoming_changes/9642.bug_fix.rst
@@ -1,0 +1,4 @@
+follow the NVVM IR form: not use . in identifier
+------------------------------------------------
+
+NVVM IR identifier uses a stricter form than LLVM IR.

--- a/numba/core/base.py
+++ b/numba/core/base.py
@@ -1089,7 +1089,7 @@ class BaseContext(object):
         llvoidptr = self.get_value_type(types.voidptr)
         addr = self.get_constant(types.uintp, intaddr).inttoptr(llvoidptr)
         # Use a unique name by embedding the address value
-        symname = 'numba.dynamic.globals.{:x}'.format(intaddr)
+        symname = 'numba_dynamic_globals_{:x}'.format(intaddr)
         gv = cgutils.add_global_variable(mod, llvoidptr, symname)
         # Use linkonce linkage to allow merging with other GV of the same name.
         # And, avoid optimization from assuming its value.


### PR DESCRIPTION
a preprocessing step for #9084 .

NVVM IR identifier uses a stricter form than LLVM IR. 
NVVM IR ID form: https://docs.nvidia.com/cuda/nvvm-ir-spec/index.html#identifiers
LLVM IR ID form: https://llvm.org/docs/LangRef.html#identifiers

This change should not affect numba core or CPU target. 🤞

The real feature implementation (or bug fix?) for #9084 will be created in `numba-cuda` repo separately.