### PR TITLE
gha/refactor numba win-64 workflows

### DIFF
--- a/.github/workflows/numba_win-64_builder.yml
+++ b/.github/workflows/numba_win-64_builder.yml
@@ -18,27 +18,36 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  LOCAL_LLVMLITE_ARTIFACT_PATH: D:/a/numba/numba/llvmlite_conda
   CONDA_CHANNEL_NUMBA: numba/label/dev
 
 jobs:
+  load-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      build-matrix-json: ${{ steps.parse_matrix.outputs.build-matrix-json }}
+      test-matrix-json: ${{ steps.parse_matrix.outputs.test-matrix-json }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: parse_matrix
+        name: Parse Workflow Matrix JSON
+        run: |
+          BUILD_JSON=$(jq -c .conda_build_matrix .github/workflows/workflow_matrix.json)
+          TEST_JSON=$(jq -c .conda_test_matrix .github/workflows/workflow_matrix.json)
+          echo "Build Matrix JSON: $BUILD_JSON"
+          echo "Test Matrix JSON: $TEST_JSON"
+          echo "build-matrix-json=$BUILD_JSON" >> $GITHUB_OUTPUT
+          echo "test-matrix-json=$TEST_JSON" >> $GITHUB_OUTPUT
+
   win-64-build-conda:
     name: win-64-build-conda (py ${{ matrix.python-version }}, np ${{ matrix.numpy_build }})
+    needs: load-matrix
     runs-on: windows-2019
     defaults:
       run:
         shell: bash -elx {0}
     strategy:
       matrix:
-        include:
-          - python-version: "3.10"
-            numpy_build: "2.0"
-          - python-version: "3.11"
-            numpy_build: "2.0"
-          - python-version: "3.12"
-            numpy_build: "2.0"
-          - python-version: "3.13"
-            numpy_build: "2.1"
+        include: ${{ fromJson(needs.load-matrix.outputs.build-matrix-json) }}
       fail-fast: false
 
     steps:
@@ -71,17 +80,17 @@ jobs:
         run: |
           CONDA_CHANNEL_DIR="conda_channel_dir"
           mkdir -p $CONDA_CHANNEL_DIR
-          
+
           # Set channel based on whether llvmlite artifact was downloaded
           if [ "${{ inputs.llvmlite_run_id }}" != "" ]; then
-            LLVMLITE_CHANNEL="file:///${{ env.LOCAL_LLVMLITE_ARTIFACT_PATH }}"
+            LLVMLITE_CHANNEL="file://${{ github.workspace }}/llvmlite_conda"
           else
             LLVMLITE_CHANNEL="${{ env.CONDA_CHANNEL_NUMBA }}"
           fi
-          
+
           conda build --debug -c $LLVMLITE_CHANNEL -c defaults \
             --python=${{ matrix.python-version }} \
-            --numpy=${{ matrix.numpy_build }} \
+            --numpy=${{ matrix.numpy_build }} blas=*=openblas \
             buildscripts/condarecipe.local/ \
             --output-folder=$CONDA_CHANNEL_DIR \
             --no-test
@@ -97,39 +106,14 @@ jobs:
 
   win-64-test:
     name: win-64-test-conda (py ${{ matrix.python-version }}, np ${{ matrix.numpy_test }})
-    needs: win-64-build-conda
+    needs: [load-matrix, win-64-build-conda]
     runs-on: windows-2019
     defaults:
       run:
         shell: bash -elx {0}
     strategy:
       matrix:
-        include:
-          # Python 3.10
-          - python-version: "3.10"
-            numpy_test: "1.24"
-          - python-version: "3.10"
-            numpy_test: "1.25"
-          
-          # Python 3.11
-          - python-version: "3.11"
-            numpy_test: "1.26"
-          - python-version: "3.11"
-            numpy_test: "2.0"
-          - python-version: "3.11"
-            numpy_test: "2.2"
-          
-          # Python 3.12
-          - python-version: "3.12"
-            numpy_test: "1.26"
-          - python-version: "3.12"
-            numpy_test: "2.0"
-          - python-version: "3.12"
-            numpy_test: "2.2"
-          
-          # Python 3.13
-          - python-version: "3.13"
-            numpy_test: "2.2"
+        include: ${{ fromJson(needs.load-matrix.outputs.test-matrix-json) }}
       fail-fast: false
 
     steps:
@@ -162,12 +146,12 @@ jobs:
         run: |
           # Set channel based on whether llvmlite artifact was downloaded
           if [ "${{ inputs.llvmlite_run_id }}" != "" ]; then
-            LLVMLITE_CHANNEL="file:///${{ env.LOCAL_LLVMLITE_ARTIFACT_PATH }}"
+            LLVMLITE_CHANNEL="file://${{ github.workspace }}/llvmlite_conda"
           else
             LLVMLITE_CHANNEL="${{ env.CONDA_CHANNEL_NUMBA }}"
           fi
-          
+
           conda build -c $LLVMLITE_CHANNEL -c defaults \
-            --extra-deps numpy=${{ matrix.numpy_test }} \
+            --extra-deps numpy=${{ matrix.numpy_test }} blas=*=openblas \
             --test \
             win-64/numba*.conda

--- a/.github/workflows/numba_win-64_builder.yml
+++ b/.github/workflows/numba_win-64_builder.yml
@@ -90,7 +90,7 @@ jobs:
 
           conda build --debug -c $LLVMLITE_CHANNEL -c defaults \
             --python=${{ matrix.python-version }} \
-            --numpy=${{ matrix.numpy_build }} blas=*=openblas \
+            --numpy=${{ matrix.numpy_build }} \
             buildscripts/condarecipe.local/ \
             --output-folder=$CONDA_CHANNEL_DIR \
             --no-test
@@ -152,6 +152,6 @@ jobs:
           fi
 
           conda build -c $LLVMLITE_CHANNEL -c defaults \
-            --extra-deps numpy=${{ matrix.numpy_test }} blas=*=openblas \
+            --extra-deps numpy=${{ matrix.numpy_test }} \
             --test \
             win-64/numba*.conda

--- a/.github/workflows/numba_win-64_whl_builder.yml
+++ b/.github/workflows/numba_win-64_whl_builder.yml
@@ -6,10 +6,6 @@ on:
       - .github/workflows/numba_win-64_whl_builder.yml
   workflow_dispatch:
     inputs:
-      llvmlite_conda_runid:
-        description: 'llvmlite conda workflow run ID (optional)'
-        required: false
-        type: string
       llvmlite_wheel_runid:
         description: 'llvmlite wheel workflow run ID (optional)'
         required: false
@@ -21,30 +17,34 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  LOCAL_LLVMLITE_ARTIFACT_PATH: D:/a/numba/numba/llvmlite_conda
   CONDA_CHANNEL_NUMBA: numba/label/dev
-  VALIDATION_PYTHON_VERSION: "3.12"
   ARTIFACT_RETENTION_DAYS: 7
-  FALLBACK_LLVMLITE_VERSION: "15"
+  WHEELS_INDEX_URL: https://pypi.anaconda.org/numba/label/dev/simple
 
 jobs:
+  load-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix-json: ${{ steps.load_matrix_json.outputs.matrix-json }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: load_matrix_json
+        name: Load Workflow Matrix JSON
+        run: |
+          MATRIX_JSON=$(jq -c .wheel_matrix .github/workflows/workflow_matrix.json)
+          echo "Workflow Matrix JSON: $MATRIX_JSON"
+          echo "matrix-json=$MATRIX_JSON" >> $GITHUB_OUTPUT
+
   win-64-build:
     name: win-64-build-wheel (py ${{ matrix.python-version }}, np ${{ matrix.numpy_build }})
+    needs: load-matrix
     runs-on: windows-2019
     defaults:
       run:
         shell: bash -el {0}
     strategy:
       matrix:
-        include:
-          - python-version: "3.10"
-            numpy_build: "2.0.2"
-          - python-version: "3.11"
-            numpy_build: "2.0.2"
-          - python-version: "3.12"
-            numpy_build: "2.0.2"
-          - python-version: "3.13"
-            numpy_build: "2.1.3"
+        include: ${{ fromJson(needs.load-matrix.outputs.matrix-json) }}
       fail-fast: false
 
     steps:
@@ -61,71 +61,8 @@ jobs:
           auto-update-conda: true
           auto-activate-base: true
 
-      - name: Download llvmlite Artifact
-        if: ${{ inputs.llvmlite_conda_runid != '' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: llvmlite-win-64-py${{ matrix.python-version }}
-          path: llvmlite_conda
-          run-id: ${{ inputs.llvmlite_conda_runid }}
-          repository: numba/llvmlite
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install build dependencies
-        run: |
-          set -x
-          if [ "${{ inputs.llvmlite_conda_runid }}" != "" ]; then
-              CHAN="file:///${{ env.LOCAL_LLVMLITE_ARTIFACT_PATH }}"
-          else
-              CHAN="${{ env.CONDA_CHANNEL_NUMBA }}"
-          fi
-          
-          # Install llvmlite from the appropriate channel
-          conda install -c "$CHAN" llvmlite setuptools python-build numpy==${{ matrix.numpy_build }}
-          
-          # Install TBB with specific versions
-          python -m pip install tbb==2021.6 tbb-devel==2021.6
-
-      - name: Build wheel
-        run: python -m build
-
-      - name: Upload numba wheel
-        uses: actions/upload-artifact@v4
-        with:
-          name: numba-win-64-py${{ matrix.python-version }}-np${{ matrix.numpy_build }}-tbb
-          path: dist/*.whl
-          compression-level: 0
-          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-          if-no-files-found: error
-
-  win-64-test:
-    if: ${{ inputs.llvmlite_wheel_runid != '' }}
-    name: win-64-test-wheel (py ${{ matrix.python-version }}, np ${{ matrix.numpy_test }})
-    needs: win-64-build
-    runs-on: windows-2019
-    defaults:
-      run:
-        shell: bash -el {0}
-    strategy:
-      matrix:
-        include:
-          - python-version: "3.10"
-            numpy_test: "2.0.2"
-          - python-version: "3.11"
-            numpy_test: "2.0.2"
-          - python-version: "3.12"
-            numpy_test: "2.0.2"
-          - python-version: "3.13"
-            numpy_test: "2.1.3"
-      fail-fast: false
-
-    steps:
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
       - name: Download llvmlite wheel
+        if: inputs.llvmlite_wheel_runid != ''
         uses: actions/download-artifact@v4
         with:
           name: llvmlite-win-64-py${{ matrix.python-version }}
@@ -134,15 +71,77 @@ jobs:
           repository: numba/llvmlite
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Download numba wheel
+      - name: Install build dependencies
+        run: |
+          if [ "${{ inputs.llvmlite_wheel_runid }}" != "" ]; then
+              python -m pip install llvmlite_wheels/*.whl
+          else
+              conda install -c ${{ env.CONDA_CHANNEL_NUMBA }} llvmlite
+          fi
+          conda install -c ${{ env.CONDA_CHANNEL_NUMBA }} python-build numpy==${{ matrix.numpy_build }} setuptools
+          python -m pip install tbb==2021.6 tbb-devel==2021.6
+
+      - name: Build wheel
+        run: python -m build
+
+      - name: Upload numba wheel
+        uses: actions/upload-artifact@v4
+        with:
+          name: numba-win-64-py${{ matrix.python-version }}-np${{ matrix.numpy_build }}
+          path: dist/*.whl
+          compression-level: 0
+          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+          if-no-files-found: error
+
+  win-64-test:
+    name: win-64-test-wheel (py ${{ matrix.python-version }}, np ${{ matrix.numpy_test }})
+    needs: [load-matrix, win-64-build]
+    runs-on: windows-2019
+    defaults:
+      run:
+        shell: bash -el {0}
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.load-matrix.outputs.matrix-json) }}
+      fail-fast: false
+
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Download Numba wheel artifact
         uses: actions/download-artifact@v4
         with:
-          name: numba-win-64-py${{ matrix.python-version }}-np${{ matrix.numpy_test }}-tbb
+          name: numba-win-64-py${{ matrix.python-version }}-np${{ matrix.numpy_build }}
           path: dist
 
-      - name: Install and test
+      - name: Download llvmlite wheel
+        if: inputs.llvmlite_wheel_runid != ''
+        uses: actions/download-artifact@v4
+        with:
+          name: llvmlite-win-64-py${{ matrix.python-version }}
+          path: llvmlite_wheels
+          run-id: ${{ inputs.llvmlite_wheel_runid }}
+          repository: numba/llvmlite
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+
+      - name: Validate and test wheel
         run: |
-          python -m pip install numpy==${{ matrix.numpy_test }} tbb==2021.6 tbb-devel==2021.6
-          python -m pip install llvmlite_wheels/*.whl
+          python -m pip install --upgrade pip twine
+          python -m pip install numpy==${{ matrix.numpy_build }} tbb==2021.6 tbb-devel==2021.6
+          if [ "${{ inputs.llvmlite_wheel_runid }}" != "" ]; then
+              python -m pip install llvmlite_wheels/*.whl
+          else
+              python -m pip install -i $WHEELS_INDEX_URL llvmlite
+          fi
+          python -m twine check dist/*.whl
           python -m pip install dist/*.whl
-          python -m numba.runtests -j 1:100 -v -m
+
+          # print Numba system information
+          python -m numba -s
+
+          # run tests
+          python -m numba.runtests -m 4 -v

--- a/.github/workflows/numba_win-64_whl_builder.yml
+++ b/.github/workflows/numba_win-64_whl_builder.yml
@@ -94,7 +94,7 @@ jobs:
           if-no-files-found: error
 
   win-64-test:
-    name: win-64-test-wheel (py ${{ matrix.python-version }}, np ${{ matrix.numpy_test }})
+    name: win-64-test-wheel (py ${{ matrix.python-version }}, np ${{ matrix.numpy_build }})
     needs: [load-matrix, win-64-build]
     runs-on: windows-2019
     defaults:


### PR DESCRIPTION
This PR refactors win-64 workflows to be more consistent with others. Changes include-
1. use of workflow-matrix.json for build and test matrix generation.
2. use of gha template var to find downloaded llvmlite artifact path.
3. use WHEELS_INDEX_URL: https://pypi.anaconda.org/numba/label/dev/simple to get dev wheel from numba channel.