### PR TITLE
solved higher order function caching

### DIFF
--- a/numba/core/caching.py
+++ b/numba/core/caching.py
@@ -682,6 +682,9 @@ class Cache(_Cache):
         the bytecode for the function and, if the function has a __closure__,
         a hash of the cell_contents.
         """
+        sig = list(sig)
+        sig = ["function" if e.name[:28] == "type(CPUDispatcher(<function" else e for e in sig]
+        sig = tuple(sig)
         codebytes = self._py_func.__code__.co_code
         if self._py_func.__closure__ is not None:
             cvars = tuple([x.cell_contents for x in self._py_func.__closure__])


### PR DESCRIPTION
should solve: #9609

My idea is to define the type `'function'` as argument, similar to `'int64'` or `'float64'` in the signature. I don't think, there is any need to check, if it is the same function, because it may not be inlined. It may be called the same way, like it was just a function directly called, without being forwarded as an argument.
