### PR TITLE
Replace deprecated abstractproperty and abstractclassmethod

### DIFF
--- a/numba/core/caching.py
+++ b/numba/core/caching.py
@@ -3,7 +3,7 @@ Caching mechanism for compiled functions.
 """
 
 
-from abc import ABCMeta, abstractmethod, abstractproperty
+from abc import ABCMeta, abstractmethod
 import contextlib
 import errno
 import hashlib
@@ -37,7 +37,8 @@ def _cache_log(msg, *args):
 
 class _Cache(metaclass=ABCMeta):
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def cache_path(self):
         """
         The base filesystem path of this cache (for example its root folder).

--- a/numba/core/serialize.py
+++ b/numba/core/serialize.py
@@ -214,7 +214,8 @@ class ReduceMixin(abc.ABC):
     def _reduce_states(self):
         raise NotImplementedError
 
-    @abc.abstractclassmethod
+    @classmethod
+    @abc.abstractmethod
     def _rebuild(cls, **kwargs):
         raise NotImplementedError
 

--- a/numba/core/types/abstract.py
+++ b/numba/core/types/abstract.py
@@ -1,4 +1,4 @@
-from abc import ABCMeta, abstractmethod, abstractproperty
+from abc import ABCMeta, abstractmethod
 from typing import Dict as ptDict, Type as ptType
 import itertools
 import weakref
@@ -295,7 +295,8 @@ class DTypeSpec(Type):
     (e.g. np.empty()).
     """
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def dtype(self):
         """
         The actual dtype denoted by this dtype spec (a Type instance).
@@ -307,7 +308,8 @@ class IterableType(Type):
     Base class for iterable types.
     """
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def iterator_type(self):
         """
         The iterator type obtained when calling iter() (explicitly or implicitly).
@@ -338,7 +340,8 @@ class IteratorType(IterableType):
     def __init__(self, name, **kwargs):
         super(IteratorType, self).__init__(name, **kwargs)
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def yield_type(self):
         """
         The type of values yielded by the iterator.
@@ -382,7 +385,8 @@ class ArrayCompatible(Type):
     # for '__array_wrap__' with arguments (input, formal result).
     array_priority = 0.0
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def as_array(self):
         """
         The equivalent array type, for operations supporting array-compatible


### PR DESCRIPTION
Linter caught these. I couldn't find a schedule for these to be removed. No urgency.