### PR TITLE
add supported np.trapezoid

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -556,6 +556,7 @@ The following top-level functions are supported:
 * :func:`numpy.take` (only the 2 first arguments)
 * :func:`numpy.take_along_axis` (the axis argument must be a literal value)
 * :func:`numpy.transpose`
+* :func:`numpy.trapezoid` (only the 3 first arguments)
 * :func:`numpy.trapz` (only the 3 first arguments)
 * :func:`numpy.tri` (only the 3 first arguments; third argument ``k`` must be an integer)
 * :func:`numpy.tril` (second argument ``k`` must be an integer)
@@ -631,7 +632,7 @@ Numba supports :py:class:`numpy.random.Generator()` objects. As of version 0.56,
 individual NumPy :py:class:`Generator` objects into Numba functions and use their
 methods inside the functions. The same algorithms are used as NumPy for
 random number generation hence maintaining parity between the random
-number generated using NumPy and Numba under identical arguments 
+number generated using NumPy and Numba under identical arguments
 (also the same documentation notes as NumPy :py:class:`Generator` methods apply).
 The current Numba support for :py:class:`Generator` is not thread-safe, hence we
 do not recommend using :py:class:`Generator` methods in methods with parallel

--- a/docs/upcoming_changes/9719.np_support.rst
+++ b/docs/upcoming_changes/9719.np_support.rst
@@ -1,0 +1,4 @@
+Support for np.trapezoid
+------------------------
+
+Add Support for numpy 2.0 new function ``numpy.trapezoid``.

--- a/docs/upcoming_changes/9719.np_support.rst
+++ b/docs/upcoming_changes/9719.np_support.rst
@@ -1,4 +1,4 @@
 Support for np.trapezoid
 ------------------------
 
-Add Support for numpy 2.0 new function ``numpy.trapezoid``.
+Add support for numpy 2.0 new function ``numpy.trapezoid``.

--- a/numba/np/new_arraymath.py
+++ b/numba/np/new_arraymath.py
@@ -2236,6 +2236,11 @@ def np_trapz(y, x=None, dx=1.0):
     return impl
 
 
+# numpy 2.0 rename np.trapz to np.trapezoid
+if numpy_version >= (2, 0):
+    overload(np.trapezoid)(np_trapz)
+
+
 @register_jitable
 def _np_vander(x, N, increasing, out):
     """

--- a/numba/np/old_arraymath.py
+++ b/numba/np/old_arraymath.py
@@ -2236,6 +2236,11 @@ def np_trapz(y, x=None, dx=1.0):
     return impl
 
 
+# numpy 2.0 rename np.trapz to np.trapezoid
+if numpy_version >= (2, 0):
+    overload(np.trapezoid)(np_trapz)
+
+
 @register_jitable
 def _np_vander(x, N, increasing, out):
     """

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -357,6 +357,22 @@ def np_trapz_x_dx(y, x, dx):
     return np.trapz(y, x, dx)
 
 
+def np_trapezoid(y):
+    return np.trapezoid(y)
+
+
+def np_trapezoid_x(y, x):
+    return np.trapezoid(y, x)
+
+
+def np_trapezoid_dx(y, dx):
+    return np.trapezoid(y, dx=dx)
+
+
+def np_trapezoid_x_dx(y, x, dx):
+    return np.trapezoid(y, x, dx)
+
+
 def np_allclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):
     return np.allclose(a, b, rtol, atol, equal_nan)
 
@@ -3895,8 +3911,11 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         cond = np.array([True, False, True, False, False, True, False])
         _check(cond, a)
 
-    def test_np_trapz_basic(self):
-        pyfunc = np_trapz
+    @unittest.skipUnless(IS_NUMPY_2, "New in numpy 2.0+")
+    def test_np_trapezoid_basic(self):
+        self.test_np_trapz_basic(pyfunc=np_trapezoid)
+
+    def test_np_trapz_basic(self, pyfunc=np_trapz):
         cfunc = jit(nopython=True)(pyfunc)
         _check = partial(self._check_output, pyfunc, cfunc)
 
@@ -3930,8 +3949,11 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         y = (True, False, True)
         _check({'y': y})
 
-    def test_np_trapz_x_basic(self):
-        pyfunc = np_trapz_x
+    @unittest.skipUnless(IS_NUMPY_2, "New in numpy 2.0+")
+    def test_np_trapezoid_x_basic(self):
+        self.test_np_trapz_x_basic(pyfunc=np_trapezoid_x)
+
+    def test_np_trapz_x_basic(self, pyfunc=np_trapz_x):
         cfunc = jit(nopython=True)(pyfunc)
         _check = partial(self._check_output, pyfunc, cfunc)
 
@@ -3989,10 +4011,13 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         x = np.array([1 + 1j, 1 + 2j])
         _check({'y': y, 'x': x})
 
+    @unittest.skipUnless(IS_NUMPY_2, "New in numpy 2.0+")
+    def test_trapezoid_numpy_questionable(self):
+        self.test_trapz_numpy_questionable(pyfunc=np_trapezoid)
+
     @unittest.skip('NumPy behaviour questionable')
-    def test_trapz_numpy_questionable(self):
+    def test_trapz_numpy_questionable(self, pyfunc=np_trapz):
         # https://github.com/numpy/numpy/issues/12858
-        pyfunc = np_trapz
         cfunc = jit(nopython=True)(pyfunc)
         _check = partial(self._check_output, pyfunc, cfunc)
 
@@ -4004,8 +4029,11 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         y = np.array([True, False, True, True])
         _check({'y': y})
 
-    def test_np_trapz_dx_basic(self):
-        pyfunc = np_trapz_dx
+    @unittest.skipUnless(IS_NUMPY_2, "New in numpy 2.0+")
+    def test_np_trapezoid_dx_basic(self):
+        self.test_np_trapz_dx_basic(pyfunc=np_trapezoid_dx)
+
+    def test_np_trapz_dx_basic(self, pyfunc=np_trapz_dx):
         cfunc = jit(nopython=True)(pyfunc)
         _check = partial(self._check_output, pyfunc, cfunc)
 
@@ -4050,8 +4078,11 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         dx = np.array([5])
         _check({'y': y, 'dx': dx})
 
-    def test_np_trapz_x_dx_basic(self):
-        pyfunc = np_trapz_x_dx
+    @unittest.skipUnless(IS_NUMPY_2, "New in numpy 2.0+")
+    def test_np_trapezoid_x_dx_basic(self):
+        self.test_np_trapz_x_dx_basic(pyfunc=np_trapezoid_x_dx)
+
+    def test_np_trapz_x_dx_basic(self, pyfunc=np_trapz_x_dx):
         cfunc = jit(nopython=True)(pyfunc)
         _check = partial(self._check_output, pyfunc, cfunc)
 
@@ -4075,8 +4106,11 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             x[2, 2, 2] = np.nan
             _check({'y': y, 'x': x, 'dx': dx})
 
-    def test_np_trapz_x_dx_exceptions(self):
-        pyfunc = np_trapz_x_dx
+    @unittest.skipUnless(IS_NUMPY_2, "New in numpy 2.0+")
+    def test_np_trapezoid_x_dx_exceptions(self):
+        self.test_np_trapz_x_dx_exceptions(pyfunc=np_trapezoid_x_dx)
+
+    def test_np_trapz_x_dx_exceptions(self, pyfunc=np_trapz_x_dx):
         cfunc = jit(nopython=True)(pyfunc)
 
         # Exceptions leak references


### PR DESCRIPTION
numpy 2.0 rename np.trapz to np.trapezoid

Ref: 
https://numpy.org/doc/stable/numpy_2_0_migration_guide.html#main-namespace
https://numpy.org/doc/stable/reference/generated/numpy.trapezoid.html
https://github.com/numpy/numpy/blob/b3ddf2fd33232b8939f48c7c68a61c10257cd0c5/numpy/lib/_function_base_impl.py#L5054-L5069