### PR TITLE
Add support for default overload values in cuda

### DIFF
--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -842,6 +842,10 @@ class CUDADispatcher(Dispatcher, serialize.ReduceMixin):
 
         A (template, pysig, args, kws) tuple is returned.
         """
+        # Fold keyword arguments and resolve default values
+        pysig, args = self._compiler.fold_argument_types(args, kws)
+        kws = {}
+
         # Ensure an exactly-matching overload is available if we can
         # compile. We proceed with the typing even if we can't compile
         # because we may be able to force a cast on the caller side.

--- a/numba/cuda/tests/cudapy/test_nested_calls.py
+++ b/numba/cuda/tests/cudapy/test_nested_calls.py
@@ -12,8 +12,12 @@ import unittest
 import numpy as np
 
 
-def generated_inner(x, y=5, z=6):
-    assert 0, "unreachable"
+def generated_inner(out, x, y=5, z=6):
+    # Provide implementation for the simulation.
+    if isinstance(x, complex):
+        out[0], out[1] = x + y, z
+    else:
+        out[0], out[1] = x - y, z
 
 
 @overload(generated_inner)

--- a/numba/cuda/tests/cudapy/test_nested_calls.py
+++ b/numba/cuda/tests/cudapy/test_nested_calls.py
@@ -6,8 +6,8 @@ Usually due to invalid type conversion between function boundaries.
 
 from numba import cuda
 from numba.core import types
+from numba.cuda.testing import CUDATestCase
 from numba.extending import overload
-from numba.tests.support import TestCase
 import unittest
 import numpy as np
 
@@ -32,10 +32,10 @@ def ol_generated_inner(out, x, y=5, z=6):
 
 
 def call_generated(a, b, out):
-    return generated_inner(out, a, z=b)
+    generated_inner(out, a, z=b)
 
 
-class TestNestedCall(TestCase):
+class TestNestedCall(CUDATestCase):
     def test_call_generated(self):
         """
         Test a nested function call to a generated jit function.
@@ -44,12 +44,10 @@ class TestNestedCall(TestCase):
 
         out = np.empty(2, dtype=np.int64)
         cfunc[1,1](1, 2, out)
-        cuda.synchronize()
         self.assertPreciseEqual(tuple(out), (-4, 2))
 
         out = np.empty(2, dtype=np.complex64)
         cfunc[1,1](1j, 2, out)
-        cuda.synchronize()
         self.assertPreciseEqual(tuple(map(complex,out)), (5 + 1j, 2 + 0j))
 
 

--- a/numba/cuda/tests/cudapy/test_nested_calls.py
+++ b/numba/cuda/tests/cudapy/test_nested_calls.py
@@ -1,0 +1,53 @@
+"""
+Test problems in nested calls.
+Usually due to invalid type conversion between function boundaries.
+"""
+
+
+from numba import cuda
+from numba.core import types
+from numba.extending import overload
+from numba.tests.support import TestCase
+import unittest
+import numpy as np
+
+
+def generated_inner(x, y=5, z=6):
+    assert 0, "unreachable"
+
+
+@overload(generated_inner)
+def ol_generated_inner(out, x, y=5, z=6):
+    if isinstance(x, types.Complex):
+        def impl(out, x, y=5, z=6):
+            out[0], out[1] = x + y, z
+    else:
+        def impl(out, x, y=5, z=6):
+            out[0], out[1] = x - y, z
+    return impl
+
+
+def call_generated(a, b, out):
+    return generated_inner(out, a, z=b)
+
+
+class TestNestedCall(TestCase):
+    def test_call_generated(self):
+        """
+        Test a nested function call to a generated jit function.
+        """
+        cfunc = cuda.jit(call_generated)
+
+        out = np.empty(2, dtype=np.int64)
+        cfunc[1,1](1, 2, out)
+        cuda.synchronize()
+        self.assertPreciseEqual(tuple(out), (-4, 2))
+
+        out = np.empty(2, dtype=np.complex64)
+        cfunc[1,1](1j, 2, out)
+        cuda.synchronize()
+        self.assertPreciseEqual(tuple(map(complex,out)), (5 + 1j, 2 + 0j))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Currently cuda does not support overloads with default values.

Fixes: https://github.com/NVIDIA/numba-cuda/issues/159