### PR TITLE
fix: handle nan correctly in np.unique

### DIFF
--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -2647,7 +2647,10 @@ def np_unique(ar):
     def np_unique_impl(ar):
         b = np.sort(ar.ravel())
         head = list(b[:1])
-        tail = [x for i, x in enumerate(b[1:]) if b[i] != x]
+        tail = [
+            x for i, x in enumerate(b[1:])
+            if b[i] != x and not (np.isnan(b[i]) and np.isnan(x))
+        ]
         return np.array(head + tail)
     return np_unique_impl
 

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -1774,6 +1774,7 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         check(np.array(np.zeros(5)))
         check(np.array([[3.1, 3.1], [1.7, 2.29], [3.3, 1.7]]))
         check(np.array([]))
+        check(np.array([np.nan, np.nan]))
 
     @needs_blas
     def test_array_dot(self):


### PR DESCRIPTION
Fixes #10069

This PR updates the `np.unique` overload to handle `np.nan` values, as simply equating `np.nan` does not work -
```py
>>> np.nan == np.nan
False
```

I am not sure if the solution I wrote is the most appropriate, but happy to improve it through reviews.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
