### PR TITLE
Fix miscompile in branch pruning of SSA form IR.

### DIFF
--- a/docs/upcoming_changes/9758.bug_fix.rst
+++ b/docs/upcoming_changes/9758.bug_fix.rst
@@ -1,0 +1,5 @@
+Fix miscompile in branch pruning of SSA form IR.
+------------------------------------------------
+
+A miscompile occurring when a binop expression with constant arguments is used
+as a predicate in SSA form IR is now fixed.

--- a/numba/core/analysis.py
+++ b/numba/core/analysis.py
@@ -354,8 +354,12 @@ def dead_branch_prune(func_ir, called_args):
         if DEBUG > 0:
             kill = branch.falsebr if take_truebr else branch.truebr
             print("Pruning %s" % kill, branch, lhs_cond, rhs_cond, condition.fn)
-        taken = do_prune(take_truebr, blk)
-        return True, taken
+        do_prune(take_truebr, blk)
+        # It is not safe to rewrite the predicate to a nominal value based on
+        # which branch is taken, the rewritten const predicate needs to
+        # hold the actual computed const value as something else may refer to
+        # it!
+        return True, take_truebr
 
     def prune_by_predicate(branch, pred, blk):
         try:


### PR DESCRIPTION
Issue #9742 demonstrates a problem in SSA form IR where a branch predicate that is a binop expression with constant arguments was erroneously being rewritten as a constant 1 or 0 depending on whether the branch would be taken or not. This is incorrect as the predicate could be referred to by later code and as a result needs to have the value that is the result of evaluating the binop expression. This patch fixes the problem and adds test cases to demonstrate.

Fixes #9742

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
