### PR TITLE
Handle empty arrays in np.median implementation and add datetime check

### DIFF
--- a/docs/upcoming_changes/9805.bug_fix.rst
+++ b/docs/upcoming_changes/9805.bug_fix.rst
@@ -1,0 +1,4 @@
+Fixed ``np.median`` raising ``AssertionError`` for empty arrays when NumPy returns NaN
+--------------------------------------------------------------------------------------
+
+Fixed an issue where passing empty arrays to ``np.median`` would cause an ``AssertionError``. Now empty arrays correctly return NaN as expected.

--- a/numba/np/old_arraymath.py
+++ b/numba/np/old_arraymath.py
@@ -1592,13 +1592,16 @@ def np_median(a):
     if not isinstance(a, types.Array):
         return
 
+    is_datetime = as_dtype(a.dtype).char in 'mM'
+
     def median_impl(a):
         # np.median() works on the flattened array, and we need a temporary
         # workspace anyway
         temp_arry = a.flatten()
         n = temp_arry.shape[0]
+        if not is_datetime and n == 0:
+            return np.nan
         return _median_inner(temp_arry, n)
-
     return median_impl
 
 

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -307,6 +307,9 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
             got = cfunc(arr)
             self.assertPreciseEqual(got, expected)
 
+        # Empty array case
+        check(np.array([]))
+
         # Odd sizes
         def check_odd(a):
             check(a)


### PR DESCRIPTION
Fixes #9433 

Added a check to handle empty arrays by returning np.nan for non-datetime arrays.

