### PR TITLE
Implemented np.frombuffer kwargs offset and count

### DIFF
--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -5176,12 +5176,14 @@ def array_astype(context, builder, sig, args):
 
 
 @intrinsic
-def np_frombuffer(typingctx, buffer, dtype, retty):
+def np_frombuffer(typingctx, buffer, dtype, count, offset, retty):
     ty = retty.instance_type
-    sig = ty(buffer, dtype, retty)
+    sig = ty(buffer, dtype, count, offset, retty)
 
     def codegen(context, builder, sig, args):
         bufty = sig.args[0]
+        count_val = args[2]
+        offset_val = args[3]
         aryty = sig.return_type
 
         buf = make_array(bufty)(context, builder, value=args[0])
@@ -5191,20 +5193,37 @@ def np_frombuffer(typingctx, buffer, dtype, retty):
 
         itemsize = get_itemsize(context, aryty)
         ll_itemsize = Constant(buf.itemsize.type, itemsize)
+        offset_bytes = builder.mul(offset_val, ll_itemsize)
         nbytes = builder.mul(buf.nitems, buf.itemsize)
+        nbytes = builder.sub(nbytes, offset_bytes)
 
-        # Check that the buffer size is compatible
-        rem = builder.srem(nbytes, ll_itemsize)
-        is_incompatible = cgutils.is_not_null(builder, rem)
-        with builder.if_then(is_incompatible, likely=False):
-            msg = "buffer size must be a multiple of element size"
+        # Compute number of elements based on count
+        is_count_negative = builder.icmp_signed('<', count_val, ir.Constant(count_val.type, 0))
+
+        with builder.if_else(is_count_negative) as (then_block, else_block):
+            with then_block:
+                bb_if = builder.basic_block
+                num_whole = builder.sdiv(nbytes, ll_itemsize)
+            with else_block:
+                bb_else = builder.basic_block
+
+        result = builder.phi(count_val.type)
+        result.add_incoming(num_whole, bb_if)
+        result.add_incoming(count_val, bb_else)
+
+        # Ensure we don’t exceed the buffer size
+        nbytes_required = builder.mul(result, ll_itemsize)
+        is_too_large = builder.icmp_unsigned('>', nbytes_required, nbytes)
+
+        with builder.if_then(is_too_large, likely=False):
+            msg = "requested count exceeds buffer size"
             context.call_conv.return_user_exc(builder, ValueError, (msg,))
 
-        shape = cgutils.pack_array(builder, [builder.sdiv(nbytes, ll_itemsize)])
+        # Set shape and strides
+        shape = cgutils.pack_array(builder, [result])
         strides = cgutils.pack_array(builder, [ll_itemsize])
-        data = builder.bitcast(
-            buf.data, context.get_value_type(out_datamodel.get_type('data'))
-        )
+
+        data = builder.gep(buf.data, [offset_val])
 
         populate_array(out_ary,
                        data=data,
@@ -5212,15 +5231,16 @@ def np_frombuffer(typingctx, buffer, dtype, retty):
                        strides=strides,
                        itemsize=ll_itemsize,
                        meminfo=buf.meminfo,
-                       parent=buf.parent,)
+                       parent=buf.parent, )
 
         res = out_ary._getvalue()
         return impl_ret_borrowed(context, builder, sig.return_type, res)
+
     return sig, codegen
 
 
 @overload(np.frombuffer)
-def impl_np_frombuffer(buffer, dtype=float):
+def impl_np_frombuffer(buffer, dtype=float, count=-1, offset=0):
     _check_const_str_dtype("frombuffer", dtype)
 
     if not isinstance(buffer, types.Buffer) or buffer.layout != 'C':
@@ -5228,8 +5248,8 @@ def impl_np_frombuffer(buffer, dtype=float):
         raise errors.TypingError(msg)
 
     if (dtype is float or
-        (isinstance(dtype, types.Function) and dtype.typing_key is float) or
-            is_nonelike(dtype)): #default
+            (isinstance(dtype, types.Function) and dtype.typing_key is float) or
+            is_nonelike(dtype)):  # default
         nb_dtype = types.double
     else:
         nb_dtype = ty_parse_dtype(dtype)
@@ -5242,8 +5262,9 @@ def impl_np_frombuffer(buffer, dtype=float):
                f"np.frombuffer({buffer}, {dtype})")
         raise errors.TypingError(msg)
 
-    def impl(buffer, dtype=float):
-        return np_frombuffer(buffer, dtype, retty)
+    def impl(buffer, dtype=float, count=-1, offset=0):
+        return np_frombuffer(buffer, dtype, count, offset, retty)
+
     return impl
 
 


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

Closes https://github.com/numba/numba/issues/8945

Here's a simple test

```
import numpy as np
import numba


@numba.jit(cache=False)
def hello():
    buffer = np.arange(1024 * 1024, 1024 * 1024 + 1024, dtype=np.int64)
    buffer2 = np.frombuffer(buffer, dtype=np.int64)
    buffer3 = np.frombuffer(buffer, dtype=np.int64, count=5, offset=1)
    print(buffer)
    print(buffer2)
    print(buffer3)

    assert len(buffer3) == 5
    assert np.all(buffer[1:6] == buffer3)


hello()
```