### PR TITLE
gha/add release notes generation

### DIFF
--- a/.github/workflows/generate_release_notes.yml
+++ b/.github/workflows/generate_release_notes.yml
@@ -21,7 +21,7 @@ env:
   PREVIOUS_RELEASE_BRANCH: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.previous_release_branch || 'release0.61' }}
 
 jobs:
-  run_towncrier:
+  generate_notes_towncrier:
     runs-on: ubuntu-latest
     outputs:
       notes_file_path: ${{ steps.set_paths.outputs.notes_file_path }}
@@ -108,15 +108,15 @@ jobs:
       - name: Upload notes file artifact (post-towncrier)
         uses: actions/upload-artifact@v4
         with:
-          name: notes-artifact-stage1
+          name: release-notes-stage1-${{ env.TARGET_VERSION }}
           path: ${{ steps.set_paths.outputs.notes_file_path }}
           if-no-files-found: ignore
 
-  run_gitlog2changelog:
+  append_pr_author_lists:
     runs-on: ubuntu-latest
-    needs: run_towncrier
+    needs: generate_notes_towncrier
     outputs:
-      notes_file_path: ${{ needs.run_towncrier.outputs.notes_file_path }}
+      notes_file_path: ${{ needs.generate_notes_towncrier.outputs.notes_file_path }}
       changelog_generated: ${{ steps.changelog_script.outputs.changelog_generated || 'false' }}
 
     steps:
@@ -129,8 +129,8 @@ jobs:
         id: download_notes
         uses: actions/download-artifact@v4
         with:
-          name: notes-artifact-stage1
-          path: ${{ needs.run_towncrier.outputs.notes_dir_path }}
+          name: release-notes-stage1-${{ env.TARGET_VERSION }}
+          path: ${{ needs.generate_notes_towncrier.outputs.notes_dir_path }}
         continue-on-error: true
 
       - name: Set up Python
@@ -146,7 +146,7 @@ jobs:
       - name: Verify gitlog2changelog requirement
         id: check_changelog
         env:
-          NOTES_FILE: ${{ needs.run_towncrier.outputs.notes_file_path }}
+          NOTES_FILE: ${{ needs.generate_notes_towncrier.outputs.notes_file_path }}
         run: |
           echo "Checking for PR/Author list in: $NOTES_FILE"
           if [[ "${{ steps.download_notes.outcome }}" != "success" && ! -f "$NOTES_FILE" ]]; then
@@ -164,7 +164,7 @@ jobs:
         id: changelog_script
         if: steps.check_changelog.outputs.skip_script == 'false'
         env:
-          NOTES_FILE: ${{ needs.run_towncrier.outputs.notes_file_path }}
+          NOTES_FILE: ${{ needs.generate_notes_towncrier.outputs.notes_file_path }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PREV_BRANCH: ${{ env.PREVIOUS_RELEASE_BRANCH }}
         run: |
@@ -192,13 +192,13 @@ jobs:
       - name: Upload final notes file artifact
         uses: actions/upload-artifact@v4
         with:
-          name: notes-final
-          path: ${{ needs.run_towncrier.outputs.notes_file_path }}
+          name: release-notes-final-${{ env.TARGET_VERSION }}
+          path: ${{ needs.generate_notes_towncrier.outputs.notes_file_path }}
           if-no-files-found: ignore
 
-  finalize:
+  rstcheck:
     runs-on: ubuntu-latest
-    needs: [run_towncrier, run_gitlog2changelog]
+    needs: [generate_notes_towncrier, append_pr_author_lists]
     if: always()
 
     steps:
@@ -206,14 +206,14 @@ jobs:
         id: download_artifact
         uses: actions/download-artifact@v4
         with:
-          name: notes-final
+          name: release-notes-final-${{ env.TARGET_VERSION }}
         continue-on-error: true
 
       - name: Install and run rstcheck
         id: rst_check
         if: steps.download_artifact.outcome == 'success'
         env:
-          NOTES_FILE: ${{ needs.run_towncrier.outputs.notes_file_path }}
+          NOTES_FILE: ${{ needs.generate_notes_towncrier.outputs.notes_file_path }}
         run: |
           python -m pip install --upgrade pip
           pip install rstcheck

--- a/.github/workflows/generate_release_notes.yml
+++ b/.github/workflows/generate_release_notes.yml
@@ -1,0 +1,207 @@
+name: Generate Release Notes
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_version:
+        description: 'Target release version (e.g., 0.61.1)'
+        required: true
+        type: string
+      previous_release_branch:
+        description: 'Name of the previous release branch (e.g., release0.61)'
+        required: true
+        type: string
+
+jobs:
+  run_towncrier:
+    runs-on: ubuntu-latest
+    outputs:
+      notes_file_path: ${{ steps.set_paths.outputs.notes_file_path }}
+      notes_dir_path: ${{ steps.set_paths.outputs.notes_dir_path }}
+      towncrier_generated: ${{ steps.towncrier_build.outputs.towncrier_generated || 'false' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install towncrier GitPython PyGithub docopt
+
+      - name: Set paths
+        id: set_paths
+        run: |
+          version="${{ github.event.inputs.target_version }}"
+          notes_dir="docs/source/release"
+          notes_file="$notes_dir/${version}-notes.rst"
+          echo "notes_dir_path=${notes_dir}" >> $GITHUB_OUTPUT
+          echo "notes_file_path=${notes_file}" >> $GITHUB_OUTPUT
+
+      - name: Verify towncrier requirement
+        id: check_towncrier
+        env:
+          NOTES_FILE: ${{ steps.set_paths.outputs.notes_file_path }}
+        run: |
+          echo "Checking towncrier for version: ${{ github.event.inputs.target_version }} into file: $NOTES_FILE"
+          if [[ -f "$NOTES_FILE" ]]; then
+            echo "Notes file exists. Checking draft..."
+            towncrier build --draft --version=${{ github.event.inputs.target_version }} > towncrier_draft.txt
+            cat towncrier_draft.txt
+            if grep -q "No significant changes." towncrier_draft.txt; then
+              echo "Draft shows no new significant changes. Skipping build."
+              echo "skip_build=true" >> $GITHUB_OUTPUT
+            else
+              echo "Draft shows new changes. Proceeding with build."
+              echo "skip_build=false" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "Notes file does not exist. Proceeding with build."
+            echo "skip_build=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run towncrier build
+        id: towncrier_build
+        if: steps.check_towncrier.outputs.skip_build == 'false'
+        env:
+          NOTES_FILE: ${{ steps.set_paths.outputs.notes_file_path }}
+          NOTES_DIR: ${{ steps.set_paths.outputs.notes_dir_path }}
+        run: |
+          echo "Running towncrier..."
+          mkdir -p $NOTES_DIR
+          towncrier build --yes --version=${{ github.event.inputs.target_version }}
+          if [[ -f "$NOTES_FILE" ]]; then
+             echo "towncrier_generated=true" >> $GITHUB_OUTPUT
+             echo "Towncrier generated/updated $NOTES_FILE"
+          else
+             echo "towncrier_generated=false" >> $GITHUB_OUTPUT
+             echo "Towncrier did not generate $NOTES_FILE (may indicate no fragments)."
+          fi
+
+      - name: Upload notes file artifact (post-towncrier)
+        uses: actions/upload-artifact@v4
+        with:
+          name: notes-artifact-stage1
+          path: ${{ steps.set_paths.outputs.notes_file_path }}
+          if-no-files-found: ignore
+
+  run_gitlog2changelog:
+    runs-on: ubuntu-latest
+    needs: run_towncrier
+    outputs:
+      notes_file_path: ${{ needs.run_towncrier.outputs.notes_file_path }} # Pass through path
+      changelog_generated: ${{ steps.changelog_script.outputs.changelog_generated || 'false' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download notes artifact (from towncrier)
+        id: download_notes
+        uses: actions/download-artifact@v4
+        with:
+          name: notes-artifact-stage1
+          path: ${{ needs.run_towncrier.outputs.notes_dir_path }}
+        continue-on-error: true # If notes file wasn't created/uploaded
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install towncrier GitPython PyGithub docopt
+
+      - name: Verify gitlog2changelog requirement
+        id: check_changelog
+        env:
+          NOTES_FILE: ${{ needs.run_towncrier.outputs.notes_file_path }}
+        run: |
+          echo "Checking for PR/Author list in: $NOTES_FILE"
+          if [[ "${{ steps.download_notes.outcome }}" != "success" && ! -f "$NOTES_FILE" ]]; then
+             echo "Notes file does not exist. Skipping changelog append."
+             echo "skip_script=true" >> $GITHUB_OUTPUT
+          elif grep -q -E "^Pull-Requests:?(\s*~+)?$" "$NOTES_FILE" && grep -q -E "^Authors:?(\s*~+)?$" "$NOTES_FILE"; then
+             echo "Pull-Requests and Authors sections seem to exist. Skipping generation."
+             echo "skip_script=true" >> $GITHUB_OUTPUT
+          else
+             echo "Sections not found or file exists but incomplete. Proceeding."
+             echo "skip_script=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Generate PR & Author list
+        id: changelog_script
+        if: steps.check_changelog.outputs.skip_script == 'false'
+        env:
+          NOTES_FILE: ${{ needs.run_towncrier.outputs.notes_file_path }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PREV_BRANCH: ${{ github.event.inputs.previous_release_branch }}
+        run: |
+          echo "Running gitlog2changelog.py for branch: $PREV_BRANCH"
+          git config user.email "action@github.com"
+          git config user.name "GitHub Action"
+          git fetch origin $PREV_BRANCH:$PREV_BRANCH
+          MERGE_BASE=$(git merge-base main $PREV_BRANCH)
+          if [ -z "$MERGE_BASE" ]; then
+            echo "::error::Could not determine merge base between main and $PREV_BRANCH"
+            exit 1
+          fi
+          echo "Merge base commit: $MERGE_BASE"
+
+          echo "" >> "$NOTES_FILE" # Ensure newline before appending
+          if python maint/gitlog2changelog.py --token="$GH_TOKEN" --beginning="$MERGE_BASE" --repo="${{ github.repository }}" --digits=4 >> "$NOTES_FILE"; then
+            echo "gitlog2changelog.py output appended to $NOTES_FILE"
+            echo "changelog_generated=true" >> $GITHUB_OUTPUT
+          else
+            echo "::error::gitlog2changelog.py script failed."
+            echo "changelog_generated=false" >> $GITHUB_OUTPUT
+            # exit 1 # Optionally fail the job
+          fi
+
+      - name: Upload final notes file artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: notes-final
+          path: ${{ needs.run_towncrier.outputs.notes_file_path }}
+          if-no-files-found: ignore
+
+  finalize:
+    runs-on: ubuntu-latest
+    needs: [run_towncrier, run_gitlog2changelog]
+    if: always() # Run always to attempt the check and report
+
+    steps:
+      - name: Download final notes artifact
+        id: download_artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: notes-final
+          # Download *to* the root, as rstcheck path needs to be simple
+          # path: . # Download to workspace root
+        continue-on-error: true
+
+      - name: Install and run rstcheck
+        id: rst_check
+        if: steps.download_artifact.outcome == 'success'
+        env:
+          NOTES_FILE: ${{ needs.run_towncrier.outputs.notes_file_path }} # Original relative path
+        run: |
+          python -m pip install --upgrade pip
+          pip install rstcheck
+          # Extract filename from the original path to check it in the current dir
+          NOTES_FILENAME=$(basename $NOTES_FILE)
+          echo "Running rstcheck on downloaded file: $NOTES_FILENAME"
+          rstcheck "$NOTES_FILENAME" # Check the file at the root
+          echo "rstcheck validation passed."
+          echo "RSTCHECK_PASSED=true" >> $GITHUB_ENV

--- a/.github/workflows/generate_release_notes.yml
+++ b/.github/workflows/generate_release_notes.yml
@@ -190,14 +190,9 @@ jobs:
 
           echo "" >> "$NOTES_FILE" # Ensure newline before appending
           # Ensure the script path is correct if it's not at the root
-          if python maint/gitlog2changelog.py --token="$GH_TOKEN" --beginning="$MERGE_BASE" --repo="${{ github.repository }}" --digits=4 >> "$NOTES_FILE"; then
-            echo "gitlog2changelog.py output appended to $NOTES_FILE"
-            echo "changelog_generated=true" >> $GITHUB_OUTPUT
-          else
-            echo "::error::gitlog2changelog.py script failed."
-            echo "changelog_generated=false" >> $GITHUB_OUTPUT
-            # exit 1 # Optionally fail the job
-          fi
+          python maint/gitlog2changelog.py --token="$GH_TOKEN" --beginning="$MERGE_BASE" --repo="numba/numba" --digits=4 >> "$NOTES_FILE"
+          echo "gitlog2changelog.py output appended to $NOTES_FILE"
+          echo "changelog_generated=true" >> $GITHUB_OUTPUT
 
       - name: Upload final notes file artifact
         uses: actions/upload-artifact@v4
@@ -219,12 +214,11 @@ jobs:
           name: notes-final
         continue-on-error: true
 
-      # --- MODIFIED: Simplified dependencies ---
       - name: Install and run rstcheck
         id: rst_check
         if: steps.download_artifact.outcome == 'success'
         env:
-          NOTES_FILE: ${{ needs.run_towncrier.outputs.notes_file_path }} # Original relative path
+          NOTES_FILE: ${{ needs.run_towncrier.outputs.notes_file_path }}
         run: |
           python -m pip install --upgrade pip
           pip install rstcheck # Only install rstcheck here

--- a/.github/workflows/generate_release_notes.yml
+++ b/.github/workflows/generate_release_notes.yml
@@ -54,13 +54,11 @@ jobs:
           echo "notes_dir_path=${notes_dir}" >> $GITHUB_OUTPUT
           echo "notes_file_path=${notes_file}" >> $GITHUB_OUTPUT
 
-      # --- ADDED: Create temporary config ---
       - name: Create temporary towncrier config
         id: temp_config
         run: |
           TEMP_CONFIG_FILE="temp_towncrier.toml"
           # Copy original and remove the 'package = ...' line using sed
-          # Use a pattern that matches the line regardless of whitespace around '='
           sed '/^[[:space:]]*package[[:space:]]*=.*$/d' towncrier.toml > $TEMP_CONFIG_FILE
           echo "Temporary config file created at $TEMP_CONFIG_FILE"
           echo "temp_config_path=$TEMP_CONFIG_FILE" >> $GITHUB_OUTPUT
@@ -74,7 +72,6 @@ jobs:
           echo "Checking towncrier for version: ${{ env.TARGET_VERSION }} into file: $NOTES_FILE"
           if [[ -f "$NOTES_FILE" ]]; then
             echo "Notes file exists. Checking draft using temporary config $TEMP_CONFIG..."
-            # --- MODIFIED: Use temp config ---
             towncrier build --config $TEMP_CONFIG --draft --version=${{ env.TARGET_VERSION }} > towncrier_draft.txt
             cat towncrier_draft.txt
             if grep -q "No significant changes." towncrier_draft.txt; then
@@ -99,14 +96,13 @@ jobs:
         run: |
           echo "Running towncrier using temporary config $TEMP_CONFIG..."
           mkdir -p $NOTES_DIR
-          # --- MODIFIED: Use temp config ---
           towncrier build --config $TEMP_CONFIG --yes --version=${{ env.TARGET_VERSION }}
           if [[ -f "$NOTES_FILE" ]]; then
              echo "towncrier_generated=true" >> $GITHUB_OUTPUT
              echo "Towncrier generated/updated $NOTES_FILE"
           else
              echo "towncrier_generated=false" >> $GITHUB_OUTPUT
-             echo "Towncrier did not generate $NOTES_FILE (may indicate no fragments)."
+             echo "Towncrier did not generate $NOTES_FILE "
           fi
 
       - name: Upload notes file artifact (post-towncrier)
@@ -120,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: run_towncrier
     outputs:
-      notes_file_path: ${{ needs.run_towncrier.outputs.notes_file_path }} # Pass through path
+      notes_file_path: ${{ needs.run_towncrier.outputs.notes_file_path }}
       changelog_generated: ${{ steps.changelog_script.outputs.changelog_generated || 'false' }}
 
     steps:
@@ -135,18 +131,17 @@ jobs:
         with:
           name: notes-artifact-stage1
           path: ${{ needs.run_towncrier.outputs.notes_dir_path }}
-        continue-on-error: true # If notes file wasn't created/uploaded
+        continue-on-error: true
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
-      # --- MODIFIED: Simplified dependencies ---
       - name: Install GitLog dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install GitPython PyGithub docopt # Only install deps for this job
+          pip install GitPython PyGithub docopt
 
       - name: Verify gitlog2changelog requirement
         id: check_changelog
@@ -204,7 +199,7 @@ jobs:
   finalize:
     runs-on: ubuntu-latest
     needs: [run_towncrier, run_gitlog2changelog]
-    if: always() # Run always to attempt the check and report
+    if: always()
 
     steps:
       - name: Download final notes artifact
@@ -221,9 +216,7 @@ jobs:
           NOTES_FILE: ${{ needs.run_towncrier.outputs.notes_file_path }}
         run: |
           python -m pip install --upgrade pip
-          pip install rstcheck # Only install rstcheck here
+          pip install rstcheck
           NOTES_FILENAME=$(basename $NOTES_FILE)
-          echo "Running rstcheck on downloaded file: $NOTES_FILENAME"
           rstcheck "$NOTES_FILENAME"
-          echo "rstcheck validation passed."
           echo "RSTCHECK_PASSED=true" >> $GITHUB_ENV

--- a/.github/workflows/generate_release_notes.yml
+++ b/.github/workflows/generate_release_notes.yml
@@ -190,7 +190,7 @@ jobs:
 
           echo "" >> "$NOTES_FILE" # Ensure newline before appending
           # Ensure the script path is correct if it's not at the root
-          python maint/gitlog2changelog.py --token="$GH_TOKEN" --beginning="$MERGE_BASE" --repo="numba/numba" --digits=4 >> "$NOTES_FILE"
+          python maint/gitlog2changelog.py --token="$GH_TOKEN" --beginning="$MERGE_BASE" --repo="numba/numba" >> "$NOTES_FILE"
           echo "gitlog2changelog.py output appended to $NOTES_FILE"
           echo "changelog_generated=true" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/generate_release_notes.yml
+++ b/.github/workflows/generate_release_notes.yml
@@ -39,35 +39,43 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install dependencies
+      # --- MODIFIED: Simplified dependencies ---
+      - name: Install Towncrier
         run: |
           python -m pip install --upgrade pip
-          # Install Numba's core runtime deps first
-          pip install numpy llvmlite 
-          # Then install the workflow tools
-          pip install towncrier GitPython PyGithub docopt
+          pip install towncrier # Only install towncrier here
 
       - name: Set paths
         id: set_paths
         run: |
-          # Use the environment variable set globally for the job
           version="${{ env.TARGET_VERSION }}"
           notes_dir="docs/source/release"
           notes_file="$notes_dir/${version}-notes.rst"
           echo "notes_dir_path=${notes_dir}" >> $GITHUB_OUTPUT
           echo "notes_file_path=${notes_file}" >> $GITHUB_OUTPUT
 
+      # --- ADDED: Create temporary config ---
+      - name: Create temporary towncrier config
+        id: temp_config
+        run: |
+          TEMP_CONFIG_FILE="temp_towncrier.toml"
+          # Copy original and remove the 'package = ...' line using sed
+          # Use a pattern that matches the line regardless of whitespace around '='
+          sed '/^[[:space:]]*package[[:space:]]*=.*$/d' towncrier.toml > $TEMP_CONFIG_FILE
+          echo "Temporary config file created at $TEMP_CONFIG_FILE"
+          echo "temp_config_path=$TEMP_CONFIG_FILE" >> $GITHUB_OUTPUT
+
       - name: Verify towncrier requirement
         id: check_towncrier
         env:
           NOTES_FILE: ${{ steps.set_paths.outputs.notes_file_path }}
+          TEMP_CONFIG: ${{ steps.temp_config.outputs.temp_config_path }}
         run: |
-          # Use the environment variable
           echo "Checking towncrier for version: ${{ env.TARGET_VERSION }} into file: $NOTES_FILE"
           if [[ -f "$NOTES_FILE" ]]; then
-            echo "Notes file exists. Checking draft..."
-            # Use the environment variable
-            towncrier build --draft --version=${{ env.TARGET_VERSION }} > towncrier_draft.txt
+            echo "Notes file exists. Checking draft using temporary config $TEMP_CONFIG..."
+            # --- MODIFIED: Use temp config ---
+            towncrier build --config $TEMP_CONFIG --draft --version=${{ env.TARGET_VERSION }} > towncrier_draft.txt
             cat towncrier_draft.txt
             if grep -q "No significant changes." towncrier_draft.txt; then
               echo "Draft shows no new significant changes. Skipping build."
@@ -87,11 +95,12 @@ jobs:
         env:
           NOTES_FILE: ${{ steps.set_paths.outputs.notes_file_path }}
           NOTES_DIR: ${{ steps.set_paths.outputs.notes_dir_path }}
+          TEMP_CONFIG: ${{ steps.temp_config.outputs.temp_config_path }}
         run: |
-          echo "Running towncrier..."
+          echo "Running towncrier using temporary config $TEMP_CONFIG..."
           mkdir -p $NOTES_DIR
-          # Use the environment variable
-          towncrier build --yes --version=${{ env.TARGET_VERSION }}
+          # --- MODIFIED: Use temp config ---
+          towncrier build --config $TEMP_CONFIG --yes --version=${{ env.TARGET_VERSION }}
           if [[ -f "$NOTES_FILE" ]]; then
              echo "towncrier_generated=true" >> $GITHUB_OUTPUT
              echo "Towncrier generated/updated $NOTES_FILE"
@@ -133,10 +142,11 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install dependencies
+      # --- MODIFIED: Simplified dependencies ---
+      - name: Install GitLog dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install towncrier GitPython PyGithub docopt
+          pip install GitPython PyGithub docopt # Only install deps for this job
 
       - name: Verify gitlog2changelog requirement
         id: check_changelog
@@ -161,7 +171,6 @@ jobs:
         env:
           NOTES_FILE: ${{ needs.run_towncrier.outputs.notes_file_path }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Use the globally set env var for previous branch
           PREV_BRANCH: ${{ env.PREVIOUS_RELEASE_BRANCH }}
         run: |
           echo "Running gitlog2changelog.py for branch: $PREV_BRANCH"
@@ -176,6 +185,7 @@ jobs:
           echo "Merge base commit: $MERGE_BASE"
 
           echo "" >> "$NOTES_FILE" # Ensure newline before appending
+          # Ensure the script path is correct if it's not at the root
           if python maint/gitlog2changelog.py --token="$GH_TOKEN" --beginning="$MERGE_BASE" --repo="${{ github.repository }}" --digits=4 >> "$NOTES_FILE"; then
             echo "gitlog2changelog.py output appended to $NOTES_FILE"
             echo "changelog_generated=true" >> $GITHUB_OUTPUT
@@ -203,10 +213,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: notes-final
-          # Download *to* the root, as rstcheck path needs to be simple
-          # path: . # Download to workspace root
         continue-on-error: true
 
+      # --- MODIFIED: Simplified dependencies ---
       - name: Install and run rstcheck
         id: rst_check
         if: steps.download_artifact.outcome == 'success'
@@ -214,10 +223,9 @@ jobs:
           NOTES_FILE: ${{ needs.run_towncrier.outputs.notes_file_path }} # Original relative path
         run: |
           python -m pip install --upgrade pip
-          pip install rstcheck
-          # Extract filename from the original path to check it in the current dir
+          pip install rstcheck # Only install rstcheck here
           NOTES_FILENAME=$(basename $NOTES_FILE)
           echo "Running rstcheck on downloaded file: $NOTES_FILENAME"
-          rstcheck "$NOTES_FILENAME" # Check the file at the root
+          rstcheck "$NOTES_FILENAME"
           echo "rstcheck validation passed."
           echo "RSTCHECK_PASSED=true" >> $GITHUB_ENV

--- a/.github/workflows/generate_release_notes.yml
+++ b/.github/workflows/generate_release_notes.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          # Install Numba's core runtime deps first
+          pip install numpy llvmlite 
+          # Then install the workflow tools
           pip install towncrier GitPython PyGithub docopt
 
       - name: Set paths

--- a/.github/workflows/generate_release_notes.yml
+++ b/.github/workflows/generate_release_notes.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Upload notes file artifact (post-towncrier)
         uses: actions/upload-artifact@v4
         with:
-          name: release-notes-stage1-${{ env.TARGET_VERSION }}
+          name: release-notes-${{ env.TARGET_VERSION }}-towncrier
           path: ${{ steps.set_paths.outputs.notes_file_path }}
           if-no-files-found: ignore
 
@@ -129,7 +129,7 @@ jobs:
         id: download_notes
         uses: actions/download-artifact@v4
         with:
-          name: release-notes-stage1-${{ env.TARGET_VERSION }}
+          name: release-notes-${{ env.TARGET_VERSION }}-towncrier
           path: ${{ needs.generate_notes_towncrier.outputs.notes_dir_path }}
         continue-on-error: true
 
@@ -192,7 +192,7 @@ jobs:
       - name: Upload final notes file artifact
         uses: actions/upload-artifact@v4
         with:
-          name: release-notes-final-${{ env.TARGET_VERSION }}
+          name: release-notes-${{ env.TARGET_VERSION }}-final
           path: ${{ needs.generate_notes_towncrier.outputs.notes_file_path }}
           if-no-files-found: ignore
 
@@ -206,7 +206,7 @@ jobs:
         id: download_artifact
         uses: actions/download-artifact@v4
         with:
-          name: release-notes-final-${{ env.TARGET_VERSION }}
+          name: release-notes-${{ env.TARGET_VERSION }}-final
         continue-on-error: true
 
       - name: Install and run rstcheck

--- a/.github/workflows/generate_release_notes.yml
+++ b/.github/workflows/generate_release_notes.yml
@@ -176,7 +176,11 @@ jobs:
           echo "Running gitlog2changelog.py for branch: $PREV_BRANCH"
           git config user.email "action@github.com"
           git config user.name "GitHub Action"
+          echo "Fetching main branch..."
+          git fetch origin main:main
+          echo "Fetching previous release branch..."
           git fetch origin $PREV_BRANCH:$PREV_BRANCH
+          echo "Determining merge base between main and $PREV_BRANCH..."
           MERGE_BASE=$(git merge-base main $PREV_BRANCH)
           if [ -z "$MERGE_BASE" ]; then
             echo "::error::Could not determine merge base between main and $PREV_BRANCH"

--- a/.github/workflows/generate_release_notes.yml
+++ b/.github/workflows/generate_release_notes.yml
@@ -1,6 +1,9 @@
 name: Generate Release Notes
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/generate_release_notes.yml
   workflow_dispatch:
     inputs:
       target_version:
@@ -11,6 +14,11 @@ on:
         description: 'Name of the previous release branch (e.g., release0.61)'
         required: true
         type: string
+
+# Helper to set versions based on trigger type
+env:
+  TARGET_VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.target_version || '0.61.1' }}
+  PREVIOUS_RELEASE_BRANCH: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.previous_release_branch || 'release0.61' }}
 
 jobs:
   run_towncrier:
@@ -39,7 +47,8 @@ jobs:
       - name: Set paths
         id: set_paths
         run: |
-          version="${{ github.event.inputs.target_version }}"
+          # Use the environment variable set globally for the job
+          version="${{ env.TARGET_VERSION }}"
           notes_dir="docs/source/release"
           notes_file="$notes_dir/${version}-notes.rst"
           echo "notes_dir_path=${notes_dir}" >> $GITHUB_OUTPUT
@@ -50,10 +59,12 @@ jobs:
         env:
           NOTES_FILE: ${{ steps.set_paths.outputs.notes_file_path }}
         run: |
-          echo "Checking towncrier for version: ${{ github.event.inputs.target_version }} into file: $NOTES_FILE"
+          # Use the environment variable
+          echo "Checking towncrier for version: ${{ env.TARGET_VERSION }} into file: $NOTES_FILE"
           if [[ -f "$NOTES_FILE" ]]; then
             echo "Notes file exists. Checking draft..."
-            towncrier build --draft --version=${{ github.event.inputs.target_version }} > towncrier_draft.txt
+            # Use the environment variable
+            towncrier build --draft --version=${{ env.TARGET_VERSION }} > towncrier_draft.txt
             cat towncrier_draft.txt
             if grep -q "No significant changes." towncrier_draft.txt; then
               echo "Draft shows no new significant changes. Skipping build."
@@ -76,7 +87,8 @@ jobs:
         run: |
           echo "Running towncrier..."
           mkdir -p $NOTES_DIR
-          towncrier build --yes --version=${{ github.event.inputs.target_version }}
+          # Use the environment variable
+          towncrier build --yes --version=${{ env.TARGET_VERSION }}
           if [[ -f "$NOTES_FILE" ]]; then
              echo "towncrier_generated=true" >> $GITHUB_OUTPUT
              echo "Towncrier generated/updated $NOTES_FILE"
@@ -146,7 +158,8 @@ jobs:
         env:
           NOTES_FILE: ${{ needs.run_towncrier.outputs.notes_file_path }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PREV_BRANCH: ${{ github.event.inputs.previous_release_branch }}
+          # Use the globally set env var for previous branch
+          PREV_BRANCH: ${{ env.PREVIOUS_RELEASE_BRANCH }}
         run: |
           echo "Running gitlog2changelog.py for branch: $PREV_BRANCH"
           git config user.email "action@github.com"

--- a/maint/gitlog2changelog.py
+++ b/maint/gitlog2changelog.py
@@ -74,7 +74,7 @@ if __name__ == '__main__':
         
         pr_title = pull.title
         print("* PR %s: %s (%s)" % (hyperlink, pr_title,
-                                    " ".join([hyperlink_user(u) for u in
+                                    " ".join([hyperlink_user(u) + '_' for u in
                                               pr_authors])))
         for a in pr_authors:
             authors.add(a)

--- a/maint/gitlog2changelog.py
+++ b/maint/gitlog2changelog.py
@@ -3,8 +3,7 @@
 Usage:
   gitlog2changelog.py (-h | --help)
   gitlog2changelog.py --version
-  gitlog2changelog.py --token=<token> --beginning=<tag> --repo=<repo> \
-          --digits=<digits> [--summary]
+  gitlog2changelog.py --token=<token> --beginning=<tag> --repo=<repo> [--summary]
 
 Options:
   -h --help          Show this screen.
@@ -12,7 +11,6 @@ Options:
   --beginning=<tag>  Where in the History to begin
   --repo=<repo>      Which repository to look at on GitHub
   --token=<token>    The GitHub token to talk to the API
-  --digits=<digits>  The number of digits to use in the issue finding regex
   --summary          Show total count for each section
 
 """
@@ -40,7 +38,6 @@ if __name__ == '__main__':
     beginning = arguments['--beginning']
     target_ghrepo = arguments['--repo']
     github_token = arguments['--token']
-    regex_digits = arguments['--digits']
     summary = arguments["--summary"]
     ghrepo = Github(github_token).get_repo(target_ghrepo)
     repo = Repo('.')
@@ -48,17 +45,18 @@ if __name__ == '__main__':
     merge_commits = [x for x in all_commits
                      if 'Merge pull request' in x.message]
     prmatch = re.compile(
-        f'^Merge pull request #([0-9]{{{regex_digits}}}) from.*')
+        r'^Merge pull request #([0-9]+) from.*')
     ordered = {}
     authors = set()
     for x in merge_commits:
         match = prmatch.match(x.message)
         if match:
             issue_id = match.groups()[0]
-            ordered[issue_id] = "%s" % (x.message.splitlines()[2])
+            ordered[issue_id] = None
+
     print("Pull-Requests:\n")
     missing_authors = set()
-    for k in sorted(ordered.keys()):
+    for k in sorted(ordered.keys(), key=int):
         pull = get_pr(int(k))
         hyperlink = "`#%s <%s>`_" % (k, pull.html_url)
         # get all users for all commits
@@ -73,7 +71,9 @@ if __name__ == '__main__':
                 pr_authors.add(c.committer)
             elif not author:
                 missing_authors.add((pull, c))
-        print("* PR %s: %s (%s)" % (hyperlink, ordered[k],
+        
+        pr_title = pull.title
+        print("* PR %s: %s (%s)" % (hyperlink, pr_title,
                                     " ".join([hyperlink_user(u) for u in
                                               pr_authors])))
         for a in pr_authors:


### PR DESCRIPTION
This PR introduces automation for release notes generation and validation. 
It has these jobs that populate release notes - 
1. towncrier (uses build --check to verify, skips if nothing to populate)
2. git2changelog (uses custom script to add PRs and authors list)
3. rstcheck (validates the generated rst formatting)