### PR TITLE
Document and test `as_numba_type`'s role in instance checks

### DIFF
--- a/docs/source/extending/interval-example.rst
+++ b/docs/source/extending/interval-example.rst
@@ -63,13 +63,13 @@ Function arguments and global values will thusly be recognized as belonging
 to ``interval_type`` whenever they are instances of ``Interval``.
 
 
-Type inference for Python annotations
--------------------------------------
+Type inference for Python types
+-------------------------------
 
 While ``typeof`` is used to infer the Numba type of Python objects,
-``as_numba_type`` is used to infer the Numba type of Python types.  For simple
-cases, we can simply register that the Python type ``Interval`` corresponds with
-the Numba type ``interval_type``:
+``as_numba_type`` is used to infer the Numba type of Python types. For simple
+cases, we can simply register that the Python type ``Interval`` corresponds
+with the Numba type ``interval_type``:
 
 .. literalinclude:: ../../../numba/tests/doc_examples/test_interval_example.py
    :language: python
@@ -77,9 +77,10 @@ the Numba type ``interval_type``:
    :end-before: magictoken.numba_type_register.end
    :dedent: 8
 
-Note that ``as_numba_type`` is only used to infer types from type annotations at
-compile time.  The ``typeof`` registry above is used to infer the type of
-objects at runtime.
+Note that ``as_numba_type`` is only used at compile time to infer types from
+type annotations on jitclass fields, and the ``classinfo`` argument to the
+:func:`isinstance` function. The ``typeof`` registry above is used to infer the
+type of objects at runtime.
 
 
 Type inference for operations

--- a/docs/source/reference/types.rst
+++ b/docs/source/reference/types.rst
@@ -346,18 +346,20 @@ Optional types
       False
 
 
-Type annotations
------------------
+Python types
+------------
+
+Python types are used in Python type annotations, and the ``classinfo``
+argument to the :func:`isinstance` function.
 
 .. function:: numba.extending.as_numba_type(py_type)
 
-   Create a Numba type corresponding to the given Python *type annotation*.
-   ``TypingError`` is raised if the type annotation can't be mapped to a Numba
-   type.  This function is meant to be used at statically compile time to
-   evaluate Python type annotations.  For runtime checking of Python objects
-   see ``typeof`` above.
+   Create a Numba type corresponding to the given Python type. ``TypingError``
+   is raised if the type can't be mapped to a Numba type. This function is used
+   by Numba at compile time to evaluate Python type annotations and instance
+   checks. For runtime checking of Python objects, see ``typeof`` above.
 
-   For any numba type, ``as_numba_type(nb_type) == nb_type``.
+   For any Numba type, ``as_numba_type(nb_type) == nb_type``.
 
       >>> numba.extending.as_numba_type(int)
       int64
@@ -384,4 +386,5 @@ Type annotations
       >>> numba.extending.as_numba_type(Counter)
       instance.jitclass.Counter#11bad4278<x:int64>
 
-   Currently ``as_numba_type`` is only used to infer fields for ``@jitclass``.
+   ``as_numba_type`` is used to infer the types of ``@jitclass`` fields, and
+   the ``classinfo`` argument to ``isinstance``.

--- a/docs/upcoming_changes/10044.improvement.rst
+++ b/docs/upcoming_changes/10044.improvement.rst
@@ -1,0 +1,6 @@
+Document and test ``as_numba_type``'s role in instance checks
+-------------------------------------------------------------
+
+Documentation now explains how ``as_numba_type()`` is used in the
+implementation of instance checks, and a test is added to ensure it continues
+to function as expected.

--- a/numba/core/typing/asnumbatype.py
+++ b/numba/core/typing/asnumbatype.py
@@ -77,7 +77,7 @@ class AsNumbaTypeRegistry:
 
     def register(self, func_or_py_type, numba_type=None):
         """
-        Add support new Python types (e.g. user-defined JitClasses) to the
+        Add support for new Python types (e.g. user-defined JitClasses) to the
         registry. For a simple pair of a Python type and a Numba type, this can
         be called as a function ``register(py_type, numba_type)``. If more
         complex logic is required (e.g. for generic types), ``register`` can be

--- a/numba/core/typing/asnumbatype.py
+++ b/numba/core/typing/asnumbatype.py
@@ -7,13 +7,17 @@ from numba.core import errors, types
 
 class AsNumbaTypeRegistry:
     """
-    A registry for python typing declarations.  This registry stores a lookup
-    table for simple cases (e.g. int) and a list of functions for more
-    complicated cases (e.g. generics like List[int]).
+    A registry for Python types. It stores a lookup table for simple cases
+    (e.g. ``int``) and a list of functions for more complicated cases (e.g.
+    generics like ``List[int]``).
 
-    The as_numba_type registry is meant to work statically on type annotations
-    at compile type, not dynamically on instances at runtime. To check the type
-    of an object at runtime, see numba.typeof.
+    Python types are used in Python type annotations, and in instance checks.
+    Therefore, this registry supports determining the Numba type of Python type
+    annotations at compile time, along with determining the type of classinfo
+    arguments to ``isinstance()``.
+
+    This registry is not used dynamically on instances at runtime; to check the
+    type of an object at runtime, use ``numba.typeof``.
     """
 
     def __init__(self):
@@ -73,12 +77,12 @@ class AsNumbaTypeRegistry:
 
     def register(self, func_or_py_type, numba_type=None):
         """
-        Extend AsNumbaType to support new python types (e.g. a user defined
-        JitClass).  For a simple pair of a python type and a numba type, can
-        use as a function register(py_type, numba_type).  If more complex logic
-        is required (e.g. for generic types), register can also be used as a
-        decorator for a function that takes a python type as input and returns
-        a numba type or None.
+        Add support new Python types (e.g. user-defined JitClasses) to the
+        registry. For a simple pair of a Python type and a Numba type, this can
+        be called as a function ``register(py_type, numba_type)``. If more
+        complex logic is required (e.g. for generic types), ``register`` can be
+        used as a decorator for a function that takes a Python type as input
+        and returns a Numba type or ``None``.
         """
         if numba_type is not None:
             # register used with a specific (py_type, numba_type) pair.
@@ -91,10 +95,10 @@ class AsNumbaTypeRegistry:
 
     def try_infer(self, py_type):
         """
-        Try to determine the numba type of a given python type.
-        We first consider the lookup dictionary.  If py_type is not there, we
-        iterate through the registered functions until one returns a numba type.
-        If type inference fails, return None.
+        Try to determine the Numba type of a given Python type. We first
+        consider the lookup dictionary. If ``py_type`` is not there, we iterate
+        through the registered functions until one returns a Numba type.  If
+        type inference fails, return ``None``.
         """
         result = self.lookup.get(py_type, None)
 
@@ -105,7 +109,7 @@ class AsNumbaTypeRegistry:
 
         if result is not None and not isinstance(result, types.Type):
             raise errors.TypingError(
-                f"as_numba_type should return a numba type, got {result}"
+                f"as_numba_type should return a Numba type, got {result}"
             )
         return result
 
@@ -113,7 +117,7 @@ class AsNumbaTypeRegistry:
         result = self.try_infer(py_type)
         if result is None:
             raise errors.TypingError(
-                f"Cannot infer numba type of python type {py_type}"
+                f"Cannot infer Numba type of Python type {py_type}"
             )
         return result
 

--- a/numba/tests/test_asnumbatype.py
+++ b/numba/tests/test_asnumbatype.py
@@ -246,6 +246,10 @@ class TestAsNumbaType(TestCase):
         # determined (it's the argument to the instance check).
         @type_callable(bfloat16)
         def type_bfloat16_ctor(context):
+            # Note that the typer is never called in this test, because we
+            # don't call bfloat16 - only the typing of it as a callable is
+            # used.
+
             def typer(value):
                 if isinstance(value, types.Integer):
                     return bfloat16_type

--- a/numba/tests/test_asnumbatype.py
+++ b/numba/tests/test_asnumbatype.py
@@ -6,9 +6,17 @@ import typing as py_typing
 
 import unittest
 
-from numba.core import types
+from contextlib import ExitStack
+from llvmlite import ir
+
+from numba import jit
+from numba.core import cgutils, types
+from numba.core.datamodel.models import PrimitiveModel
 from numba.core.errors import TypingError
-from numba.core.typing.typeof import typeof
+from numba.core.extending import (register_model, type_callable, unbox,
+                                  NativeValue)
+from numba.core.types import Number
+from numba.core.typing.typeof import typeof, typeof_impl
 from numba.core.typing.asnumbatype import as_numba_type, AsNumbaTypeRegistry
 from numba.experimental.jitclass import jitclass
 from numba.tests.support import TestCase
@@ -150,7 +158,7 @@ class TestAsNumbaType(TestCase):
             with self.assertRaises(TypingError) as raises:
                 as_numba_type(bad_py_type)
             self.assertIn(
-                "Cannot infer numba type of python type",
+                "Cannot infer Numba type of Python type",
                 str(raises.exception),
             )
 
@@ -164,6 +172,112 @@ class TestAsNumbaType(TestCase):
             with self.assertRaises(TypingError) as raises:
                 as_numba_type(bad_py_type)
             self.assertIn("Cannot type Union", str(raises.exception))
+
+    def test_instance_check_usecase(self):
+        # Demonstrates that registering the type class with as_numba_type
+        # supports instance checks, at least for those subclasses supported by
+        # the instance check (e.g. types.Number, etc.).
+        #
+        # To set up the test we need quite a lot of extension code to support
+        # a new type independent of the existing types.
+
+        # The Python class
+        class bfloat16:
+            def __init__(self, value):
+                self._value = value
+
+        # The Numba type class - we use a Number subclass both because it makes
+        # sense for a new numeric type, and it's one of the types supported by
+        # instance checks in Numba
+        class _type_class_bfloat16(Number):
+            def __init__(self):
+                self.bitwidth = 16
+                super().__init__(name="bfloat16")
+
+        # The Numba type instance
+        bfloat16_type = _type_class_bfloat16()
+
+        # Register typing of the Python class for use as arguments and
+        # constants
+        @typeof_impl.register(bfloat16)
+        def typeof_bfloat16(val, c):
+            return bfloat16_type
+
+        # A data model for the bfloat16 class. We don't need much actual
+        # implementation so it doesn't matter too much what this is; a 16-bit
+        # integer representation is sufficient.
+        @register_model(_type_class_bfloat16)
+        class _model_bfloat16(PrimitiveModel):
+            def __init__(self, dmm, fe_type):
+                be_type = ir.IntType(fe_type.bitwidth)
+                super(_model_bfloat16, self).__init__(dmm, fe_type, be_type)
+
+        # Ideally we pass in a value so we ensure that the instance check is
+        # working with values dynamically passed in (preventing the whole check
+        # being potentially optimized into a simple True or False). For this we
+        # need an unboxing.
+        @unbox(_type_class_bfloat16)
+        def unbox_bfloat16(ty, obj, c):
+            ll_type = c.context.get_argument_type(ty)
+            val = cgutils.alloca_once(c.builder, ll_type)
+            is_error_ptr = cgutils.alloca_once_value(c.builder,
+                                                     cgutils.false_bit)
+
+            with ExitStack() as stack:
+                value_obj = c.pyapi.object_getattr_string(obj, "_value")
+
+                with cgutils.early_exit_if_null(c.builder, stack, value_obj):
+                    c.builder.store(cgutils.true_bit, is_error_ptr)
+
+                value_native = c.unbox(types.uint16, value_obj)
+                c.pyapi.decref(value_obj)
+
+                with cgutils.early_exit_if(c.builder, stack,
+                                           value_native.is_error):
+                    c.builder.store(cgutils.true_bit, is_error_ptr)
+
+                c.builder.store(value_native.value, val)
+
+            return NativeValue(c.builder.load(val),
+                               is_error=c.builder.load(is_error_ptr))
+
+        # We never call bfloat16 to construct one inside a jitted function, but
+        # we need this typing so that the type of the bfloat16 class can be
+        # determined (it's the argument to the instance check).
+        @type_callable(bfloat16)
+        def type_bfloat16_ctor(context):
+            def typer(value):
+                if isinstance(value, types.Integer):
+                    return bfloat16_type
+
+        # First we try the instance check without an as_numba_type
+        # registration, to prove that it is necessary for instance checks to
+        # work.
+        @jit
+        def instancecheck_no_ant_reg(x):
+            return isinstance(x, bfloat16)
+
+        # A "random" value to test with
+        x_bf16 = bfloat16(0x4049)  # bfloat16(3.14)
+
+        # Ensure the typing fails without the registration
+        expected_message = r"Cannot infer Numba type of Python type.*bfloat16"
+        with self.assertRaisesRegex(TypingError, expected_message):
+            instancecheck_no_ant_reg(x_bf16)
+
+        # Register the typing with as_numba_type so that we can expect instance
+        # checks to work
+        as_numba_type.register(bfloat16, bfloat16_type)
+
+        # We define a new function to ensure all registrations are as-required
+        @jit
+        def instancecheck(x):
+            return isinstance(x, bfloat16)
+
+        # The instance check should be True for bfloat16 instances and False
+        # otherwise.
+        self.assertTrue(instancecheck(x_bf16))
+        self.assertFalse(instancecheck(1))
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_builtins.py
+++ b/numba/tests/test_builtins.py
@@ -1262,7 +1262,7 @@ class TestIsinstanceBuiltin(TestCase):
         self.assertTrue(cfunc(3.4))
 
         # invalid type
-        msg = 'Cannot infer numba type of python type'
+        msg = 'Cannot infer Numba type of Python type'
 
         with self.assertRaises(errors.TypingError) as raises:
             cfunc(100)
@@ -1272,7 +1272,7 @@ class TestIsinstanceBuiltin(TestCase):
     def test_isinstance_exceptions(self):
         fns = [
             (invalid_isinstance_usecase,
-             'Cannot infer numba type of python type'),
+             'Cannot infer Numba type of Python type'),
             (invalid_isinstance_usecase_phi_nopropagate,
              ('isinstance() cannot determine the type of variable "z" due to a '
              'branch.')),


### PR DESCRIPTION
Originally `as_numba_type()` was added to facilitate the inference of Numba types from Python type annotations on jitclass fields.

However, since #7244 it also plays a role in `isinstance` checks, as it is used to determine the type of the `classinfo` argument to the `isinstance()` function.

This PR adds a test demonstrating its use (and elucidating some of the pre-requisites for the instance check to work) and updates the documentation to explain its use in instance checks.

There are mentions of `as_numba_type()` in a couple of other files that are unmodified:

- `source/extending/low-level.rst`
- `source/user/jitclass.rst`

The wording in these sections already appeared to be appropriate so they are left unchanged.

Note: this was discovered during the review of https://github.com/NVIDIA/numba-cuda/pull/166, due to its use of `as_numba_type()`.