### PR TITLE
Fix C99 `I` not working with NumPy 2.0.1

### DIFF
--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -24,7 +24,7 @@
     #elif defined(_Complex_I)
         #define _complex_float_ctor(r, i) (r + _Complex_I * i)
     #else
-        #error "Lack _Imaginery_I and _Complex_I"
+        #error "Lack _Imaginary_I and _Complex_I"
     #endif 
     #define _complex_double_t complex double
 #endif

--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -19,7 +19,13 @@
 #else
     #include <stdint.h>
     #define _complex_float_t complex float
-    #define _complex_float_ctor(r, i) (r + _Complex_I * i)
+    #if defined(_Imaginary_I)
+        #define _complex_float_ctor(r, i) (r + _Imaginary_I * i)
+    #elif defined(_Complex_I)
+        #define _complex_float_ctor(r, i) (r + _Complex_I * i)
+    #else
+        #error "Lack _Imaginery_I and _Complex_I"
+    #endif 
     #define _complex_double_t complex double
 #endif
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION

--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -19,7 +19,7 @@
 #else
     #include <stdint.h>
     #define _complex_float_t complex float
-    #define _complex_float_ctor(r, i) (r + I * i)
+    #define _complex_float_ctor(r, i) (r + _Complex_I * i)
     #define _complex_double_t complex double
 #endif
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION


### PR DESCRIPTION
Workaround problem with `I`