### PR TITLE
Fix two bugs in Generator.binomial().

### DIFF
--- a/docs/upcoming_changes/9747.bug_fix.rst
+++ b/docs/upcoming_changes/9747.bug_fix.rst
@@ -1,0 +1,6 @@
+Fixed numerical error and infinite loop bug in ``numpy.random.Generator.binomial``.
+-----------------------------------------------------------------------------------
+
+A bug impacting the correctness of numerical results is fixed alongside an issue
+which led to executing an infinite loop under specific circumstances most easily
+triggered by the aforementioned correctness bug.

--- a/numba/np/random/old_distributions.py
+++ b/numba/np/random/old_distributions.py
@@ -565,7 +565,7 @@ def random_binomial_btpe(bitgen, n, p):
     q = 1.0 - r
     fm = n * r + r
     m = int(np.floor(fm))
-    p1 = int(np.floor(2.195 * np.sqrt(n * r * q) - 4.6 * q) + 0.5)
+    p1 = np.floor(2.195 * np.sqrt(n * r * q) - 4.6 * q) + 0.5
     xm = m + 0.5
     xl = xm - p1
     xr = xm + p1
@@ -673,6 +673,8 @@ def random_binomial_btpe(bitgen, n, p):
                       / w2) / w / 66320.)):
                 case = 10
                 continue
+            case = 60
+            continue
         elif case == 60:
             if (p > 0.5):
                 y = n - y


### PR DESCRIPTION
Issue #9493 reports two bugs which materialise as executing an infinite loop for large `n` and incorrect results for mid-range values of `n` (extracted as issue #9734) in the
`Generator.binomial()` function. Details:

1. A branch that should have a fall through state was not entering the fall through correctly. This, when combined with 2. led to executing an infinite loop in specific circumstances. This patch adds in the appropriate fall through branch.
2. One of the variables in `random_binomial_btpe` was incorrectly initialised with an expression that was cast to `int`. Fixing this addresses the issue with Numba not replicating NumPy for "mid-range" values of `n`. This patch simply removes the cast to reflect NumPy's C code.

Fixes #9493
Fixes #9734
