### PR TITLE
Add env-var NUMBA_JIT_COVERAGE to disable coverage

### DIFF
--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -279,6 +279,11 @@ These variables influence what is printed out during compilation of
 
     *Default value*: ``0`` (Off)
 
+.. envvar:: NUMBA_JIT_COVERAGE
+
+   Set to ``1`` to enable coverage data reporting by the JIT compiler on 
+   compiled source lines. Default to ``0`` (Off).
+
 .. seealso::
    :ref:`numba-troubleshooting` and :ref:`architecture`.
 

--- a/docs/upcoming_changes/9887.change.rst
+++ b/docs/upcoming_changes/9887.change.rst
@@ -1,0 +1,5 @@
+Add ``NUMBA_JIT_COVERAGE`` to control coverage support
+------------------------------------------------------
+
+The new ``NUMBA_JIT_COVERAGE`` environment variable enables or disables coverage
+support. Coverage is disabled by default.

--- a/numba/core/config.py
+++ b/numba/core/config.py
@@ -568,6 +568,14 @@ class _EnvReloader(object):
             "NUMBA_LLVM_PASS_TIMINGS", int, 0,
         )
 
+        # Coverage support.
+
+        # JIT_COVERAGE (bool) controls whether the compiler report compiled
+        # lines to coverage tools. Defaults to off.
+        JIT_COVERAGE = _readenv(
+            "NUMBA_JIT_COVERAGE", int, 0,
+        )
+
         # Inject the configuration values into the module globals
         for name, value in locals().copy().items():
             if name.isupper():

--- a/numba/misc/coverage_support.py
+++ b/numba/misc/coverage_support.py
@@ -10,7 +10,7 @@ from abc import ABC, abstractmethod
 import atexit
 from functools import cache
 
-from numba.core import ir
+from numba.core import ir, config
 
 
 try:
@@ -38,6 +38,9 @@ def get_registered_loc_notify() -> Sequence["NotifyLocBase"]:
     """
     Returns a list of the registered NotifyLocBase instances.
     """
+    if not config.JIT_COVERAGE:
+        # Coverage disabled.
+        return []
     return list(filter(lambda x: x is not None,
                        (factory() for factory in _the_registry)))
 

--- a/numba/tests/test_misc_coverage_support.py
+++ b/numba/tests/test_misc_coverage_support.py
@@ -9,6 +9,7 @@ from numba.misc.coverage_support import NotifyLocBase, _the_registry
 
 
 class TestMiscCoverageSupport(TestCase):
+    @TestCase.run_test_in_subprocess(envvars={"NUMBA_JIT_COVERAGE": "1"})
     def test_custom_loc_notifier(self):
         class MyNotify(NotifyLocBase):
             records = []


### PR DESCRIPTION
Workaround for #9859 and an minimal risk alternative to https://github.com/numba/numba/pull/9862 for the 0.61.0 final.

Introduce an environment variable to control coverage data reporting from the JIT compiler. This disables the coverage feature by default.