### PR TITLE
workaround for bug in TemporaryFile on windows

### DIFF
--- a/numba/core/caching.py
+++ b/numba/core/caching.py
@@ -106,7 +106,11 @@ class _CacheLocator(metaclass=ABCMeta):
         path = self.get_cache_path()
         os.makedirs(path, exist_ok=True)
         # Ensure the directory is writable by trying to write a temporary file
-        tempfile.TemporaryFile(dir=path).close()
+        # We avoid using tempfile.TemporaryFile since it may hang indefinitely on Windows:
+        # https://github.com/python/cpython/issues/66305
+        filename = os.path.join(path, "cache_write_test.txt")
+        open(filename, mode="wb").close()
+        os.remove(filename)
 
     @abstractmethod
     def get_cache_path(self):


### PR DESCRIPTION
Adaption of https://github.com/numba/numba/pull/9261 (adds 'write' flag to the mode)

This aims to fix https://github.com/numba/numba/issues/8755