### PR TITLE
Add new type-checking level

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -7,23 +7,22 @@ show_error_context = True
 files = **/numba/core/types/*.py, **/numba/core/datamodel/*.py, **/numba/core/rewrites/*.py, **/numba/core/unsafe/*.py
 
 # Per-module options:
-# To classify a given module as Level 1, 2 or 3 it must be added both in files (variable above) and in the lists below.
-# Level 1 - modules checked on the strictest settings.
+# To classify a given module as Level 0, 1, 2 or 3 it must be added both in files (variable above) and in the lists below.
+# Level 0 - modules checked on the strictest settings. Any is prohibited anywhere.
 ;[mypy-]
-;warn_return_any = True
-;disallow_any_expr = True
+;disallow_any_decorated = True
 ;disallow_any_explicit = True
-;disallow_any_generics = True
-;disallow_subclassing_any = True
-;disallow_untyped_calls = True
-;disallow_untyped_defs = True
-;disallow_incomplete_defs = True
-;check_untyped_defs = True
-;disallow_untyped_decorators = True
-;warn_unused_ignores = True
-;follow_imports = normal
+;disallow_any_expr = True
+;disallow_any_unimported = True
+;strict = True
 ;warn_unreachable = True
-;strict_equality = True
+;follow_imports = normal
+
+# Level 1 - module that pass mypy's strict mode and dead code detection.
+;[mypy-]
+;strict = True
+;warn_unreachable = True
+;follow_imports = normal
 
 # Level 2 - module that pass reasonably strict settings.
 #           No untyped functions allowed. Imports must be typed or explicitly ignored.


### PR DESCRIPTION
Suggestion related to #9820 .

## Changes

- Add level 0, which aggressively bans `Any`
  - This is slightly strictier than the original level 1
- Add new level 1, which allows `Any` if correctly quarantined