### PR TITLE
Resolve NumPy `DeprecationWarning` in `constant_record`

### DIFF
--- a/docs/upcoming_changes/10081.bug_fix.rst
+++ b/docs/upcoming_changes/10081.bug_fix.rst
@@ -1,0 +1,6 @@
+Fix deprecation warning caused by ``tostring()`` in structured record constant
+------------------------------------------------------------------------------
+
+Replaces the deprecated usage of ``tostring()`` with ``tobytes()`` in
+``numba/np/arrayobj.py:constant_record``. This resolves a DeprecationWarning
+raised when creating structured record constants under recent versions of NumPy.

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -3335,7 +3335,7 @@ def constant_record(context, builder, ty, pyval):
     Create a record constant as a stack-allocated array of bytes.
     """
     lty = ir.ArrayType(ir.IntType(8), pyval.nbytes)
-    val = lty(bytearray(pyval.tostring()))
+    val = lty(bytearray(pyval.tobytes()))
     return cgutils.alloca_once_value(builder, val)
 
 


### PR DESCRIPTION
# What does this PR do?

As suggested in this issue - https://github.com/numba/numba/issues/10080#issue - this PR resolves a `DeprecationWarning` by replacing the deprecated call to `tostring()` with the recommended `tobytes()` in `constant_record()` defined in `numba/np/arrayobj.py`. 

The change aligns with the latest NumPy deprecation policy and ensures compatibility with future NumPy versions.

## Who can review?

Hello @CamRuiz! 👋 Thanks a lot for reporting this issue. Appreciate your contribution!

