### PR TITLE
Fix issue with IR mutation in label renaming.

### DIFF
--- a/docs/upcoming_changes/9755.bug_fix.rst
+++ b/docs/upcoming_changes/9755.bug_fix.rst
@@ -1,0 +1,7 @@
+Fix 0.60.0 objectmode fallback regression due to bug in label renaming.
+-----------------------------------------------------------------------
+
+A regression in objectmode fallback introduced in Numba 0.60 is fixed. The issue
+relates to the "label renaming" code mutating the IR directly opposed to
+constructing new terminator nodes, the mutations would impact copies of the IR
+as present in objectmode fallback.

--- a/numba/core/dispatcher.py
+++ b/numba/core/dispatcher.py
@@ -1129,7 +1129,8 @@ class LiftedLoop(LiftedCode):
                 pyobject_loop_flags.force_pyobject = True
 
                 # Clone IR to avoid (some of the) mutation in the rewrite pass
-                cloned_func_ir = self.func_ir.copy()
+                cloned_func_ir_npm = self.func_ir.copy()
+                cloned_func_ir_fbk = self.func_ir.copy()
 
                 ev_details = dict(
                     dispatcher=self,
@@ -1142,7 +1143,7 @@ class LiftedLoop(LiftedCode):
                     try:
                         cres = compiler.compile_ir(typingctx=self.typingctx,
                                                    targetctx=self.targetctx,
-                                                   func_ir=cloned_func_ir,
+                                                   func_ir=cloned_func_ir_npm,
                                                    args=args,
                                                    return_type=return_type,
                                                    flags=npm_loop_flags,
@@ -1153,7 +1154,7 @@ class LiftedLoop(LiftedCode):
                     except errors.TypingError:
                         cres = compiler.compile_ir(typingctx=self.typingctx,
                                                    targetctx=self.targetctx,
-                                                   func_ir=cloned_func_ir,
+                                                   func_ir=cloned_func_ir_fbk,
                                                    args=args,
                                                    return_type=return_type,
                                                    flags=pyobject_loop_flags,

--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -1311,11 +1311,18 @@ def rename_labels(blocks):
     # update target labels in jumps/branches
     for b in blocks.values():
         term = b.terminator
+        # create new IR nodes instead of mutating the existing one as copies of
+        # the IR may also refer to the same nodes!
         if isinstance(term, ir.Jump):
-            term.target = label_map[term.target]
+            b.body[-1] = ir.Jump(label_map[term.target], term.loc)
         if isinstance(term, ir.Branch):
-            term.truebr = label_map[term.truebr]
-            term.falsebr = label_map[term.falsebr]
+            b.body[-1] = ir.Branch(term.cond,
+                                   label_map[term.truebr],
+                                   label_map[term.falsebr],
+                                   term.loc)
+
+
+
     # update blocks dictionary keys
     new_blocks = {}
     for k, b in blocks.items():


### PR DESCRIPTION
This fixes an issue in the "objectmode fallback" emulation pipeline. Prior to this fix, the inline closure call would run as part of a "nopython" pipeline and the label renamer would mutate the IR terminators when renaming in topological order. This mutation would carry over into a copy of the IR that was used in a subsequent "objectmode" compilation attempt (assuming the nopython mode attempt failed). As a result, this invalid IR would not compile as the CFG cannot be constructed from incorrect labels. The fix is to ensure that renaming of the terminators is done via constructing a replacement node opposed to direct mutation of an existing node.

Fixes #9725

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
