### PR TITLE
Document the inline and forceinline kwargs

### DIFF
--- a/docs/source/developer/inlining.rst
+++ b/docs/source/developer/inlining.rst
@@ -1,3 +1,4 @@
+.. _notes-on-inlining:
 
 =================
 Notes on Inlining

--- a/docs/source/reference/jit-compilation.rst
+++ b/docs/source/reference/jit-compilation.rst
@@ -6,7 +6,7 @@ Just-in-Time compilation
 JIT functions
 -------------
 
-.. decorator:: numba.jit(signature=None, nopython=False, nogil=False, cache=False, forceobj=False, parallel=False, error_model='python', fastmath=False, locals={}, boundscheck=False)
+.. decorator:: numba.jit(signature=None, nopython=False, nogil=False, cache=False, forceobj=False, parallel=False, error_model='python', fastmath=False, locals={}, boundscheck=False, inline="never", forceinline=False)
 
    Compile the decorated function on-the-fly to produce efficient machine
    code.  All parameters are optional.
@@ -124,6 +124,12 @@ JIT functions
 
       @jit()
       def f(x): ...
+
+   If set to ``"always"``, *inline* will enable inlining at the Numba IR level.
+   See :ref:`notes-on-inlining`.
+
+   If set to ``True``, *forceinline* will force inlining at the LLVM IR level by
+   adding the ``alwaysinline`` attribute to the function definition in the IR.
 
    The decorator returns a :class:`Dispatcher` object.
 


### PR DESCRIPTION
I saw no mention of `forceinline` in the docs, so this PR adds documentation for the `inline` and `forceinline` kwargs to the `@jit` decorator, for clarity.