### PR TITLE
Fix regression in exception handling against 0.60.

### DIFF
--- a/docs/upcoming_changes/9799.bug_fix.rst
+++ b/docs/upcoming_changes/9799.bug_fix.rst
@@ -1,0 +1,7 @@
+Fix regression in type-inference for star-arg arguments.
+--------------------------------------------------------
+
+A regression, that occurred between versions 0.59.0 and 0.60.0, in the
+type-inference associated with star-arg arguments has been fixed. The cause of
+the regression was the code for star-args handling in type-inference not being
+updated following the switch to use new-style error handling by default.

--- a/numba/core/typeinfer.py
+++ b/numba/core/typeinfer.py
@@ -518,14 +518,14 @@ def fold_arg_vars(typevars, args, vararg, kws):
             const_val = args[-1].literal_value
             # Is the constant value a tuple?
             if not isinstance(const_val, tuple):
-                raise TypeError(errmsg % (args[-1],))
+                raise TypingError(errmsg % (args[-1],))
             # Append the elements in the const tuple to the positional args
             pos_args += const_val
         # Handle non-constant
         elif not isinstance(args[-1], types.BaseTuple):
             # Unsuitable for *args
             # (Python is more lenient and accepts all iterables)
-            raise TypeError(errmsg % (args[-1],))
+            raise TypingError(errmsg % (args[-1],))
         else:
             # Append the elements in the tuple to the positional args
             pos_args += args[-1].types

--- a/numba/core/typing/templates.py
+++ b/numba/core/typing/templates.py
@@ -217,7 +217,15 @@ def fold_arguments(pysig, args, kws, normal_handler, default_handler,
             bind_kws[n] = args[len(kwonly) + idx]
 
     # now bind
-    ba = pysig.bind(*bind_args, **bind_kws)
+    try:
+        ba = pysig.bind(*bind_args, **bind_kws)
+    except TypeError as e:
+        # The binding attempt can raise if the args don't match up, this needs
+        # to be converted to a TypingError so that e.g. partial type inference
+        # doesn't just halt.
+        msg = (f"Cannot bind 'args={bind_args} kws={bind_kws}' to "
+               f"signature '{pysig}' due to \"{type(e).__name__}: {e}\".")
+        raise TypingError(msg)
     for i, param in enumerate(pysig.parameters.values()):
         name = param.name
         default = param.default


### PR DESCRIPTION
Numba 0.60 changed to use `new_style` exception handling by default. This means that any exception that does not inherit from `NumbaError` that is raised during compilation is treated as a "hard error", i.e. it causes the exception to propagate without being captured/handled by the compiler.

Issue #9795 highlights a case where an invalid signature binding would raise an exception that would cause a hard error during the partial type inference pass. On investigation two more related cases were identified. This patch fixes these three cases by converting the exceptions raised into `NumbaError` based exceptions, which allows partial type inference to succeed.

Closes #9795

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
