### PR TITLE
Replace Uses of `ir.Inst._rec_list_vars` When Statically Known

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -56,3 +56,21 @@ ignore_missing_imports = True
 
 [mypy-graphviz.*]
 ignore_missing_imports = True
+
+; [mypy-pygments.*]
+; ignore_missing_imports = True
+
+; [mypy-jinja2.*]
+; ignore_missing_imports = True
+
+; [mypy-yaml.*]
+; ignore_missing_imports = True
+
+; [mypy-colorama.*]
+; ignore_missing_imports = True
+
+; [mypy-cffi.*]
+; ignore_missing_imports = True
+
+; [mypy-elftools.*]
+; ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -57,20 +57,20 @@ ignore_missing_imports = True
 [mypy-graphviz.*]
 ignore_missing_imports = True
 
-; [mypy-pygments.*]
-; ignore_missing_imports = True
+[mypy-pygments.*]
+ignore_missing_imports = True
 
-; [mypy-jinja2.*]
-; ignore_missing_imports = True
+[mypy-jinja2.*]
+ignore_missing_imports = True
 
-; [mypy-yaml.*]
-; ignore_missing_imports = True
+[mypy-yaml.*]
+ignore_missing_imports = True
 
-; [mypy-colorama.*]
-; ignore_missing_imports = True
+[mypy-colorama.*]
+ignore_missing_imports = True
 
-; [mypy-cffi.*]
-; ignore_missing_imports = True
+[mypy-cffi.*]
+ignore_missing_imports = True
 
-; [mypy-elftools.*]
-; ignore_missing_imports = True
+[mypy-elftools.*]
+ignore_missing_imports = True

--- a/numba/core/byteflow.py
+++ b/numba/core/byteflow.py
@@ -2,12 +2,11 @@
 Implement python 3.8+ bytecode analysis
 """
 import dis
-from pprint import pformat
 import logging
 from collections import namedtuple, defaultdict, deque
 from functools import total_ordering
 
-from numba.core.utils import UniqueDict, PYVERSION, ALL_BINOPS_TO_OPERATORS
+from numba.core.utils import UniqueDict, PYVERSION, ALL_BINOPS_TO_OPERATORS, _lazy_pformat
 from numba.core.controlflow import NEW_BLOCKERS, CFGraph
 from numba.core.ir import Loc
 from numba.core.errors import UnsupportedError
@@ -70,15 +69,6 @@ class BlockKind(object):
 
     def __repr__(self):
         return "BlockKind({})".format(self._value)
-
-
-class _lazy_pformat(object):
-    def __init__(self, *args, **kwargs):
-        self.args = args
-        self.kwargs = kwargs
-
-    def __str__(self):
-        return pformat(*self.args, **self.kwargs)
 
 
 class Flow(object):

--- a/numba/core/byteflow.py
+++ b/numba/core/byteflow.py
@@ -6,7 +6,8 @@ import logging
 from collections import namedtuple, defaultdict, deque
 from functools import total_ordering
 
-from numba.core.utils import UniqueDict, PYVERSION, ALL_BINOPS_TO_OPERATORS, _lazy_pformat
+from numba.core.utils import (UniqueDict, PYVERSION, ALL_BINOPS_TO_OPERATORS,
+                              _lazy_pformat)
 from numba.core.controlflow import NEW_BLOCKERS, CFGraph
 from numba.core.ir import Loc
 from numba.core.errors import UnsupportedError

--- a/numba/core/compiler_machinery.py
+++ b/numba/core/compiler_machinery.py
@@ -2,7 +2,6 @@ import timeit
 from abc import abstractmethod, ABCMeta
 from collections import namedtuple, OrderedDict
 import inspect
-from pprint import pformat
 
 
 from numba.core.compiler_lock import global_compiler_lock

--- a/numba/core/compiler_machinery.py
+++ b/numba/core/compiler_machinery.py
@@ -300,7 +300,7 @@ class PassManager(object):
             name=f"{pss.name()} [{qualname}]",
             qualname=qualname,
             module=internal_state.func_id.modname,
-            flags=pformat(internal_state.flags.values()),
+            flags=utils._lazy_pformat(internal_state.flags.values()),
             args=str(internal_state.args),
             return_type=str(internal_state.return_type),
         )

--- a/numba/core/ssa.py
+++ b/numba/core/ssa.py
@@ -12,12 +12,11 @@ import operator
 import warnings
 from functools import reduce
 from copy import copy
-from pprint import pformat
 from collections import defaultdict
 
 from numba import config
 from numba.core import ir, ir_utils, errors
-from numba.core.utils import OrderedSet
+from numba.core.utils import OrderedSet, _lazy_pformat
 from numba.core.analysis import compute_cfg_from_blocks
 
 
@@ -67,7 +66,7 @@ def _run_ssa(blocks):
         # Fix up the LHS
         # Put fresh variables for all assignments to the variable
         blocks, defmap = _fresh_vars(blocks, varname)
-        _logger.debug("Replaced assignments: %s", pformat(defmap))
+        _logger.debug("Replaced assignments: %s", _lazy_pformat(defmap))
         # Fix up the RHS
         # Re-associate the variable uses with the reaching definition
         blocks = _fix_ssa_vars(blocks, varname, defmap, cfg, df_plus,
@@ -154,7 +153,7 @@ def _find_defs_violators(blocks, cfg):
     uses = defaultdict(set)
     states = dict(defs=defs, uses=uses)
     _run_block_analysis(blocks, states, _GatherDefsHandler())
-    _logger.debug("defs %s", pformat(defs))
+    _logger.debug("defs %s", _lazy_pformat(defs))
     # Gather violators by number of definitions.
     # The violators are added by the order that they are seen and the algorithm
     # scan from the first to the last basic-block as they occur in bytecode.
@@ -169,7 +168,7 @@ def _find_defs_violators(blocks, cfg):
                 if not def_labels.intersection(dom):
                     violators.add(k)
                     break
-    _logger.debug("SSA violators %s", pformat(violators))
+    _logger.debug("SSA violators %s", _lazy_pformat(violators))
     return violators
 
 

--- a/numba/core/utils.py
+++ b/numba/core/utils.py
@@ -13,6 +13,7 @@ import warnings
 import threading
 import contextlib
 import typing as _tp
+from pprint import pformat
 
 from types import ModuleType
 from importlib import import_module
@@ -797,3 +798,12 @@ def dump_llvm(fndesc, module):
     else:
         print(module)
     print('=' * 80)
+
+
+class _lazy_pformat(object):
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    def __str__(self):
+        return pformat(*self.args, **self.kwargs)

--- a/numba/tests/test_event.py
+++ b/numba/tests/test_event.py
@@ -6,6 +6,7 @@ import numpy as np
 from numba import njit, jit, literal_unroll
 from numba.core import event as ev
 from numba.tests.support import TestCase, override_config
+from numba.core.utils import _lazy_pformat
 
 
 class TestEvent(TestCase):
@@ -69,7 +70,7 @@ class TestEvent(TestCase):
             self.assertIsInstance(data['name'], str)
             self.assertIsInstance(data['qualname'], str)
             self.assertIsInstance(data['module'], str)
-            self.assertIsInstance(data['flags'], str)
+            self.assertIsInstance(data['flags'], _lazy_pformat)
             self.assertIsInstance(data['args'], str)
             self.assertIsInstance(data['return_type'], str)
 


### PR DESCRIPTION
Closes https://github.com/numba/numba/issues/9716.

Replaces uses of `_rec_list_vars` inside of `list_vars` for statically-known cases in subclasses of `ir.Inst`.

See approximately a 10% performance improvement on the mentioned benchmark

WAITING FOR BASE PR `slade/lazy_pformat` to be merged first.