### PR TITLE
Handle empty traceback in get_loc method to prevent IndexError

### DIFF
--- a/numba/core/types/functions.py
+++ b/numba/core/types/functions.py
@@ -216,8 +216,11 @@ class _ResolutionFailures(object):
         """
         if isinstance(error, Exception) and hasattr(error, '__traceback__'):
             # traceback is unavailable in py2
-            frame = traceback.extract_tb(error.__traceback__)[-1]
-            return "{}:{}".format(frame[0], frame[1])
+            frame_list = traceback.extract_tb(error.__traceback__)
+            # Check if length of frame_list is 0
+            if len(frame_list) != 0:
+                frame = frame_list[-1]
+                return "{}:{}".format(frame[0], frame[1])
 
     def raise_error(self):
         for faillist in self._failures.values():


### PR DESCRIPTION
Fixes #9822 

This PR prevents an IndexError by checking if frame_list is empty before accessing its last element in the get_loc method.