### PR TITLE
Release branch pins for 0.61

### DIFF
--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -39,7 +39,7 @@ requirements:
     - tbb-devel >=2021.6       # [not (aarch64 or ppc64le)]
   run:
     - python >=3.10
-    - numpy >=1.24
+    - numpy >=1.24,<2.2
     # On channel https://anaconda.org/numba/
     - llvmlite 0.44.*
   run_constrained:

--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - numpy
     - setuptools
     # On channel https://anaconda.org/numba/
-    - llvmlite >=0.44.0dev0,<0.44
+    - llvmlite 0.44.*
     # TBB devel version is to match TBB libs.
     # NOTE: ppc64le and aarch64 are pending testing so excluded for now.
     - tbb-devel >=2021.6       # [not (aarch64 or ppc64le)]
@@ -41,7 +41,7 @@ requirements:
     - python >=3.10
     - numpy >=1.24
     # On channel https://anaconda.org/numba/
-    - llvmlite >=0.44.0dev0,<0.44
+    - llvmlite 0.44.*
   run_constrained:
     # If TBB is present it must be at least version 2021.6
     - tbb >=2021.6    # [not (aarch64 or ppc64le)]

--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -39,6 +39,11 @@ def _ensure_critical_deps():
                f"{numpy_version[0]}.{numpy_version[1]}.")
         raise ImportError(msg)
 
+    if numpy_version > (2, 1):
+        msg = (f"Numba needs NumPy 2.1 or less. Got NumPy "
+               f"{numpy_version[0]}.{numpy_version[1]}.")
+        raise ImportError(msg)
+
     try:
         import scipy
     except ImportError:

--- a/numba/testing/main.py
+++ b/numba/testing/main.py
@@ -243,7 +243,7 @@ class NumbaTestProgram(unittest.main):
         parser.add_argument('-g', '--gitdiff', dest='gitdiff', type=git_diff_str,
                             default=False, nargs='?',
                             help=('Run tests from changes made against '
-                                  'origin/main as identified by `git diff`. '
+                                  'origin/release0.61 as identified by `git diff`. '
                                   'If set to "ancestor", the diff compares '
                                   'against the common ancestor.'))
         return parser
@@ -435,9 +435,9 @@ def _choose_gitdiff_tests(tests, *, use_common_ancestor=False):
     path = os.path.join('numba', 'tests')
     if use_common_ancestor:
         print(f"Git diff by common ancestor")
-        target = 'origin/main...HEAD'
+        target = 'origin/release0.61...HEAD'
     else:
-        target = 'origin/main..HEAD'
+        target = 'origin/release0.61..HEAD'
     gdiff_paths = repo.git.diff(target, path, name_only=True).split()
     # normalise the paths as they are unix style from repo.git.diff
     gdiff_paths = [os.path.normpath(x) for x in gdiff_paths]

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,9 @@ except ImportError:
 
 min_python_version = "3.10"
 max_python_version = "3.14"  # exclusive
-min_numpy_build_version = "1.11"
+min_numpy_build_version = "2.0.0rc1"
 min_numpy_run_version = "1.24"
+max_numpy_run_version = "2.2"
 min_llvmlite_version = "0.44.0dev0"
 max_llvmlite_version = "0.45"
 
@@ -366,10 +367,10 @@ def get_ext_modules():
 
 packages = find_packages(include=["numba", "numba.*"])
 
-build_requires = ['numpy >={}'.format(min_numpy_build_version)]
+build_requires = ['numpy >={},<{}'.format(min_numpy_build_version, max_numpy_run_version)]
 install_requires = [
     'llvmlite >={},<{}'.format(min_llvmlite_version, max_llvmlite_version),
-    'numpy >={}'.format(min_numpy_run_version),
+    'numpy >={},<{}'.format(min_numpy_run_version, max_numpy_run_version),
 ]
 
 metadata = dict(


### PR DESCRIPTION
As titled, this PR pins NumPy and llvmlite for the `0.61.0` release.