### PR TITLE
Improve UX: `numba.jit` and `numba.njit`

### DIFF
--- a/numba/core/decorators.py
+++ b/numba/core/decorators.py
@@ -23,7 +23,7 @@ _msg_deprecated_signature_arg = ("Deprecated keyword argument `{0}`. "
                                  "positional argument.")
 
 
-def jit(signature_or_function=None, locals={}, cache=False,
+def jit(signature_or_function=None, locals=None, cache=False,
         pipeline_class=None, boundscheck=None, **options):
     """
     This decorator is used to compile a Python function into native code.
@@ -138,6 +138,8 @@ def jit(signature_or_function=None, locals={}, cache=False,
                 return x + y
 
     """
+    if locals is None:
+        locals = {}
     forceobj = options.get('forceobj', False)
     if 'argtypes' in options:
         raise DeprecationError(_msg_deprecated_signature_arg.format('argtypes'))
@@ -251,7 +253,7 @@ def njit(*args, **kws):
     return jit(*args, **kws)
 
 
-def cfunc(sig, locals={}, cache=False, pipeline_class=None, **options):
+def cfunc(sig, locals=None, cache=False, pipeline_class=None, **options):
     """
     This decorator is used to compile a Python function into a C callback
     usable with foreign C libraries.
@@ -262,6 +264,8 @@ def cfunc(sig, locals={}, cache=False, pipeline_class=None, **options):
             return a + b
 
     """
+    if locals is None:
+        locals = {}
     sig = sigutils.normalize_signature(sig)
 
     def wrapper(func):

--- a/numba/core/decorators.py
+++ b/numba/core/decorators.py
@@ -2,11 +2,14 @@
 Define @jit and related decorators.
 """
 
+from __future__ import annotations
 
+from collections.abc import Callable
 import sys
 import warnings
 import inspect
 import logging
+import typing
 
 from numba.core.errors import DeprecationError, NumbaDeprecationWarning
 from numba.stencils.stencil import stencil
@@ -14,6 +17,9 @@ from numba.core import config, extending, sigutils, registry
 
 _logger = logging.getLogger(__name__)
 
+_F = typing.TypeVar("_F", bound=Callable)
+# TODO: Make it more specific
+_SignatureType = typing.Any
 
 # -----------------------------------------------------------------------------
 # Decorators
@@ -21,6 +27,14 @@ _logger = logging.getLogger(__name__)
 _msg_deprecated_signature_arg = ("Deprecated keyword argument `{0}`. "
                                  "Signatures should be passed as the first "
                                  "positional argument.")
+
+
+@typing.overload
+def jit(signature_or_function: _F) -> _F: ...
+
+
+@typing.overload
+def jit(signature_or_function: _SignatureType | None = ..., *args, **kwargs) -> Callable[[_F], _F]: ...
 
 
 def jit(signature_or_function=None, locals=None, cache=False,
@@ -236,6 +250,14 @@ def _jit(sigs, locals, target, cache, targetoptions, **dispatcher_args):
         return disp
 
     return wrapper
+
+
+@typing.overload
+def njit(signature_or_function: _F) -> _F: ...
+
+
+@typing.overload
+def njit(signature_or_function: _SignatureType | None = ..., *args, **kwargs) -> Callable[[_F], _F]: ...
 
 
 def njit(*args, **kws):


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
### Changes

- Create fresh `dict` every time called

See https://docs.astral.sh/ruff/rules/mutable-argument-default/ for details.

- Add type annotation to `jit` / `njit` (preliminary)

Now decorator does not strip of type annotations.

```python
import numba

# All inferred as `(x: int) -> int`

@numba.njit
def f(x: int) -> int:
    return x


@numba.njit()
def g(x: int) -> int:
    return x


@numba.njit(cache=True)
def h(x: int) -> int:
    return x


@numba.njit("int64(int64)")
def i(x: int) -> int:
    return x


def _inner(x: int) -> int:
    return x


j = numba.njit(_inner)
k = numba.njit("int64(int64)")(_inner)
```
