### PR TITLE
update win conda builder test matrix to match buildfarm

### DIFF
--- a/.github/workflows/numba_win-64_builder.yml
+++ b/.github/workflows/numba_win-64_builder.yml
@@ -107,15 +107,21 @@ jobs:
         include:
           # Python 3.10
           - python-version: "3.10"
-            numpy_test: "2.0"
+            numpy_test: "1.24"
+          - python-version: "3.10"
+            numpy_test: "1.25"
           
           # Python 3.11
+          - python-version: "3.11"
+            numpy_test: "1.26"
           - python-version: "3.11"
             numpy_test: "2.0"
           - python-version: "3.11"
             numpy_test: "2.1"
           
           # Python 3.12
+          - python-version: "3.12"
+            numpy_test: "1.26"
           - python-version: "3.12"
             numpy_test: "2.0"
           - python-version: "3.12"


### PR DESCRIPTION
This PR updates and expands the test matrix on conda builder workflow to match this matrix:
- "3.10":
   numpy_test: ["1.24", "1.25"] 
   
- "3.11":
    numpy_test: ["1.26", "2.0", "2.1"]

- "3.12":
    numpy_test: ["1.26", "2.0", "2.1"]

- "3.13":
    numpy_build: "2.1"
    numpy_test: ["2.1"]