### PR TITLE
Use linkonce_odr linkage for `__excinfo_unwrap_args` global 

### DIFF
--- a/numba/core/callconv.py
+++ b/numba/core/callconv.py
@@ -564,6 +564,8 @@ class CPUCallConv(BaseCallConv):
 
         fnty = ir.FunctionType(GENERIC_POINTER, [GENERIC_POINTER])
         fn = ir.Function(module, fnty, name)
+        # Linkage is changed to linkonce_odr for PYCC.
+        fn.linkage = "external"
 
         # prevent the function from being inlined
         fn.attributes.add('nounwind')

--- a/numba/core/callconv.py
+++ b/numba/core/callconv.py
@@ -564,7 +564,7 @@ class CPUCallConv(BaseCallConv):
 
         fnty = ir.FunctionType(GENERIC_POINTER, [GENERIC_POINTER])
         fn = ir.Function(module, fnty, name)
-        # Linkage is changed to linkonce_odr for PYCC.
+        # Linkage is changed to linkonce_odr for PYCC. External is the default.
         fn.linkage = "external"
 
         # prevent the function from being inlined

--- a/numba/pycc/compiler.py
+++ b/numba/pycc/compiler.py
@@ -162,6 +162,12 @@ class _ModuleCompiler(object):
                                 entry.signature.return_type, flags,
                                 locals={}, library=library)
 
+            # Fix up dynamic exc globals
+            module = library._final_module
+            for gv in module.functions:
+                if gv.name.startswith("__excinfo_unwrap_args"):
+                    gv.linkage = "linkonce_odr"
+
             func_name = cres.fndesc.llvm_func_name
             llvm_func = cres.library.get_function(func_name)
 

--- a/numba/tests/compile_with_pycc.py
+++ b/numba/tests/compile_with_pycc.py
@@ -132,3 +132,16 @@ def internal_str_dict(x):
 @cc_nrt.export('hash_literal_str_A', i8())
 def internal_str_dict():
     return hash("A")
+
+
+# For test dynamic exception
+
+cc_dynexc = CC('pycc_test_dynamic_exc')
+
+@cc_dynexc.export('do_setitem1', 'void(f8[:, :], f8[:, :])')
+def do_setitem1(a, b):
+    a[:, :] = b
+
+@cc_dynexc.export('do_setitem2', 'void(f8[:, :], f8[:, :])')
+def do_setitem2(a, b):
+    a[:, :] = b

--- a/numba/tests/compile_with_pycc.py
+++ b/numba/tests/compile_with_pycc.py
@@ -134,7 +134,7 @@ def internal_str_dict():
     return hash("A")
 
 
-# For test dynamic exception
+# For testing dynamic exception symbol collision/linkage
 
 cc_dynexc = CC('pycc_test_dynamic_exc')
 

--- a/numba/tests/test_pycc.py
+++ b/numba/tests/test_pycc.py
@@ -265,7 +265,7 @@ class TestCC(BasePYCCTest):
     def test_dynamic_exc(self):
         """See https://github.com/numba/numba/issues/9948
 
-        Dynamic exception uses a symbol that in PYCC compilation must be come
+        Dynamic exception uses a symbol that in PYCC compilation must become
         linkonce_odr linkage to prevent symbol collision.
         """
         with self.check_cc_compiled(self._test_module.cc_dynexc) as lib:

--- a/numba/tests/test_pycc.py
+++ b/numba/tests/test_pycc.py
@@ -262,6 +262,44 @@ class TestCC(BasePYCCTest):
             expect = arr * arr
             self.assertPreciseEqual(got, expect)
 
+    def test_dynamic_exc(self):
+        """See https://github.com/numba/numba/issues/9948
+
+        Dynamic exception uses a symbol that in PYCC compilation must be come
+        linkonce_odr linkage to prevent symbol collision.
+        """
+        with self.check_cc_compiled(self._test_module.cc_dynexc) as lib:
+            # these cases do not raise
+            a = np.zeros((2, 2), dtype=np.float64)
+            b = np.ones((2, 2), dtype=np.float64)
+            lib.do_setitem1(a, b)
+            self.assertPreciseEqual(a, b)
+
+            a = np.zeros((2, 2), dtype=np.float64)
+            lib.do_setitem2(a, b)
+            self.assertPreciseEqual(a, b)
+
+            # these cases will raise a dynamic exc
+            a = np.zeros((2, 2), dtype=np.float64)
+            b = np.ones((2, 3), dtype=np.float64)
+            with self.assertRaises(ValueError) as raises:
+                lib.do_setitem1(a, b)
+
+            self.assertIn(
+                f"cannot assign slice of shape {b.shape} from "
+                f"input of shape {a.shape}",
+                str(raises.exception))
+
+            a = np.zeros((4, 6), dtype=np.float64)
+            b = np.ones((4, 5), dtype=np.float64)
+            with self.assertRaises(ValueError) as raises:
+                lib.do_setitem2(a, b)
+
+            self.assertIn(
+                f"cannot assign slice of shape {b.shape} from "
+                f"input of shape {a.shape}",
+                str(raises.exception))
+
 
 @needs_setuptools
 @skip_if_py313_on_windows


### PR DESCRIPTION

Fixes https://github.com/numba/numba/issues/9948