### PR TITLE
Fix compiler error on RTD

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,7 +2,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: mambaforge-4.10
+    python: miniconda3-3.12-24.1
 sphinx:
   configuration: docs/source/conf.py
 python:

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -14,3 +14,4 @@ dependencies:
   - docutils==0.16
   # The following is needed to fix RTD.
   - conda
+  - gxx_linux-64


### PR DESCRIPTION
Change summary:

- make sure we have specify the compiler.
- use miniconda instead of mambaforge.

The mambaforge problem:

Below is from a [failing build](https://readthedocs.org/api/v2/build/25148758.txt), by printing CC/CXX in sysconfig:
```
SYSCONFIG[CC] gcc -pthread -B /home/docs/checkouts/readthedocs.org/user_builds/numba/conda/9675/compiler_compat
SYSCONFIG[CXX] g++ -pthread -B /home/docs/checkouts/readthedocs.org/user_builds/numba/conda/9675/compiler_compat
```
Despite having `gxx_linux-64` installed, sysconfig is still pointing to `/usr/bin/gcc`. 
