### PR TITLE
Fall back on inspect.getsourcelines() in first line finder

### DIFF
--- a/docs/upcoming_changes/9861.improvement.rst
+++ b/docs/upcoming_changes/9861.improvement.rst
@@ -1,0 +1,7 @@
+Fall back to ``inspect.getsourcelines()`` in first line finder
+--------------------------------------------------------------
+
+If the first line finder can't locate source code on disk, it now tries using
+``inspect.getsourcelines()`` to get the source. This enables it to locate
+source for cells in Jupyter notebooks, so that line info for them can be
+generated for profiling tools.

--- a/numba/misc/firstlinefinder.py
+++ b/numba/misc/firstlinefinder.py
@@ -91,7 +91,7 @@ def get_func_body_first_lineno(pyfunc):
             source = "".join(lines)
             offset = offset - 1
         except (OSError, TypeError):
-            return
+            return None
 
     tree = ast.parse(source)
     finder = FindDefFirstLine(co.co_name, co.co_firstlineno - offset)
@@ -100,4 +100,4 @@ def get_func_body_first_lineno(pyfunc):
         return finder.first_stmt_line + offset
     else:
         # No first line found.
-        return
+        return None

--- a/numba/misc/firstlinefinder.py
+++ b/numba/misc/firstlinefinder.py
@@ -96,4 +96,8 @@ def get_func_body_first_lineno(pyfunc):
     tree = ast.parse(source)
     finder = FindDefFirstLine(co.co_name, co.co_firstlineno - offset)
     finder.visit(tree)
-    return finder.first_stmt_line + offset
+    if finder.first_stmt_line:
+        return finder.first_stmt_line + offset
+    else:
+        # No first line found.
+        return

--- a/numba/misc/firstlinefinder.py
+++ b/numba/misc/firstlinefinder.py
@@ -5,6 +5,7 @@ body.
 
 import ast
 import inspect
+import textwrap
 
 
 class FindDefFirstLine(ast.NodeVisitor):
@@ -93,7 +94,7 @@ def get_func_body_first_lineno(pyfunc):
         except (OSError, TypeError):
             return None
 
-    tree = ast.parse(source)
+    tree = ast.parse(textwrap.dedent(source))
     finder = FindDefFirstLine(co.co_name, co.co_firstlineno - offset)
     finder.visit(tree)
     if finder.first_stmt_line:

--- a/numba/misc/firstlinefinder.py
+++ b/numba/misc/firstlinefinder.py
@@ -4,6 +4,7 @@ body.
 """
 
 import ast
+import inspect
 
 
 class FindDefFirstLine(ast.NodeVisitor):
@@ -15,15 +16,15 @@ class FindDefFirstLine(ast.NodeVisitor):
         Or, ``None`` if the definition is not found.
     """
 
-    def __init__(self, code):
+    def __init__(self, name, firstlineno):
         """
         Parameters
         ----------
         code :
             The function's code object.
         """
-        self._co_name = code.co_name
-        self._co_firstlineno = code.co_firstlineno
+        self._co_name = name
+        self._co_firstlineno = firstlineno
         self.first_stmt_line = None
 
     def _visit_children(self, node):
@@ -82,11 +83,17 @@ def get_func_body_first_lineno(pyfunc):
     co = pyfunc.__code__
     try:
         with open(co.co_filename) as fin:
-            file_content = fin.read()
+            source = fin.read()
+            offset = 0
     except (FileNotFoundError, OSError):
-        return
-    else:
-        tree = ast.parse(file_content)
-        finder = FindDefFirstLine(co)
-        finder.visit(tree)
-        return finder.first_stmt_line
+        try:
+            lines, offset = inspect.getsourcelines(pyfunc)
+            source = "".join(lines)
+            offset = offset - 1
+        except (OSError, TypeError):
+            return
+
+    tree = ast.parse(source)
+    finder = FindDefFirstLine(co.co_name, co.co_firstlineno - offset)
+    finder.visit(tree)
+    return finder.first_stmt_line + offset

--- a/numba/tests/test_firstlinefinder.py
+++ b/numba/tests/test_firstlinefinder.py
@@ -90,7 +90,7 @@ class TestFirstLineFinder(TestCase):
         # inspect.getsourcelines()
         filename = "<foo>"
         timestamp = None
-        entry = (len(source), timestamp, source.splitlines(), filename)
+        entry = (len(source), timestamp, source.splitlines(True), filename)
         linecache.cache[filename] = entry
 
         # We need to compile the code so we can give it the fake filename used

--- a/numba/tests/test_firstlinefinder.py
+++ b/numba/tests/test_firstlinefinder.py
@@ -104,7 +104,7 @@ class TestFirstLineFinder(TestCase):
         # We should be able to determine the first line number even though the
         # source does not exist on disk
         first_def_line = get_func_body_first_lineno(foo)
-        self.assertEqual(first_def_line, 1)
+        self.assertEqual(first_def_line, 2)
 
     def test_single_line_function(self):
         @njit

--- a/numba/tests/test_firstlinefinder.py
+++ b/numba/tests/test_firstlinefinder.py
@@ -1,6 +1,7 @@
 import unittest
 import linecache
 import inspect
+import textwrap
 
 from numba import njit
 from numba.tests.support import TestCase
@@ -80,15 +81,11 @@ class TestFirstLineFinder(TestCase):
         # Cannot determine first line of string evaled functions
         self.assertIsNone(first_def_line)
 
-    def test_string_eval_linecache(self):
-        source = """def foo():
-            pass
-        """
-
+    def _test_with_patched_linecache(self, filename, source,
+                                     function_name, expected_first_line):
         # Modify the line cache in a similar manner to Jupyter, so that
         # get_func_body_first_lineno can find the code using the fallback to
         # inspect.getsourcelines()
-        filename = "<foo>"
         timestamp = None
         entry = (len(source), timestamp, source.splitlines(True), filename)
         linecache.cache[filename] = entry
@@ -99,12 +96,95 @@ class TestFirstLineFinder(TestCase):
 
         globalns = {}
         exec(code, globalns)
-        foo = globalns['foo']
+        function = globalns[function_name]
 
         # We should be able to determine the first line number even though the
         # source does not exist on disk
-        first_def_line = get_func_body_first_lineno(foo)
-        self.assertEqual(first_def_line, 2)
+        first_def_line = get_func_body_first_lineno(function)
+        self.assertEqual(first_def_line, expected_first_line)
+
+    def test_string_eval_linecache_basic(self):
+        source = """def foo():
+            pass
+        """
+
+        filename = "<foo-basic>"
+        function_name = "foo"
+        expected_first_line = 2
+        self._test_with_patched_linecache(filename, source, function_name,
+                                          expected_first_line)
+
+    def test_string_eval_linecache_indent(self):
+        source = """if True:
+        # indent designed to test against potential indent error in ast.parse
+
+        def foo():
+            pass
+        """
+
+        filename = "<foo-indent>"
+        function_name = "foo"
+        expected_first_line = 5
+        self._test_with_patched_linecache(filename, source, function_name,
+                                          expected_first_line)
+
+    def test_string_eval_linecache_closure(self):
+        source = textwrap.dedent("""
+        def foo_gen():
+            def foo():
+                pass
+            return foo
+
+        generated_foo = foo_gen()
+        """)
+
+        filename = "<foo-gen>"
+        function_name = "generated_foo"
+        expected_first_line = 4
+        self._test_with_patched_linecache(filename, source, function_name,
+                                          expected_first_line)
+
+    def test_string_eval_linecache_stacked_decorators(self):
+        source = textwrap.dedent("""
+        def decorator(function):
+            return function
+
+        @decorator
+        @decorator
+        @decorator
+        def decorated():
+            pass
+        """)
+
+        filename = "<foo-stacked-decorator>"
+        function_name = "decorated"
+        expected_first_line = 9
+        self._test_with_patched_linecache(filename, source, function_name,
+                                          expected_first_line)
+
+    def test_string_eval_linecache_all(self):
+        # A test combining indented code, a closure, and stacked decorators
+        source = """if 1:
+        def decorator(function):
+            return function
+
+        def gen_decorated_foo():
+            @decorator
+            @decorator
+            @decorator
+            def _foo():
+                pass
+
+            return _foo
+
+        foo_all = gen_decorated_foo()
+        """
+
+        filename = "<foo-all>"
+        function_name = "foo_all"
+        expected_first_line = 10
+        self._test_with_patched_linecache(filename, source, function_name,
+                                          expected_first_line)
 
     def test_single_line_function(self):
         @njit


### PR DESCRIPTION
This enables lineinfo to be produced for cells in Jupyter notebooks.

This was initially manually verified with a kernel in source in a .py file and the same in a Jupyter notebook, with `lineinfo=True` - these two cases produce PTX with identical lineinfo (`.loc` directives).

A test that modifies the linecache in a similar manner to the Jupyter notebook is added. This is based on the `test_string_eval` test, but the difference is that the first line finder does succeed in finding the first line from the linecache.

Fixes #9385.