### PR TITLE
Add support for PYCC for functions that has indirect dependency on Environment object

### DIFF
--- a/docs/upcoming_changes/10035.improvement.rst
+++ b/docs/upcoming_changes/10035.improvement.rst
@@ -1,0 +1,6 @@
+Improve Environment Object Support in PYCC
+------------------------------------------
+
+Added support for Environment objects referenced indirectly by entry points in
+PYCC-compiled code. Previously, PYCC was unable to handle these indirect
+Environment object references, which limited certain compilation scenarios.

--- a/numba/pycc/compiler.py
+++ b/numba/pycc/compiler.py
@@ -15,6 +15,7 @@ from numba.core.compiler_lock import global_compiler_lock
 from numba.core.registry import cpu_target
 from numba.core.runtime import nrtdynmod
 from numba.core import cgutils
+from numba.core.environment import lookup_environment
 
 
 logger = logging.getLogger(__name__)
@@ -139,6 +140,7 @@ class _ModuleCompiler(object):
         self.exported_function_types = {}
         self.function_environments = {}
         self.environment_gvs = {}
+        self.extra_environments = {}
 
         codegen = self.context.codegen()
         library = codegen.create_library(self.module_name)
@@ -182,6 +184,18 @@ class _ModuleCompiler(object):
                 self.exported_function_types[entry] = fnty
                 self.function_environments[entry] = cres.environment
                 self.environment_gvs[entry] = cres.fndesc.env_name
+
+                # Search for extra environments from linked libraries
+                for linkedlib in library._linking_libraries:
+                    linkedmod = linkedlib._final_module
+                    # Find environments
+                    for gv in linkedmod.global_variables:
+                        gvn = gv.name
+                        if gvn.startswith("_ZN08NumbaEnv"):
+                            env = lookup_environment(gvn)
+                            if env is not None:
+                                if env.can_cache():
+                                    self.extra_environments[gvn] = env
             else:
                 llvm_func.name = entry.symbol
                 self.dll_exports.append(entry.symbol)
@@ -277,6 +291,11 @@ class _ModuleCompiler(object):
             # Constants may be unhashable so avoid trying to cache them
             env_def = pyapi.serialize_uncached(env.consts)
             env_defs.append(env_def)
+        # Append extra environments
+        env_defs.extend([
+            pyapi.serialize_uncached(env.consts)
+            for env in self.extra_environments.values()
+        ])
         env_defs_init = create_constant_array(self.env_def_ty, env_defs)
         gv = self.context.insert_unique_const(llvm_module,
                                               '.module_environments',
@@ -294,6 +313,16 @@ class _ModuleCompiler(object):
             gv = self.context.declare_env_global(llvm_module, envgv_name)
             envgv = gv.bitcast(lt._void_star)
             env_setters.append(envgv)
+        # Append extra environments
+        env_setters.extend([
+            self.context.declare_env_global(
+                llvm_module,
+                envgv_name
+            ).bitcast(lt._void_star)
+            for envgv_name in self.extra_environments
+        ])
+        # The array ends with NULL
+        env_setters.append(lt._void_star(None))
 
         env_setters_init = create_constant_array(lt._void_star, env_setters)
         gv = self.context.insert_unique_const(llvm_module,

--- a/numba/pycc/modulemixin.c
+++ b/numba/pycc/modulemixin.c
@@ -197,6 +197,19 @@ PYCC(pycc_init_) (PyObject *module, PyMethodDef *defs,
         }
         Py_DECREF(func);
     }
+    /* Recreate other environment objects 
+       envgvs is expected to end with a NULL pointer.
+    */
+    for (; envgvs[i]; ++i) {
+        EnvironmentObject *envobj;
+        envobj = recreate_environment(module, envs[i]);
+        if (envobj == NULL) {
+            goto error;
+        }
+        // Store the environment pointer into the global
+        *envgvs[i] = envobj;
+        Py_DECREF(envobj);
+    }
     Py_DECREF(docobj);
     Py_DECREF(modname);
     return 0;


### PR DESCRIPTION
This fixes a segfault on main caused by a combination of #9972 and #9955.

Details:

#9955 adds test for dynamic exception. #9972 moved the dynamic exception raising code a `CodeLibrary` deeper in the dependency chain. Since dynamic exception relies on a valid Environment object but PYCC is not inserting Environment objects that are needed indirectly, this ends up reading invalid memory.