### PR TITLE
Fix pythonapi wrapper for some PyTuple API

### DIFF
--- a/numba/core/pythonapi.py
+++ b/numba/core/pythonapi.py
@@ -772,18 +772,18 @@ class PythonAPI(object):
         return self.builder.call(fn, [tup])
 
     def tuple_new(self, count):
-        fnty = ir.FunctionType(self.pyobj, [ir.IntType(32)])
+        fnty = ir.FunctionType(self.pyobj, [self.py_ssize_t])
         fn = self._get_function(fnty, name='PyTuple_New')
-        return self.builder.call(fn, [self.context.get_constant(types.int32,
-                                                                count)])
+        return self.builder.call(fn, [self.py_ssize_t(count)])
 
     def tuple_setitem(self, tuple_val, index, item):
         """
         Steals a reference to `item`.
         """
-        fnty = ir.FunctionType(ir.IntType(32), [self.pyobj, ir.IntType(32), self.pyobj])
+        fnty = ir.FunctionType(ir.IntType(32),
+                               [self.pyobj, self.py_ssize_t, self.pyobj])
         setitem_fn = self._get_function(fnty, name='PyTuple_SetItem')
-        index = self.context.get_constant(types.int32, index)
+        index = self.py_ssize_t(index)
         self.builder.call(setitem_fn, [tuple_val, index, item])
 
     #


### PR DESCRIPTION
- use py_ssize_t instead of int32

This fixes API mismatch noticed in https://github.com/numba/numba/issues/9640

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
