### PR TITLE
Fix PyRef leaks in unboxing of np.random.Generator

### DIFF
--- a/docs/upcoming_changes/9756.bug_fix.rst
+++ b/docs/upcoming_changes/9756.bug_fix.rst
@@ -1,0 +1,7 @@
+Fix Python reference leaks in unboxing of ``numpy.random.Generator`` instances.
+-------------------------------------------------------------------------------
+
+Some Python reference leaks in the unboxing of ``numpy.random.Generator``
+instances have been fixed. Note that it was actually the referenced
+``numpy.random.BitGenerator`` that was leaking on unboxing, but it is rare to
+use these objects themselves as arguments.

--- a/numba/core/old_boxing.py
+++ b/numba/core/old_boxing.py
@@ -1196,7 +1196,7 @@ def unbox_numpy_random_bitgenerator(typ, obj, c):
         interface_state = object_getattr_safely(ctypes_binding, 'state')
         with cgutils.early_exit_if_null(c.builder, stack, interface_state):
             handle_failure()
-    
+
         interface_state_value = object_getattr_safely(
             interface_state, 'value')
         with cgutils.early_exit_if_null(c.builder, stack, interface_state_value):
@@ -1241,9 +1241,11 @@ def unbox_numpy_random_bitgenerator(typ, obj, c):
             args = c.pyapi.tuple_pack([interface_next_fn, ct_voidptr_ty])
             with cgutils.early_exit_if_null(c.builder, stack, args):
                 handle_failure()
+            extra_refs.append(args)
 
             # Call ctypes.cast()
             interface_next_fn_casted = c.pyapi.call(ct_cast, args)
+            extra_refs.append(interface_next_fn_casted)
 
             # Fetch the .value attr on the resulting ctypes.c_void_p for storage
             # in the function pointer slot.
@@ -1277,7 +1279,7 @@ def unbox_numpy_random_generator(typ, obj, c):
     * ('meminfo', types.MemInfoPointer(types.voidptr)): The information about the memory
         stored at the pointer (to the original Generator PyObject). This is useful for
         keeping track of reference counts within the Python runtime. Helps prevent cases
-        where deletion happens in Python runtime without NRT being awareness of it. 
+        where deletion happens in Python runtime without NRT being awareness of it.
     """
     is_error_ptr = cgutils.alloca_once_value(c.builder, cgutils.false_bit)
 


### PR DESCRIPTION
Issue #9103 shows what appears to be a memory leak associated with the use of `np.random.Generator` objects. The unboxed `Generator` object has a `bit_generator` field which refers to a struct formed from an unboxed `np.random.BitGenerator`. It is the unboxing of the `BitGenerator` instances that are leaking numerous Python reference (the leaking code is called 3x per unbox). This patch fixes those leaks.

Fixes #9103

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
