### PR TITLE
Fix `IntEnumMember.can_convert_to()` when no conversions found

### DIFF
--- a/docs/upcoming_changes/10047.bug_fix.rst
+++ b/docs/upcoming_changes/10047.bug_fix.rst
@@ -1,0 +1,5 @@
+Fix ``IntEnumMember.can_convert_to()`` when no conversions found
+----------------------------------------------------------------
+
+A spurious ``TypeError`` that was raised when no conversion from an
+``IntEnumMember`` was possible has now been fixed.

--- a/numba/core/types/new_scalars/scalars.py
+++ b/numba/core/types/new_scalars/scalars.py
@@ -158,4 +158,5 @@ class IntEnumMember(EnumMember):
         """
         if issubclass(self.instance_class, enum.IntEnum):
             conv = typingctx.can_convert(self.dtype, other)
-            return max(conv, Conversion.safe)
+            if conv:
+                return max(conv, Conversion.safe)

--- a/numba/core/types/old_scalars.py
+++ b/numba/core/types/old_scalars.py
@@ -267,4 +267,5 @@ class IntEnumMember(EnumMember):
         """
         if issubclass(self.instance_class, enum.IntEnum):
             conv = typingctx.can_convert(self.dtype, other)
-            return max(conv, Conversion.safe)
+            if conv:
+                return max(conv, Conversion.safe)

--- a/numba/tests/test_types.py
+++ b/numba/tests/test_types.py
@@ -874,6 +874,16 @@ class TestIssues(TestCase):
                     ty1 == ty2
                 )
 
+    def test_int_enum_no_conversion(self):
+        # Ensures that IntEnumMember.can_convert_to() handles the case when the
+        # typing context's can_convert() method returns None to signal no
+        # possible conversion
+        ctx = typing.Context()
+        int_enum_type = types.IntEnumMember(Shape, types.int64)
+        # Conversion of an int enum member to a 1D array would be invalid
+        invalid_toty = types.int64[::1]
+        self.assertIsNone(ctx.can_convert(int_enum_type, invalid_toty))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
`TypingContext.can_convert()` returns `None` when no conversion is possible. `can_convert_to()` implementations must handle the case where this happens. The `IntEnumMember.can_convert_to()` method did not, and this would result in errors like:

```
  File "/home/gmarkall/numbadev/numba/numba/core/typing/context.py", line 556, in can_convert
    forward = fromty.can_convert_to(self, toty)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/gmarkall/numbadev/numba/numba/core/types/old_scalars.py", line 271, in can_convert_to
    return max(conv, Conversion.safe)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '>' not supported between instances of 'Conversion' and 'NoneType'`
```

if no conversion was possible.

This commit fixes the issue by returning `None` when `typingctx.can_convert()` returns `None`.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
