### PR TITLE
Prevent bools from if ops being interpreted as user variables

### DIFF
--- a/docs/upcoming_changes/9888.bug_fix.rst
+++ b/docs/upcoming_changes/9888.bug_fix.rst
@@ -1,5 +1,6 @@
-Avoid declaring if op bools in debug info
------------------------------------------
+Avoid declaring ``if`` operation bools in debug info
+----------------------------------------------------
 
-Internal bool variables that hold the result of conditional tests in if ops are
-no longer declared, and therefore can't show up in the locals in GDB.
+Internal bool variables that hold the result of conditional tests in ``if``
+operations are no longer declared, and therefore can't show up in the
+``locals`` in GDB.

--- a/docs/upcoming_changes/9888.bug_fix.rst
+++ b/docs/upcoming_changes/9888.bug_fix.rst
@@ -1,0 +1,5 @@
+Avoid declaring if op bools in debug info
+-----------------------------------------
+
+Internal bool variables that hold the result of conditional tests in if ops are
+no longer declared, and therefore can't show up in the locals in GDB.

--- a/numba/core/interpreter.py
+++ b/numba/core/interpreter.py
@@ -3055,7 +3055,7 @@ class Interpreter(object):
         truebr = brs[iftrue]
         falsebr = brs[not iftrue]
 
-        name = "bool%s" % (inst.offset)
+        name = "$bool%s" % (inst.offset)
         gv_fn = ir.Global("bool", bool, loc=self.loc)
         self.store(value=gv_fn, name=name)
 


### PR DESCRIPTION
The convention for user variables is that they don't begin with "$". Bools from if ops violate this convention by using the name `bool<X>`.

The result of them being seen as user variables is that they appear in the debug info, which we don't want (e.g. `info locals` can show `bool<X>` names that will be unfamiliar to the user).

This PR prepends a $ to their name in order to keep their names hidden from debug info, and tests that if op bools are no longer declared with debug intrinsics in the LLVM IR.