### PR TITLE
Fix bug in `np.searchsorted` when the arguments have `float32` dtype

### DIFF
--- a/docs/upcoming_changes/10052.bug_fix.rst
+++ b/docs/upcoming_changes/10052.bug_fix.rst
@@ -1,0 +1,6 @@
+Fix ``np.searchsorted`` with ``float32`` NaN values
+---------------------------------------------------
+
+Fixes a bug in ``np.searchsorted`` where passing a ``float32`` array containing
+NaN values produces incorrect results. This issue occurs due to the use of an
+incorrect comparison function.

--- a/numba/np/new_arraymath.py
+++ b/numba/np/new_arraymath.py
@@ -3737,7 +3737,7 @@ def _less_than_or_equal(a, b):
     if isinstance(a, complex) or isinstance(b, complex):
         return less_than_or_equal_complex(a, b)
 
-    elif isinstance(b, float):
+    elif isinstance(b, (float, types.float32, types.float64)):
         if np.isnan(b):
             return True
 
@@ -3749,7 +3749,7 @@ def _less_than(a, b):
     if isinstance(a, complex) or isinstance(b, complex):
         return less_than_complex(a, b)
 
-    elif isinstance(b, float):
+    elif isinstance(b, (float, types.float32, types.float64)):
         return less_than_float(a, b)
 
     return a < b

--- a/numba/np/old_arraymath.py
+++ b/numba/np/old_arraymath.py
@@ -3737,7 +3737,7 @@ def _less_than_or_equal(a, b):
     if isinstance(a, complex) or isinstance(b, complex):
         return less_than_or_equal_complex(a, b)
 
-    elif isinstance(b, float):
+    elif isinstance(b, (float, types.float32, types.float64)):
         if np.isnan(b):
             return True
 
@@ -3749,7 +3749,7 @@ def _less_than(a, b):
     if isinstance(a, complex) or isinstance(b, complex):
         return less_than_complex(a, b)
 
-    elif isinstance(b, float):
+    elif isinstance(b, (float, types.float32, types.float64)):
         return less_than_float(a, b)
 
     return a < b

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -1511,6 +1511,11 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         check(nans, ones)
         check(nans, nans)
 
+        # `a` and `v` are float32
+        a = np.array([9, np.nan], dtype=np.float32)
+        v = np.array([np.nan], dtype=np.float32)
+        check(a, v)
+
         # `v` is zero size
         a = np.arange(1)
         v = np.arange(0)


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

This is needed because `isinstance(types.float32(1.0), float) := False`.

```python
import numpy as np
from numba import njit

@njit
def searchsorted_numba(array, values):
    return np.searchsorted(array, values, side='left')


dtype = 'float32'
array = np.array([9, np.nan], dtype=dtype)
values = np.array([np.nan], dtype=dtype)
indices = searchsorted_numba(array, values)
print(indices)  # [0] instead of [1]
```

```python
In [2]: isinstance(np.float64(3), float)
Out[2]: True

In [3]: isinstance(np.float32(3), float)
Out[3]: False
```