### PR TITLE
Ensure _launch_threads is called if cached function calls a parallel=True function.

### DIFF
--- a/numba/core/codegen.py
+++ b/numba/core/codegen.py
@@ -647,6 +647,7 @@ class CPUCodeLibrary(CodeLibrary):
             str(self._codegen._create_empty_module(self.name)))
         self._final_module.name = cgutils.normalize_ir_text(self.name)
         self._shared_module = None
+        self._reload_init = set()
 
     def _optimize_functions(self, ll_module):
         """
@@ -760,6 +761,8 @@ class CPUCodeLibrary(CodeLibrary):
         seen = set()
         for library in self._linking_libraries:
             if library not in seen:
+                # Parent inherits reload_init
+                self._reload_init.update(library._reload_init)
                 seen.add(library)
                 self._final_module.link_in(
                     library._get_module_for_linking(), preserve=True,

--- a/numba/core/typed_passes.py
+++ b/numba/core/typed_passes.py
@@ -453,6 +453,8 @@ class BaseNativeLowering(abc.ABC, LoweringPass):
         flags = state.flags
         metadata = state.metadata
         pre_stats = llvm.passmanagers.dump_refprune_stats()
+        # Add reload functions to library
+        library._reload_init.update(state.reload_init)
 
         msg = ("Function %s failed at nopython "
                "mode lowering" % (state.func_id.func_name,))
@@ -498,6 +500,7 @@ class BaseNativeLowering(abc.ABC, LoweringPass):
                 # We also register its library to allow for inlining.
                 cfunc = targetctx.get_executable(library, fndesc, env)
                 targetctx.insert_user_function(cfunc, fndesc, [library])
+                state.reload_init.extend(library._reload_init)
                 state['cr'] = _LowerResult(fndesc, call_helper,
                                            cfunc=cfunc, env=env)
 


### PR DESCRIPTION
Resolves #9938 

Put reload_init from compilation state into code library and then merge called function's reload_init into the parent function.  This process is naturally recursive as the compilation process is naturally recursive so reload_init's from called functions now percolate up to their callee's.

