### PR TITLE
[DUX] fix use of rstcheck in towncrier check script

### DIFF
--- a/docs/upcoming_changes/9893.bug_fix.rst
+++ b/docs/upcoming_changes/9893.bug_fix.rst
@@ -1,0 +1,8 @@
+[DUX] fix use of rstcheck in towncrier check script
+---------------------------------------------------
+
+The script ``maint/towncrier_rst_validator.py`` now correctly reports any RST
+issues encountered when calling ``rstcheck`` via ``subprocess.chck_output``.
+This helps to improve the developer experience as any issues are reported
+directly and the developers no longer need to be confused and/or run a
+secondary tools

--- a/maint/towncrier_rst_validator.py
+++ b/maint/towncrier_rst_validator.py
@@ -1,6 +1,7 @@
-from subprocess import STDOUT, check_output
+from subprocess import STDOUT, check_output, CalledProcessError
 import argparse
 import os
+import sys
 
 manual_mode = False
 parser=argparse.ArgumentParser()
@@ -104,7 +105,12 @@ with open(file, "r") as f:
     print(f"\nPassed: File contents are valid\n")
 
 print(f"Validating RST")
-output = check_output(["rstcheck", file], stderr=STDOUT, encoding="utf-8")
-assert "Success! No issues detected." in output, \
-    "File is not a valid .rst file. Please check for errors using rstcheck"
-print(f"Passed: rstcheck passed")
+try:
+    output = check_output(["rstcheck", file], stderr=STDOUT, encoding="utf-8")
+except CalledProcessError as cpe:
+    print(f"Failed: rstcheck failed")
+    print(cpe.output)
+    sys.exit(cpe.returncode)
+else:
+    assert "Success! No issues detected." in output
+    print(f"Passed: rstcheck passed")


### PR DESCRIPTION
This fixes the use of ``check_output`` in the script ``towncrier_rst_validator.py``. Previously, if there was an error when running ``rstcheck`` the actual error message from that tool would just be swallowed by the script.

The following is an example taken from a recent attempt to write a news fragment:

```
$ python maint/towncrier_rst_validator.py --pull_request_id 9892
Found modified .rst files in directory docs/upcoming_changes from git diff:
docs/upcoming_changes/9892.improvement.rst

Found required file: docs/upcoming_changes/9892.improvement.rst

Checking naming convention.
Passed: Filename is valid

Checking file contents:

[UX] TypedDict: better error message for KeyError #9892
-------------------------------------------------------

The ``KeyError`` raised from ``__getitem__`` for the ``numba.typed.Dict`` in
case of an non-existing key now reports the value of the key. This behaviour is
in-line with regular ``dict``s via CPython.

Passed: File contents are valid

Validating RST
Traceback (most recent call last):
  File "/Users/esc/git/numba/maint/towncrier_rst_validator.py", line 107, in <module>
    output = check_output(["rstcheck", file], stderr=STDOUT, encoding="utf-8")
  File "/Users/esc/miniconda3-arm64/envs/numba_3.13/lib/python3.13/subprocess.py", line 472, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
               **kwargs).stdout
               ^^^^^^^^^
  File "/Users/esc/miniconda3-arm64/envs/numba_3.13/lib/python3.13/subprocess.py", line 577, in run
    raise CalledProcessError(retcode, process.args,
                             output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['rstcheck', 'docs/upcoming_changes/9892.improvement.rst']' returned non-zero exit status 1.
```

This PR modifys the script such that the output is now:

```
$ python maint/towncrier_rst_validator.py --pull_request_id 9892                                                                                                                                  :(
Found modified .rst files in directory docs/upcoming_changes from git diff:
docs/upcoming_changes/9892.improvement.rst

Found required file: docs/upcoming_changes/9892.improvement.rst

Checking naming convention.
Passed: Filename is valid

Checking file contents:

[UX] TypedDict: better error message for KeyError #9892
-------------------------------------------------------

The ``KeyError`` raised from ``__getitem__`` for the ``numba.typed.Dict`` in
case of an non-existing key now reports the value of the key. This behaviour is
in-line with regular ``dict``s via CPython.

Passed: File contents are valid

Validating RST
Failed: rstcheck failed
docs/upcoming_changes/9892.improvement.rst:4: (WARNING/2) Inline literal start-string without end-string.
Error! Issues detected.
```

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
