### PR TITLE
Emit warnings when missing authors are dectected in `gitlog2changelog`

### DIFF
--- a/maint/gitlog2changelog.py
+++ b/maint/gitlog2changelog.py
@@ -71,7 +71,7 @@ if __name__ == '__main__':
                 missing_authors.add((pull, c))
             if c.committer and c.committer.login != "web-flow":
                 pr_authors.add(c.committer)
-            else if not author:
+            elif not author:
                 missing_authors.add((pull, c))
         print("* PR %s: %s (%s)" % (hyperlink, ordered[k],
                                     " ".join([hyperlink_user(u) for u in

--- a/maint/gitlog2changelog.py
+++ b/maint/gitlog2changelog.py
@@ -64,13 +64,14 @@ if __name__ == '__main__':
         # get all users for all commits
         pr_authors = set()
         for c in pull.get_commits():
-            if c.author:
+            author = c.author
+            if author:
                 pr_authors.add(c.author)
             else:
                 missing_authors.add((pull, c))
             if c.committer and c.committer.login != "web-flow":
                 pr_authors.add(c.committer)
-            else:
+            else if not author:
                 missing_authors.add((pull, c))
         print("* PR %s: %s (%s)" % (hyperlink, ordered[k],
                                     " ".join([hyperlink_user(u) for u in


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
Fixes #9426 

This updates the `gitlog2changelog.py` script such that the missing author info i.e. authors whose emails aren't associated with a Github username are detected. In this case the script will print warnings to `stdout` and details of the commits which have the missing authors.