### PR TITLE
Added support for `reversed` keyword

### DIFF
--- a/numba/cpython/iterators.py
+++ b/numba/cpython/iterators.py
@@ -6,6 +6,7 @@ from numba.core import types, cgutils
 from numba.core.imputils import (
     lower_builtin, iternext_impl, call_iternext, call_getiter,
     impl_ret_borrowed, impl_ret_new_ref, RefType)
+from numba.core.extending import overload
 
 
 
@@ -138,3 +139,15 @@ def iternext_zip(context, builder, sig, args, result):
                              builder.and_(status.is_error,
                                           builder.not_(status.is_stop_iteration))):
         context.call_conv.return_status_propagate(builder, status)
+
+
+@overload(reversed)
+def iter_reverse(A):
+    """
+    reversed(A) for an iterable A.
+    """
+    if isinstance(A, types.IterableType) and not isinstance(A, types.RangeType):
+        def impl_reversed(A):
+            for i in reversed(range(len(A))):
+                yield A[i]
+        return impl_reversed

--- a/numba/cpython/rangeobj.py
+++ b/numba/cpython/rangeobj.py
@@ -245,3 +245,14 @@ def impl_contains(robj, val):
 
 for ix, attr in enumerate(('start', 'stop', 'step')):
     make_range_attr(index=ix, attribute=attr)
+
+
+@overload(reversed)
+def range_reverse(A):
+    """
+    reversed implementation for RangeType
+    """
+    if isinstance(A, types.RangeType):
+        def range_impl(A):
+            return range(A.start + (len(A) - 1) * A.step, A.start - A.step, -A.step)
+        return range_impl

--- a/numba/tests/test_lists.py
+++ b/numba/tests/test_lists.py
@@ -231,6 +231,11 @@ def list_iteration(n):
         res += i * v
     return res
 
+def list_reversed(n):
+    l = list(range(n))
+    rev = reversed(l)
+    return list(rev)
+
 def list_contains(n):
     l = list(range(n))
     return (0 in l, 1 in l, n - 1 in l, n in l,
@@ -750,6 +755,10 @@ request more memory than can be provided###\n".encode("UTF-8"))
         cfunc = jit(nopython=True)(pyfunc)
         self.assertPreciseEqual(cfunc(), pyfunc())
 
+    def test_list_reversed(self):
+        pyfunc = list_reversed
+        cfunc = jit(nopython=True)(pyfunc)
+        self.assertPreciseEqual(cfunc(5), pyfunc(5))
 
 class TestUnboxing(MemoryLeakMixin, TestCase):
     """

--- a/numba/tests/test_range.py
+++ b/numba/tests/test_range.py
@@ -39,6 +39,13 @@ def range_len2(a, b):
 
 def range_len3(a, b, c):
     return len(range(a, b, c))
+
+def range_reversed(n):
+    tmp = []
+    for r in reversed(range(n)):
+        tmp.append(r)
+    return tmp
+
 def range_iter_len1(a):
     return length_of_iterator(iter(range(a)))
 
@@ -84,6 +91,11 @@ class TestRange(unittest.TestCase):
         ]
         for args in arglist:
             self.assertEqual(cfunc(*args), pyfunc(*args))
+
+    def test_range_reversed(self):
+        pyfunc = range_reversed
+        cfunc = njit()(pyfunc)
+        self.assertTrue(cfunc(6), pyfunc(6))
 
     def test_range_len1(self):
         pyfunc = range_len1


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
Resolves #2774 

This PR adds support for the `reversed` keyword. Based on an abandoned PR #6881.
