### PR TITLE
Add `NUMBA_CACHE_OVERRIDE` to force caching on or off

### DIFF
--- a/docs/source/developer/caching.rst
+++ b/docs/source/developer/caching.rst
@@ -18,7 +18,10 @@ cache directory (see :envvar:`NUMBA_CACHE_DIR`). The index of the cache is
 stored in a ``.nbi`` file, with one index per function, and it lists all the
 overloaded signatures compiled for the function. The *object code* is stored in
 files with an ``.nbc`` extension, one file per overload. The data in both files
-is serialized with :mod:`pickle`.
+is serialized with :mod:`pickle`. Caching can be configured on a per-function
+basis using the ``cache`` parameter of the compilation decorators. To override
+this parameter and globally enable or disable caching, use the
+:envvar:`NUMBA_CACHE_OVERRIDE` environment variable.
 
 
 Requirements for Cacheability

--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -470,6 +470,16 @@ Options for the compilation cache.
     Also see :ref:`docs on cache sharing <cache-sharing>` and
     :ref:`docs on cache clearing <cache-clearing>`
 
+.. envvar:: NUMBA_CACHE_OVERRIDE
+
+   Override the `cache` parameter to the Numba compilation decorators
+   (:func:`~numba.jit`, :func:`~numba.njit`, :func:`~numba.cfunc`,
+   :func:`numba.cuda.jit`). If defined, this should be set to one of the
+   following values:
+
+   * ``always``: always cache compiled code.
+   * ``never``: never cache compiled code.
+
 
 .. _numba-envvars-gpu-support:
 

--- a/numba/core/config.py
+++ b/numba/core/config.py
@@ -312,6 +312,10 @@ class _EnvReloader(object):
         # Contains path to the directory
         CACHE_DIR = _readenv("NUMBA_CACHE_DIR", str, "")
 
+        # Override cache= parameter in decorators
+        # Can be set to always (force cache=True) or never (force cache=False)
+        CACHE_OVERRIDE = _readenv("NUMBA_CACHE_OVERRIDE", str, "")
+
         # Enable tracing support
         TRACE = _readenv("NUMBA_TRACE", int, 0)
 

--- a/numba/core/decorators.py
+++ b/numba/core/decorators.py
@@ -221,7 +221,8 @@ def _jit(sigs, locals, target, cache, targetoptions, **dispatcher_args):
         disp = dispatcher(py_func=func, locals=locals,
                           targetoptions=targetoptions,
                           **dispatcher_args)
-        if cache:
+        override = config.CACHE_OVERRIDE.lower()
+        if override == "always" or (cache and override != "never"):
             disp.enable_caching()
         if sigs is not None:
             # Register the Dispatcher to the type inference mechanism,
@@ -270,7 +271,8 @@ def cfunc(sig, locals={}, cache=False, pipeline_class=None, **options):
         if pipeline_class is not None:
             additional_args['pipeline_class'] = pipeline_class
         res = CFunc(func, sig, locals=locals, options=options, **additional_args)
-        if cache:
+        override = config.CACHE_OVERRIDE.lower()
+        if override == "always" or (cache and override != "never"):
             res.enable_caching()
         res.compile()
         return res

--- a/numba/cuda/decorators.py
+++ b/numba/cuda/decorators.py
@@ -116,7 +116,8 @@ def jit(func_or_sig=None, device=False, inline=False, link=[], debug=None,
 
             disp = CUDADispatcher(func, targetoptions=targetoptions)
 
-            if cache:
+            override = config.CACHE_OVERRIDE.lower()
+            if override == "always" or (cache and override != "never"):
                 disp.enable_caching()
 
             for sig in signatures:
@@ -166,7 +167,8 @@ def jit(func_or_sig=None, device=False, inline=False, link=[], debug=None,
                 targetoptions['extensions'] = extensions
                 disp = CUDADispatcher(func_or_sig, targetoptions=targetoptions)
 
-                if cache:
+                override = config.CACHE_OVERRIDE.lower()
+                if override == "always" or (cache and override != "never"):
                     disp.enable_caching()
 
                 return disp

--- a/numba/tests/cache_overrides.py
+++ b/numba/tests/cache_overrides.py
@@ -1,0 +1,70 @@
+"""
+This file will be copied to a temporary directory in order to
+exercise overriding of caching compiled functions.
+
+See test_caching.py (TestCacheOverrides class)
+"""
+
+import sys
+
+from numba import jit, njit, cfunc, double as ndouble
+from numba.tests.support import TestCase
+
+
+@jit(cache=True)
+def add_jit_cached(a, b):
+    return a + b
+
+
+@jit(cache=False)
+def add_jit_notcached(a, b):
+    return a + b
+
+
+@njit(cache=True)
+def add_njit_cached(a, b):
+    return a + b
+
+
+@njit(cache=False)
+def add_njit_notcached(a, b):
+    return a + b
+
+
+@cfunc(ndouble(ndouble, ndouble), cache=True)
+def add_cfunc_cached(a, b):
+    return a + b
+
+
+@cfunc(ndouble(ndouble, ndouble), cache=False)
+def add_cfunc_notcached(a, b):
+    return a + b
+
+
+class _TestModule(TestCase):
+    """
+    Tests for functionality of this module's functions.
+    Note this does not define any "test_*" method, instead check_module()
+    should be called by hand.
+    """
+
+    def check_module(self, mod):
+        f = mod.add_jit_cached
+        self.assertPreciseEqual(f(2.0, 3.0), 5.0)
+        f = mod.add_jit_notcached
+        self.assertPreciseEqual(f(-2.0, 3.0), 1.0)
+
+        f = mod.add_njit_cached
+        self.assertPreciseEqual(f(2.0, 3.0), 5.0)
+        f = mod.add_njit_notcached
+        self.assertPreciseEqual(f(-2.0, 3.0), 1.0)
+
+        f = mod.add_cfunc_cached
+        self.assertPreciseEqual(f.ctypes(2.0, 3.0), 5.0)
+        f = mod.add_cfunc_notcached
+        self.assertPreciseEqual(f.ctypes(-2.0, 3.0), 1.0)
+
+
+def self_test():
+    mod = sys.modules[__name__]
+    _TestModule().check_module(mod)


### PR DESCRIPTION
This adds a `NUMBA_CACHE_OVERRIDE` environment variable which is read into the `config.CACHE_OVERRIDE` setting. If set to ``always``, then the compilation decorators ignore the ``cache=`` parameter and always enable caching. If set to ``never``, then the decorators ignore the ``cache=`` parameter and always disable caching.

This closes #4549 where this variable and values were first suggested.

Note that I have added the override behavior to `numba.cuda.jit` but I currently don't have a CUDA setup to test this with. I assume the CI pipelines will take care of this -- if there is anything else I need to do to enable testing with CUDA, please let me know.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
