### PR TITLE
[UX] TypedDict: better error message for KeyError

### DIFF
--- a/docs/upcoming_changes/9892.improvement.rst
+++ b/docs/upcoming_changes/9892.improvement.rst
@@ -1,0 +1,7 @@
+[UX] TypedDict: better error message for KeyError #9892
+-------------------------------------------------------
+
+The ``KeyError`` raised from ``__getitem__`` for the ``numba.typed.Dict`` in
+case of an non-existing key now reports the value of the key. This behaviour is
+in-line with regular ``dict``s via CPython.
+

--- a/docs/upcoming_changes/9892.improvement.rst
+++ b/docs/upcoming_changes/9892.improvement.rst
@@ -3,5 +3,5 @@
 
 The ``KeyError`` raised from ``__getitem__`` for the ``numba.typed.Dict`` in
 case of an non-existing key now reports the value of the key. This behaviour is
-in-line with regular ``dict``s via CPython.
+in-line with the regular ``dict`` via CPython.
 

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -124,9 +124,9 @@ class TestDictObject(MemoryLeakMixin, TestCase):
         self.assert_no_memory_leak()
         # disable leak check for exception test
         self.disable_leak_check()
-        with self.assertRaises(KeyError):
+        with self.assertRaisesRegex(KeyError, "0"):
             foo(keys, vals, 0)
-        with self.assertRaises(KeyError):
+        with self.assertRaisesRegex(KeyError, "4"):
             foo(keys, vals, 4)
 
     def test_dict_popitem(self):

--- a/numba/typed/dictobject.py
+++ b/numba/typed/dictobject.py
@@ -775,7 +775,7 @@ def impl_getitem(d, key):
         castedkey = _cast(key, keyty)
         ix, val = _dict_lookup(d, castedkey, hash(castedkey))
         if ix == DKIX.EMPTY:
-            raise KeyError()
+            raise KeyError(f"Key \"{key}\" of type {keyty} not found in dict")
         elif ix < DKIX.EMPTY:
             raise AssertionError("internal dict error during lookup")
         else:

--- a/numba/typed/dictobject.py
+++ b/numba/typed/dictobject.py
@@ -775,7 +775,7 @@ def impl_getitem(d, key):
         castedkey = _cast(key, keyty)
         ix, val = _dict_lookup(d, castedkey, hash(castedkey))
         if ix == DKIX.EMPTY:
-            raise KeyError(f"Key \"{key}\" of type {keyty} not found in dict")
+            raise KeyError(key)
         elif ix < DKIX.EMPTY:
             raise AssertionError("internal dict error during lookup")
         else:


### PR DESCRIPTION
Followup from https://github.com/numba/numba/pull/9530

The error message has been updated to the format:

```
KeyError: <KEYVALUE>
```

... since this is what the CPython does with a regular Python dict:

```
In [1]: d = {}

In [2]: d[0]
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
Cell In[2], line 1
----> 1 d[0]

KeyError: 0
```

Tests for the correct message are now included.

