### PR TITLE
Fix C++ linkage for Python builds with Valgrind

### DIFF
--- a/numba/_dispatcher.cpp
+++ b/numba/_dispatcher.cpp
@@ -40,6 +40,7 @@
 #endif
 #undef _PyGC_FINALIZED
 
+#include "dynamic_annotations.h"
 #if (PY_MINOR_VERSION == 12)
     #include "internal/pycore_atomic.h"
 #endif

--- a/numba/_dispatcher.cpp
+++ b/numba/_dispatcher.cpp
@@ -40,6 +40,10 @@
 #endif
 #undef _PyGC_FINALIZED
 
+/* dynamic_annotations.h is needed for building Python with --with-valgrind 
+ * support. The following include is to workaround issues described in
+ * https://github.com/numba/numba/pull/10073
+ */
 #include "dynamic_annotations.h"
 #if (PY_MINOR_VERSION == 12)
     #include "internal/pycore_atomic.h"


### PR DESCRIPTION
Fedora-based distributions including RHEL and CentOS are building Python with `--with-valgrind` support. The option enables dynamic annotation support. Numba fails to build from soure on systems with Valgrind support. The problem is caused by use of internal CPython core APIs that are untested under C++.

```
g++ -fno-strict-overflow -Wsign-compare -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DNDEBUG -fcf-protection -fexceptions -fcf-protection -fexceptions -fcf-protection -fexceptions -O3 -fPIC -I/tmp/pip-build-env-bi8g7ilp/normal/lib64/python3.13/site-packages/numpy/_core/include -I/opt/app-root/include -I/usr/include/python3.13 -c numba/_dispatcher.cpp -o build/temp.linux-x86_64-cpython-313/numba/_dispatcher.o -std=c++11
  In file included from /usr/include/python3.13/internal/pycore_pythread.h:11,
                   from /usr/include/python3.13/internal/pycore_condvar.h:8,
                   from /usr/include/python3.13/internal/pycore_gil.h:11,
                   from /usr/include/python3.13/internal/pycore_ceval_state.h:12,
                   from /usr/include/python3.13/internal/pycore_interp.h:15,
                   from numba/_dispatcher.cpp:46:
  /usr/include/python3.13/dynamic_annotations.h:472:3: error: template with C linkage
    472 |   template <class T>
        |   ^~~~~~~~
  /usr/include/python3.13/internal/pycore_pythread.h:4:1: note: ‘extern "C"’ linkage started here
      4 | extern "C" {
        | ^~~~~~~~~~
  error: command '/usr/bin/g++' failed with exit code 1
```

- `numba/_dispatcher.cpp` is compiled as C++ program
- the C++ file includes `pycore_pythread.h`
- `pycore_pythread.h` includes `dynamic_annotations.h` in an `extern "C" {}` block.
- `dynamic_annotations.h` gets confused because it is treated as external C header but has `__cplusplus` defined as the same time.
- since `DYNAMIC_ANNOTATIONS_ENABLED != 0 && defined(__cplusplus)` is true, `dynamic_annotations.h` uses C++ features.

This workaround includes `dynamic_annotations.h` earlier and under C++ linkage.

Fixes: #10067
