### PR TITLE
[CI ONLY] Mark argument initialization with their value

### DIFF
--- a/numba/core/lowering.py
+++ b/numba/core/lowering.py
@@ -1562,16 +1562,15 @@ class Lower(BaseLower):
             # store following reassemble from CC splatting structs as many args
             # to the function) then mark this variable as such.
             if argidx is not None:
-                with debuginfo.suspend_emission(self.builder):
-                    self.builder.store(value, ptr)
+                self.builder.store(value, ptr)
                 loc = self.defn_loc # the line with `def <func>`
                 lltype = self.context.get_value_type(fetype)
                 sizeof = self.context.get_abi_sizeof(lltype)
                 datamodel = self.context.data_model_manager[fetype]
-                self.debuginfo.mark_variable(self.builder, ptr, name=name,
-                                             lltype=lltype, size=sizeof,
-                                             line=loc.line, datamodel=datamodel,
-                                             argidx=argidx)
+                self.debuginfo.mark_arg(self.builder, value, name=name,
+                                        lltype=lltype, size=sizeof,
+                                        line=loc.line, datamodel=datamodel,
+                                        argidx=argidx)
             else:
                 self.builder.store(value, ptr)
 


### PR DESCRIPTION
... instead of their location. This can improve tracking for LLVM backends that run mem2reg at `-O0`.

Seeing if this has a negative effect on testing - e.g. do any debug tests fail?