### PR TITLE
Fix some memory leaks/poor memory behaviour

### DIFF
--- a/docs/upcoming_changes/9757.bug_fix.rst
+++ b/docs/upcoming_changes/9757.bug_fix.rst
@@ -1,0 +1,6 @@
+Fix excessive memory use/poor memory behaviour in the dispatcher for non-fingerprintable types.
+-----------------------------------------------------------------------------------------------
+
+In the case of repeated dispatch on non-fingerprintable types, the dispatcher
+now uses memory in proportion to the number of unique types seen opposed to in
+proportion to the number of types in total.

--- a/numba/core/dispatcher.py
+++ b/numba/core/dispatcher.py
@@ -209,7 +209,7 @@ class _DispatcherBase(_dispatcher.Dispatcher):
         # but newer python uses a different name
         self.__code__ = self.func_code
         # a place to keep an active reference to the types of the active call
-        self._types_active_call = []
+        self._types_active_call = set()
         # Default argument values match the py_func
         self.__defaults__ = py_func.__defaults__
 
@@ -441,7 +441,7 @@ class _DispatcherBase(_dispatcher.Dispatcher):
             # ignore the FULL_TRACEBACKS config, this needs reporting!
             raise e
         finally:
-            self._types_active_call = []
+            self._types_active_call.clear()
         return return_val
 
     def inspect_llvm(self, signature=None):
@@ -691,7 +691,7 @@ class _DispatcherBase(_dispatcher.Dispatcher):
         else:
             if tp is None:
                 tp = types.pyobject
-        self._types_active_call.append(tp)
+        self._types_active_call.add(tp)
         return tp
 
     def _callback_add_timer(self, duration, cres, lock_name):


### PR DESCRIPTION
Issue #9103 showed what appears to be a memory leak associated with the use of `np.random.Generator` objects.

It turned out that the `np.random.Generator` unboxing code leaked numerous references, however, fixing these didn't completely stop the continuous consumption of memory.

Following on from the above, what appeared to be a less drastic leak was observable. On investigation, it turns out that this is not a "leak" in that the memory is still addressable and would eventually be garbage collected. The issue is that in the dispatcher, the use of the `typeof_pyval` method, as occurs in the case of a type which cannot be fingerprinted, appends the result of computing the type to a list so as to keep a reference alive. This append is unconditional, therefore every dispatch adds to the list. The fix is to make this a `set` such that references are held, but only once, and memory use does not grow with each invocation of the dispatcher with a non-fingerprintable type.

Fixes #9733

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
