### PR TITLE
Fix issue with error handling in slice assignment.

### DIFF
--- a/docs/upcoming_changes/9972.bug_fix.rst
+++ b/docs/upcoming_changes/9972.bug_fix.rst
@@ -1,0 +1,7 @@
+Fix issue in code generation for array set-slice.
+-------------------------------------------------
+
+The code generation for array set-slice was inadvertently written as being CPU
+target specific. This is now rectified and refactored so as to provide a
+"generic" target version that should be safe to use everywhere, along with an
+``@overload``-able stub to allow targets to implement custom versions as needed.

--- a/numba/cuda/tests/cudapy/test_slicing.py
+++ b/numba/cuda/tests/cudapy/test_slicing.py
@@ -1,6 +1,6 @@
 import numpy as np
-from numba import cuda
-from numba.cuda.testing import unittest, CUDATestCase
+from numba import cuda, errors
+from numba.cuda.testing import unittest, CUDATestCase, skip_on_cudasim
 
 
 def foo(inp, out):
@@ -32,29 +32,45 @@ class TestCudaSlicing(CUDATestCase):
         arr = cuda.device_array(len(a))
         arr[:] = cuda.to_device(a)
 
-    def test_slice_error_handling_codegen(self):
-        # This checks that the error handling code for invalid slice assignment
-        # will compile for the CUDA target. There is nothing to run or check
-        # because the CUDA target cannot propagate the raised exception across
-        # the (generated) function call boundary, in essence it fails silently.
-        # Further the built-in CUDA implementation does not support a "dynamic"
-        # sequence type (i.e. list or set) as it has no NRT available. As a
-        # result it's not possible at runime to take the execution path for
-        # raising the exception coming from the "sequence" side of the
-        # "mismatched" set-slice operation code generation. This is because it
-        # is preempted by an exception raised from the tuple being "seen" as the
-        # wrong size earlier in the execution.
-        # See #9906 for context.
+    # NOTE: The following applies to:
+    # - test_array_slice_assignment_from_sequence_error_handling_codegen
+    # - test_array_slice_assignment_from_array_error_handling_codegen
+    #
+    # This checks that the error handling code for invalid slice assignment
+    # will compile for the CUDA target. There is nothing to check at run time
+    # because the CUDA target cannot propagate the raised exception across
+    # the (generated) function call boundary, in essence it fails silently.
+    # Further the built-in CUDA implementation does not support a "dynamic"
+    # sequence type (i.e. list or set) as it has no NRT available. As a
+    # result it's not possible at run time to take the execution path for
+    # raising the exception coming from the "sequence" side of the
+    # "mismatched" set-slice operation code generation. This is because it
+    # is preempted by an exception raised from the tuple being "seen" as the
+    # wrong size earlier in the execution. Also, due to lack of the NRT, the
+    # path for setting an array slice to a buffer value will not compile for
+    # CUDA and testing is best-effort (it checks compilation was ok up to
+    # the point it cannot get past without the NRT).
+    # See #9906 for context.
 
-        # Compile the "assign slice from sequence" path
+    def test_array_slice_assignment_from_sequence_error_handling_codegen(self):
+        # Compile the "assign slice from sequence" path, this should compile
+        # without error, but will not execute correctly without exception
+        # propagation.
         @cuda.jit("void(f4[:, :, :], i4, i4)")
         def check_sequence_setslice(tmp, a, b):
             tmp[a, b] = 1, 1, 1
 
-        # Compile the "assign slice from array" path
-        @cuda.jit("void(f4[:, :, :], f4[:], i4, i4)")
-        def check_array_setslice(tmp, value, a, b):
-            tmp[a, b] = value
+    @skip_on_cudasim("No NRT codegen in the CUDA simulator")
+    def test_array_slice_assignment_from_array_error_handling_codegen(self):
+        # Compile the "assign slice from array" path, it will fail, but only
+        # when it tries to do code generation for a potential array copy.
+        with self.assertRaises(errors.NumbaRuntimeError) as raises:
+            @cuda.jit("void(f4[:, :, :], f4[:], i4, i4)")
+            def check_array_setslice(tmp, value, a, b):
+                tmp[a, b] = value
+
+        msg = "NRT required but not enabled"
+        self.assertIn(msg, str(raises.exception))
 
 
 if __name__ == '__main__':

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1619,6 +1619,43 @@ def numpy_broadcast_arrays(*args):
     return impl
 
 
+def raise_with_shape_context(src_shapes, index_shape):
+    """Targets should implement this if they wish to specialize the error
+    handling/messages. The overload implementation takes two tuples as arguments
+    and should raise a ValueError."""
+    raise NotImplementedError
+
+
+@overload(raise_with_shape_context, target="generic")
+def ol_raise_with_shape_context_generic(src_shapes, index_shape):
+    # This overload is for a "generic" target, which makes no assumption about
+    # the NRT or string support, but does assume exceptions can be raised.
+    if ((isinstance(src_shapes, types.BaseTuple) and
+         isinstance(index_shape, types.BaseTuple))):
+        def impl(src_shapes, index_shape):
+            raise ValueError("cannot assign slice from input of different size")
+        return impl
+
+
+@overload(raise_with_shape_context, target="CPU")
+def ol_raise_with_shape_context_cpu(src_shapes, index_shape):
+    if ((isinstance(src_shapes, types.BaseTuple) and
+         isinstance(index_shape, types.BaseTuple))):
+        def impl(src_shapes, index_shape):
+            if len(src_shapes) == 1:
+                shape_str = f"({src_shapes[0]},)"
+            else:
+                shape_str = f"({', '.join([str(x) for x in src_shapes])})"
+            if len(index_shape) == 1:
+                index_str = f"({index_shape[0]},)"
+            else:
+                index_str = f"({', '.join([str(x) for x in index_shape])})"
+            msg = (f"cannot assign slice of shape {shape_str} from input of "
+                   f"shape {index_str}")
+            raise ValueError(msg)
+        return impl
+
+
 def fancy_setslice(context, builder, sig, args, index_types, indices):
     """
     Implement slice assignment for arrays.  This implementation works for
@@ -1636,6 +1673,21 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
     indexer = FancyIndexer(context, builder, aryty, ary,
                            index_types, indices)
     indexer.prepare()
+
+    def raise_shape_mismatch_error(context, builder, src_shapes, index_shape):
+        # This acts as the "trampoline" to raise a ValueError in the case
+        # of the source and destination shapes mismatch at runtime. It resolves
+        # the public overload stub `raise_with_shape_context`
+        fnty = context.typing_context.resolve_value_type(
+            raise_with_shape_context)
+        argtys = (types.UniTuple(types.int64, len(src_shapes)),
+                  types.UniTuple(types.int64, len(index_shape)))
+        raise_sig = fnty.get_call_type(context.typing_context, argtys, {})
+        func = context.get_function(fnty, raise_sig)
+        func(builder, (context.make_tuple(builder, raise_sig.args[0],
+                                          src_shapes),
+                       context.make_tuple(builder, raise_sig.args[1],
+                                          index_shape)))
 
     if isinstance(srcty, types.Buffer):
         # Source is an array
@@ -1658,23 +1710,8 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
                                       builder.icmp_signed('!=', u, v))
 
         with builder.if_then(shape_error, likely=False):
-            def raise_impl(src_shapes, index_shape):
-                return ("cannot assign slice of shape " +
-                        f"({', '.join([str(x) for x in src_shapes])}) from " +
-                        "input of shape " +
-                        f"({', '.join([str(x) for x in index_shape])})")
-
-            sig = types.unicode_type(
-                types.UniTuple(types.int64, len(src_shapes)),
-                types.UniTuple(types.int64, len(index_shape)))
-            tup = (context.make_tuple(builder, sig.args[0], src_shapes),
-                   context.make_tuple(builder, sig.args[1], index_shape))
-
-            res = context.compile_internal(builder, raise_impl, sig, tup)
-            msg = impl_ret_new_ref(context, builder, sig, res)
-            context.call_conv.return_dynamic_user_exc(builder, ValueError,
-                                                      (msg,),
-                                                      (types.unicode_type,))
+            raise_shape_mismatch_error(context, builder, src_shapes,
+                                       index_shape)
 
         # Check for array overlap
         src_start, src_end = get_array_memory_extents(context, builder, srcty,
@@ -1706,17 +1743,8 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
         shape_error = builder.icmp_signed('!=', index_shape[0], seq_len)
 
         with builder.if_then(shape_error, likely=False):
-            def raise_impl(seq_len, input_shape):
-                return (f"cannot assign slice of shape ({seq_len}, )" +
-                        f"from input of shape ({input_shape}, )")
-
-            tup = (seq_len, index_shape[0])
-            sig = types.unicode_type(types.int64, types.int64)
-            res = context.compile_internal(builder, raise_impl, sig, tup)
-            msg = impl_ret_new_ref(context, builder, sig, res)
-            context.call_conv.return_dynamic_user_exc(builder, ValueError,
-                                                      (msg,),
-                                                      (types.unicode_type,))
+            raise_shape_mismatch_error(context, builder, (seq_len,),
+                                       (index_shape[0],))
 
         def src_getitem(source_indices):
             idx, = source_indices

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1630,8 +1630,11 @@ def raise_with_shape_context(src_shapes, index_shape):
 def ol_raise_with_shape_context_generic(src_shapes, index_shape):
     # This overload is for a "generic" target, which makes no assumption about
     # the NRT or string support, but does assume exceptions can be raised.
-    if ((isinstance(src_shapes, types.BaseTuple) and
-         isinstance(index_shape, types.BaseTuple))):
+    if (isinstance(src_shapes, types.UniTuple) and
+        isinstance(index_shape, types.UniTuple) and
+        src_shapes.dtype == index_shape.dtype and
+            isinstance(src_shapes.dtype, types.Integer)):
+
         def impl(src_shapes, index_shape):
             raise ValueError("cannot assign slice from input of different size")
         return impl
@@ -1639,8 +1642,11 @@ def ol_raise_with_shape_context_generic(src_shapes, index_shape):
 
 @overload(raise_with_shape_context, target="CPU")
 def ol_raise_with_shape_context_cpu(src_shapes, index_shape):
-    if ((isinstance(src_shapes, types.BaseTuple) and
-         isinstance(index_shape, types.BaseTuple))):
+    if (isinstance(src_shapes, types.UniTuple) and
+        isinstance(index_shape, types.UniTuple) and
+        src_shapes.dtype == index_shape.dtype and
+            isinstance(src_shapes.dtype, types.Integer)):
+
         def impl(src_shapes, index_shape):
             if len(src_shapes) == 1:
                 shape_str = f"({src_shapes[0]},)"

--- a/numba/tests/test_indexing.py
+++ b/numba/tests/test_indexing.py
@@ -809,6 +809,13 @@ class TestSetItem(TestCase):
         with self.assertRaises(ValueError) as raises:
             cfunc(arg.copy(), *args)
 
+        if flags.get('nopython', False):
+            # if in nopython mode, check the error message from Numba
+            slice_size = len(arg[slice(1, -N + k, 1)])
+            msg = (f"cannot assign slice of shape ({k},) from input of shape "
+                   f"({slice_size},)")
+            self.assertIn(msg, str(raises.exception))
+
     def test_1d_slicing_set_tuple(self, flags=enable_pyobj_flags):
         """
         Tuple to 1d slice assignment


### PR DESCRIPTION
This patch fixes the case where runtime error handling due to a mistmatch in slice assignment needs to be target aware. The CUDA target does not support dynamic string generation (no NRT), whereas the CPU does, therefore exception raising code with a potential runtime generated message needs to specialise based on the current target. This patch implements this by creating a "generic" target overload that raises via a static exception with a constant string message and a "CPU" target overload that raises via an exception with a dynamically generated string message containing extra context about the problem encountered. The CUDA target should "see" the "generic" target overload variant, which will permit compilation, but also allows for future CUDA specific specialisation as needed.

Fixes #9906

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
