### PR TITLE
Add debug print to debug test_monitoring_multiple_threads failing on …

### DIFF
--- a/numba/tests/test_sys_monitoring.py
+++ b/numba/tests/test_sys_monitoring.py
@@ -732,8 +732,14 @@ class TestMonitoring(TestCase):
             t.join()
 
         # make sure there were no exceptions
-        self.assertFalse(q1.qsize())
-        self.assertFalse(q2.qsize())
+        def assert_empty_queue(q):
+            if q.qsize() != 0:
+                while not q.empty():
+                    print(q.get())
+                self.fail("queue supposed to be empty")
+
+        assert_empty_queue(q1)
+        assert_empty_queue(q2)
 
 
 @unittest.skipUnless(PYVERSION >= (3, 12), "needs Python 3.12+")


### PR DESCRIPTION
This is added for logging issues of difficult to reproduce error that happened on windows on the buildfarm