### PR TITLE
Prevent cache invalidation due to file system differences on various systems

### DIFF
--- a/docs/source/developer/caching.rst
+++ b/docs/source/developer/caching.rst
@@ -105,3 +105,33 @@ Related Environment Variables
 -----------------------------
 
 See :ref:`env-vars for caching <numba-envvars-caching>`.
+
+Cache Locators
+--------------
+
+Numba uses cache locators to determine where to store and find cached compiled
+functions. The following cache locators are available:
+
+**InTreeCacheLocator**
+    Stores cache files next to the source files in a ``__pycache__`` directory,
+    similar to how Python stores ``.pyc`` files.
+
+**InTreeCacheLocatorFsAgnostic**
+    A variant of ``InTreeCacheLocator`` that is agnostic to filesystem
+    differences, particularly timestamp precision. This locator floors
+    timestamps to seconds, making it suitable for environments where
+    filesystem timestamp precision may vary (e.g., when sharing cache across
+    different filesystems or systems).
+
+**UserWideCacheLocator**
+    Stores cache files in a user-wide application directory using the
+    ``appdirs`` package.
+
+**IPythonCacheLocator**
+    Stores cache files in an IPython-specific cache directory.
+
+**ZipCacheLocator**
+    Handles caching for functions defined in zip files.
+
+The order and selection of cache locators can be customized using the
+:envvar:`NUMBA_CACHE_LOCATOR_CLASSES` environment variable.

--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -472,6 +472,25 @@ Options for the compilation cache.
     Also see :ref:`docs on cache sharing <cache-sharing>` and
     :ref:`docs on cache clearing <cache-clearing>`
 
+.. envvar:: NUMBA_CACHE_LOCATOR_CLASSES
+
+    Override the default cache locator classes and their order. If defined,
+    this should be a comma-separated list of cache locator class names.
+
+    Available locator classes include:
+
+    - ``InTreeCacheLocator`` - Cache next to source files in ``__pycache__``
+    - ``InTreeCacheLocatorFsAgnostic`` - Like ``InTreeCacheLocator`` but
+      agnostic to filesystem timestamp precision differences
+    - ``UserWideCacheLocator`` - Cache in user-wide application directory
+    - ``IPythonCacheLocator`` - Cache in IPython-specific directory
+    - ``ZipCacheLocator`` - Cache for functions in zip files
+
+    Custom locator classes can also be specified using their full module path
+    (e.g., ``mymodule.MyCustomLocator``).
+
+    If not defined, Numba uses the default locator order.
+
 
 .. _numba-envvars-gpu-support:
 

--- a/docs/upcoming_changes/9899.new_feature.rst
+++ b/docs/upcoming_changes/9899.new_feature.rst
@@ -1,5 +1,5 @@
 Add NUMBA_CACHE_LOCATOR_CLASSES environment variable and InTreeCacheLocatorFsAgnostic
----------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------
 
 A new environment variable :envvar:`NUMBA_CACHE_LOCATOR_CLASSES` has been added
 that allows users to override the default cache locator classes and their order.

--- a/docs/upcoming_changes/9899.new_feature.rst
+++ b/docs/upcoming_changes/9899.new_feature.rst
@@ -1,7 +1,7 @@
 Add NUMBA_CACHE_LOCATOR_CLASSES environment variable and InTreeCacheLocatorFsAgnostic
 -------------------------------------------------------------------------------------
 
-A new environment variable :envvar:`NUMBA_CACHE_LOCATOR_CLASSES` has been added
+A new environment variable `NUMBA_CACHE_LOCATOR_CLASSES` has been added
 that allows users to override the default cache locator classes and their order.
 This variable accepts a comma-separated list of locator class names.
 

--- a/docs/upcoming_changes/9899.new_feature.rst
+++ b/docs/upcoming_changes/9899.new_feature.rst
@@ -1,0 +1,12 @@
+Add NUMBA_CACHE_LOCATOR_CLASSES environment variable and InTreeCacheLocatorFsAgnostic
+---------------------------------------------------------------------------------
+
+A new environment variable :envvar:`NUMBA_CACHE_LOCATOR_CLASSES` has been added
+that allows users to override the default cache locator classes and their order.
+This variable accepts a comma-separated list of locator class names.
+
+Additionally, a new cache locator class ``InTreeCacheLocatorFsAgnostic`` has been
+introduced. This locator is a subclass of ``InTreeCacheLocator`` that is agnostic
+to filesystem differences, particularly timestamp precision differences (e.g.,
+milliseconds vs seconds). This helps ensure cache consistency across different
+filesystems and environments.

--- a/numba/core/config.py
+++ b/numba/core/config.py
@@ -283,6 +283,11 @@ class _EnvReloader(object):
         # Contains path to the directory
         CACHE_DIR = _readenv("NUMBA_CACHE_DIR", str, "")
 
+        # Override default cache locators list including their order
+        # Comma separated list of locator class names,
+        # see _locator_classes in caching submodule
+        CACHE_LOCATOR_CLASSES = _readenv("NUMBA_CACHE_LOCATOR_CLASSES", str, "")
+
         # Enable tracing support
         TRACE = _readenv("NUMBA_TRACE", int, 0)
 

--- a/numba/tests/test_caching.py
+++ b/numba/tests/test_caching.py
@@ -14,10 +14,17 @@ from pathlib import Path
 
 import llvmlite.binding as ll
 import numpy as np
+from math import floor
 
 from numba import njit
 from numba.core import codegen
-from numba.core.caching import _UserWideCacheLocator, _ZipCacheLocator
+from numba.core.caching import (
+    UserWideCacheLocator,
+    ZipCacheLocator,
+    FunctionCache,
+    InTreeCacheLocator,
+    InTreeCacheLocatorFsAgnostic,
+)
 from numba.core.errors import NumbaWarning
 from numba.parfors import parfor
 from numba.tests.support import (
@@ -30,6 +37,7 @@ from numba.tests.support import (
     skip_if_typeguard,
     skip_parfors_unsupported,
     temp_directory,
+    override_env_config,
 )
 
 from numba.core.registry import cpu_target
@@ -538,14 +546,14 @@ class TestCache(DispatcherCacheUsecasesTest):
             source = inspect.getfile(function)
             # doesn't return anything, since it cannot find the module
             # fails unless the executable is frozen
-            locator = _UserWideCacheLocator.from_function(function, source)
+            locator = UserWideCacheLocator.from_function(function, source)
             self.assertIsNone(locator)
 
             sys.frozen = True
             # returns a cache locator object, only works when the executable
             # is frozen
-            locator = _UserWideCacheLocator.from_function(function, source)
-            self.assertIsInstance(locator, _UserWideCacheLocator)
+            locator = UserWideCacheLocator.from_function(function, source)
+            self.assertIsInstance(locator, UserWideCacheLocator)
 
         finally:
             function.__code__ = old_code
@@ -781,7 +789,7 @@ class TestCacheZipLib(DispatcherCacheUsecasesTest):
 
         zip_path = "/path/to/archive.zip/module.py"
 
-        locator = _ZipCacheLocator.from_function(mock_func, zip_path)
+        locator = ZipCacheLocator.from_function(mock_func, zip_path)
         self.assertIsNotNone(locator)
         self.assertEqual(locator._zip_path, str(Path("/path/to/archive.zip")))
         self.assertEqual(locator._internal_path, "module.py")
@@ -793,7 +801,7 @@ class TestCacheZipLib(DispatcherCacheUsecasesTest):
 
         non_zip_path = "/path/to/module.py"
 
-        locator = _ZipCacheLocator.from_function(mock_func, non_zip_path)
+        locator = ZipCacheLocator.from_function(mock_func, non_zip_path)
         self.assertIsNone(locator)
 
 
@@ -1178,6 +1186,137 @@ class TestCFuncCache(BaseCacheTest):
         self.check_module(mod)
 
         self.run_in_separate_process()
+
+
+class TestLocator(InTreeCacheLocator):
+    pass
+
+
+class TestCacheLocatorEnvironmentIntegration(TestCase):
+    """Integration tests for environment variable functionality."""
+
+    def test_locators_env_override_unknown(self):
+        def mock_func():
+            return 42
+
+        with override_env_config(
+            "NUMBA_CACHE_LOCATOR_CLASSES",
+            "foo,bar",
+        ):
+            with self.assertRaises(RuntimeError):
+                FunctionCache(mock_func)
+
+    def test_locators_env_override_single(self):
+        def mock_func():
+            return 42
+
+        with override_env_config(
+            "NUMBA_CACHE_LOCATOR_CLASSES",
+            "InTreeCacheLocatorFsAgnostic",
+        ):
+            cache = FunctionCache(mock_func)
+            expectedLocator = InTreeCacheLocatorFsAgnostic
+            self.assertIsInstance(cache._impl.locator,
+                                  expectedLocator)
+
+    def test_locators_env_override_custom(self):
+        def mock_func():
+            return 42
+
+        with override_env_config(
+            "NUMBA_CACHE_LOCATOR_CLASSES",
+            f"{__name__}.TestLocator",
+        ):
+            cache = FunctionCache(mock_func)
+            expectedLocator = TestLocator
+            self.assertIsInstance(cache._impl.locator,
+                                  expectedLocator)
+
+    def test_locators_env_override_list(self):
+        def mock_func():
+            return 42
+
+        locatorClasses = ("InTreeCacheLocatorFsAgnostic,InTreeCacheLocator,"
+                          "IPythonCacheLocator,UserWideCacheLocator")
+        expectedLocator = InTreeCacheLocatorFsAgnostic
+
+        with override_env_config(
+            "NUMBA_CACHE_LOCATOR_CLASSES",
+            locatorClasses,
+        ):
+            cache = FunctionCache(mock_func)
+            self.assertIsInstance(cache._impl.locator, expectedLocator)
+
+    def test_default_locators(self):
+        def mock_func():
+            return 42
+
+        cache = FunctionCache(mock_func)
+        expectedLocator = InTreeCacheLocator
+        self.assertIsInstance(cache._impl.locator, expectedLocator)
+
+
+class TestInTreeCacheLocatorFsAgnostic(TestCase):
+    """Test _InTreeCacheLocatorFsAgnostic class functionality."""
+
+    def test_source_stamp_precision(self):
+        """Test that FsAgnostic locator floors timestamp to seconds."""
+        from .dummy_module import function
+
+        source = inspect.getfile(function)
+
+        # Create regular and FsAgnostic locators
+        regular_locator = InTreeCacheLocator.from_function(function, source)
+        fs_agnostic_locator = InTreeCacheLocatorFsAgnostic.from_function(
+            function, source
+        )
+
+        # Both should be valid locators
+        self.assertIsNotNone(regular_locator)
+        self.assertIsNotNone(fs_agnostic_locator)
+
+        # Get source stamps
+        regular_stamp = regular_locator.get_source_stamp()
+        fs_agnostic_stamp = fs_agnostic_locator.get_source_stamp()
+
+        # Verify structure: (timestamp, size)
+        self.assertEqual(len(regular_stamp), 2)
+        self.assertEqual(len(fs_agnostic_stamp), 2)
+
+        # The second element (size) should be the same
+        self.assertEqual(regular_stamp[1], fs_agnostic_stamp[1])
+
+        # The first element (timestamp) in fs_agnostic should be floored
+        self.assertEqual(fs_agnostic_stamp[0], floor(regular_stamp[0]))
+
+        # Verify that fs_agnostic timestamp is always <= regular timestamp
+        self.assertLessEqual(fs_agnostic_stamp[0], regular_stamp[0])
+
+    def test_timestamp_precision_on_fs(self):
+        """Test FsAgnostic timestamp handling using filesystem mtime."""
+
+        from .dummy_module import function
+
+        source = inspect.getfile(function)
+
+        # Test with a file that has a precise timestamp
+        fs_agnostic_locator = InTreeCacheLocatorFsAgnostic.from_function(
+            function, source
+        )
+
+        # Get file stat
+        stat_result = os.stat(source)
+        original_mtime = stat_result.st_mtime
+
+        # Get stamp from locator
+        stamp = fs_agnostic_locator.get_source_stamp()
+
+        # Verify that the timestamp is floored
+        expected_timestamp = floor(original_mtime)
+        self.assertEqual(stamp[0], expected_timestamp)
+
+        # Verify size is correct
+        self.assertEqual(stamp[1], stat_result.st_size)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Depending on a filesystem on host you might or might not get millisecond precision for file timestamps.
This leads to unwanted consequences and cache invalidation.

Concrete use case: compiling and building caches in CI (within Docker container) and using them later in k8s pod.
Alternative to this approach might be AOT compilation, but unfortunately it's not on par feature-wise with JIT compilation. For example, `parallel=True` mode is not supported with AOT.

This PR proposes to ignore milliseconds precision while comparing file and cache timestamps. 
Should be safe enough? 
I'm also wondering why comparison of contents (its hashes) might not be sufficient and one need to involve timestamps at  all?
