### PR TITLE
Add support for np.binary_repr

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -463,6 +463,7 @@ The following top-level functions are supported:
 * :func:`numpy.atleast_2d`
 * :func:`numpy.atleast_3d`
 * :func:`numpy.bartlett`
+* :func:`numpy.binary_repr`
 * :func:`numpy.bincount`
 * :func:`numpy.blackman`
 * :func:`numpy.broadcast_to` (only the 2 first arguments)

--- a/numba/np/new_arraymath.py
+++ b/numba/np/new_arraymath.py
@@ -3450,6 +3450,49 @@ def np_imag(val):
     return np_imag_impl
 
 
+@register_jitable
+def _bin(x):
+    br = ""
+    x = abs(x)
+    while (x):
+        br = str(x % 2) + br
+        x //= 2
+    return br
+
+
+@overload(np.binary_repr)
+def np_binary_repr1(num):
+    if not isinstance(num, (int, types.Integer)):
+        return
+
+    def impl(num):
+        return ("-" if num < 0 else "") + _bin(num)
+    return impl
+
+
+@overload(np.binary_repr)
+def np_binary_repr2(num, width):
+    if not isinstance(num, (int, types.Integer)):
+        return
+    else:
+        if is_nonelike(width):
+            def impl(num, width):
+                return ("-" if num < 0 else "") + _bin(num)
+        else:
+            def impl(num, width):
+                br = _bin(num)
+                lbr = len(br)
+                if width < lbr:
+                    raise ValueError(f"Insufficient bit width={width} "
+                                     f"provided for binwidth={lbr}")
+                if num >= 0:
+                    br = "0" * (width - len(br)) + br
+                else:
+                    br = _bin(2**width + num)
+                return br
+    return impl
+
+
 #----------------------------------------------------------------------------
 # Misc functions
 

--- a/numba/np/new_arraymath.py
+++ b/numba/np/new_arraymath.py
@@ -3461,17 +3461,7 @@ def _bin(x):
 
 
 @overload(np.binary_repr)
-def np_binary_repr1(num):
-    if not isinstance(num, (int, types.Integer)):
-        return
-
-    def impl(num):
-        return ("-" if num < 0 else "") + _bin(num)
-    return impl
-
-
-@overload(np.binary_repr)
-def np_binary_repr2(num, width):
+def np_binary_repr(num, width):
     if not isinstance(num, (int, types.Integer)):
         return
     else:

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -13,6 +13,7 @@ from numba import jit, njit, typeof
 from numba.core import types
 from numba.typed import List, Dict
 from numba.np.numpy_support import numpy_version
+import numba.np.new_arraymath
 from numba.core.errors import TypingError
 from numba.core.config import IS_32BITS
 from numba.core.utils import pysignature
@@ -538,6 +539,10 @@ def np_isin_3b(a, b, invert=False):
 
 def np_isin_4(a, b, assume_unique=False, invert=False):
     return np.isin(a, b, assume_unique, invert)
+
+
+def np_binary_repr(a, w=None):
+    return np.binary_repr(a, w)
 
 
 class TestNPFunctions(MemoryLeakMixin, TestCase):
@@ -6781,6 +6786,28 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         aux2 = nb_union1d(a, b)
         c2 = nb_setdiff1d(aux2, aux1)
         self.assertPreciseEqual(c1, c2)
+
+    def test_binary_repr(self):
+        npfunc = np_binary_repr
+        cfunc = njit(np_binary_repr)
+
+        unitary_tests = [ 15,
+                          -15]
+        binary_tests = [(12, 5),
+                        (-12, 5),
+                        (10, None),
+                        (-10, None),
+                        (-3, 3),
+                        (-10, 5)]
+        # error_tests   = [(8, 2) ]
+
+        for t in unitary_tests:
+            self.assertPreciseEqual(cfunc(t), npfunc(t))
+        for x, w in binary_tests:
+            self.assertPreciseEqual(cfunc(x, w), npfunc(x, w))
+        # for x, w in error_tests:
+        #     with self.assertRaises(ValueError):
+        #         cfunc(x, w)
 
 
 class TestNPMachineParameters(TestCase):


### PR DESCRIPTION
Adding support for `numpy.binary_repr`; implemented `overload` decorated function and added tests.