### PR TITLE
Use `warnings.simplefilter()` to implement `NUMBA_DISABLE_PERFORMANCE_WARNINGS` env var

### DIFF
--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -238,6 +238,9 @@ Is set to True if Intel SVML is in use.
 """
 config.USING_SVML = _try_enable_svml()
 
+# Apply warning filter if configured
+if config.DISABLE_PERFORMANCE_WARNINGS:
+    warnings.simplefilter("ignore", errors.NumbaPerformanceWarning)
 
 # ---------------------- WARNING WARNING WARNING ----------------------------
 # The following imports occur below here (SVML init) because somewhere in their

--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -240,7 +240,7 @@ config.USING_SVML = _try_enable_svml()
 
 # Apply warning filter if configured
 if config.DISABLE_PERFORMANCE_WARNINGS:
-    warnings.simplefilter("ignore", errors.NumbaPerformanceWarning)
+    warnings.simplefilter('ignore', errors.NumbaPerformanceWarning)
 
 # ---------------------- WARNING WARNING WARNING ----------------------------
 # The following imports occur below here (SVML init) because somewhere in their

--- a/numba/core/typed_passes.py
+++ b/numba/core/typed_passes.py
@@ -325,8 +325,7 @@ class ParforPass(FunctionPass):
 
         if not has_parfor:
             # parfor calls the compiler chain again with a string
-            if not (config.DISABLE_PERFORMANCE_WARNINGS or
-                    state.func_ir.loc.filename == '<string>'):
+            if not state.func_ir.loc.filename == '<string>':
                 url = ("https://numba.readthedocs.io/en/stable/user/"
                        "parallel.html#diagnostics")
                 msg = ("\nThe keyword argument 'parallel=True' was specified "

--- a/numba/core/typing/npydecl.py
+++ b/numba/core/typing/npydecl.py
@@ -609,8 +609,7 @@ class MatMulTyperMixin(object):
         else:
             all_args = (a, b)
 
-        if not (config.DISABLE_PERFORMANCE_WARNINGS or
-                all(x.layout in 'CF' for x in (a, b))):
+        if not all(x.layout in 'CF' for x in (a, b)):
             msg = ("%s is faster on contiguous arrays, called on %s" %
                    (self.func_name, (a, b)))
             warnings.warn(NumbaPerformanceWarning(msg))

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -2376,25 +2376,24 @@ class ConvertLoopPass:
         # We go over all loops, smaller loops first (inner first)
         for loop, s in sorted(sized_loops, key=lambda tup: tup[1]):
             if len(loop.entries) != 1 or len(loop.exits) != 1:
-                if not config.DISABLE_PERFORMANCE_WARNINGS:
-                    for entry in loop.entries:
-                        for inst in blocks[entry].body:
-                            # if prange or pndindex call
-                            if (
-                                isinstance(inst, ir.Assign)
-                                and isinstance(inst.value, ir.Expr)
-                                and inst.value.op == "call"
-                                and self._is_parallel_loop(
-                                    inst.value.func.name, call_table)
-                            ):
-                                msg = "\nprange or pndindex loop " \
-                                      "will not be executed in " \
-                                      "parallel due to there being more than one " \
-                                      "entry to or exit from the loop (e.g., an " \
-                                      "assertion)."
-                                warnings.warn(
-                                    errors.NumbaPerformanceWarning(
-                                        msg, inst.loc))
+                for entry in loop.entries:
+                    for inst in blocks[entry].body:
+                        # if prange or pndindex call
+                        if (
+                            isinstance(inst, ir.Assign)
+                            and isinstance(inst.value, ir.Expr)
+                            and inst.value.op == "call"
+                            and self._is_parallel_loop(
+                                inst.value.func.name, call_table)
+                        ):
+                            msg = "\nprange or pndindex loop " \
+                                    "will not be executed in " \
+                                    "parallel due to there being more than one " \
+                                    "entry to or exit from the loop (e.g., an " \
+                                    "assertion)."
+                            warnings.warn(
+                                errors.NumbaPerformanceWarning(
+                                    msg, inst.loc))
                 continue
 
             entry = list(loop.entries)[0]

--- a/numba/tests/test_warnings.py
+++ b/numba/tests/test_warnings.py
@@ -117,7 +117,6 @@ class TestBuiltins(unittest.TestCase):
             import numba
             from numba.tests.support import ignore_internal_warnings
             with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter('always')
                 ignore_internal_warnings()
                 foo()
             for x in w:


### PR DESCRIPTION
This PR implements the `NUMBA_DISABLE_PERFORMANCE_WARNINGS` environment variable using a `warnings.simplefilter()` in `__init__.py`, which provides better integration with the `warnings` stdlib module.

Currently, the `NUMBA_DISABLE_PERFORMANCE_WARNINGS` environment variable is implemented by reading it into `config.DISABLE_PERFORMANCE_WARNINGS` and checking this variable at each warning site. However, a few functions have crept into the code that lack this check, and therefore emit warnings even if the environment variable is set; see https://github.com/numba/numba/issues/9762.

This PR fixes that bug at the module level. This makes the code more maintainable because authors of future code that emits performance warnings don't need to remember to check the config variable.

To make `test_warnings.py` pass, I had to make a slight modification to the test code by removing the line `warnings.simplefilter('always')`. This appears to have been a "stress test" to ensure that warnings were actually being suppressed by the environment variable and not by some quirk of the test environment. But because the new implementation takes effect at the moment Numba is imported, this second filter overrides the filter under test.

Actually, the behavior of `warnings.simplefilter('always')` in this context highlights another benefit of this PR: With the new implementation, you can disable performance warnings globally using the env var, then selectively re-enable them in a local scope using `with warnings.simplefilter('always')`. This didn't work before.

Closes #9762.