### PR TITLE
Adding Edge Case for Median of Empty Array

### DIFF
--- a/numba/np/new_arraymath.py
+++ b/numba/np/new_arraymath.py
@@ -1577,6 +1577,11 @@ def _median_inner(temp_arry, n):
     The main logic of the median() call.  *temp_arry* must be disposable,
     as this function will mutate it.
     """
+    
+    # New code
+    if n == 0:
+        return np.nan
+
     low = 0
     high = n - 1
     half = n >> 1

--- a/numba/np/old_arraymath.py
+++ b/numba/np/old_arraymath.py
@@ -1577,6 +1577,11 @@ def _median_inner(temp_arry, n):
     The main logic of the median() call.  *temp_arry* must be disposable,
     as this function will mutate it.
     """
+
+    # New code
+    if n == 0:
+        return np.nan
+
     low = 0
     high = n - 1
     half = n >> 1

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -17,6 +17,8 @@ from numba.tests.support import (TestCase, MemoryLeakMixin,
 TIMEDELTA_M = 'timedelta64[M]'
 TIMEDELTA_Y = 'timedelta64[Y]'
 
+def median_function(arr, n):
+    return np.median(arr, n)
 
 def np_around_array(arr, decimals, out):
     np.around(arr, decimals, out)
@@ -272,6 +274,7 @@ def array_dot_chain(a, b):
 
 def array_ctor(n, dtype):
     return np.ones(n, dtype=dtype)
+    
 
 class TestArrayMethods(MemoryLeakMixin, TestCase):
     """
@@ -1812,6 +1815,12 @@ class TestArrayComparisons(TestCase):
 
     # Other comparison operators ('==', etc.) are tested in test_ufuncs
 
+class TestMedianFunction(TestCase):
+    # Testing empty to ensure nan return.
+
+    def test_empty_array(self):
+        arr = np.array([])
+        self.assertTrue(np.isnan(median_function(arr, 0))) 
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I added in an edge case catcher within the calculate median function to catch empty arrays.