### PR TITLE
update llvmlite artifact name in win-64 builder workflow

### DIFF
--- a/.github/workflows/numba_win-64_builder.yml
+++ b/.github/workflows/numba_win-64_builder.yml
@@ -58,7 +58,7 @@ jobs:
         if: ${{ inputs.llvmlite_run_id != '' }}
         uses: actions/download-artifact@v4
         with:
-          name: llvmlite_win-64_conda_py${{ matrix.python-version }}
+          name: llvmlite-win-64-py${{ matrix.python-version }}
           path: llvmlite_conda
           run-id: ${{ inputs.llvmlite_run_id }}
           repository: numba/llvmlite
@@ -134,7 +134,7 @@ jobs:
         if: ${{ inputs.llvmlite_run_id != '' }}
         uses: actions/download-artifact@v4
         with:
-          name: llvmlite_win-64_conda_py${{ matrix.python-version }}
+          name: llvmlite-win-64-py${{ matrix.python-version }}
           path: llvmlite_conda
           run-id: ${{ inputs.llvmlite_run_id }}
           repository: numba/llvmlite


### PR DESCRIPTION
This PR is to correct llvmlite artifact name to download. This matches the llvmlite exported artifact on its win conda builder workflow. 