### PR TITLE
Add support for `posinf` and `neginf` in `nan_to_num`

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -527,7 +527,7 @@ The following top-level functions are supported:
 * :func:`numpy.in1d` (matching pre-1.24 behaviour without the ``kind`` keyword)
 * :func:`numpy.linspace` (only the 3-argument form)
 * :func:`numpy.logspace` (only the 3 first arguments)
-* :func:`numpy.nan_to_num` (only the 3 first arguments)
+* :func:`numpy.nan_to_num`
 * :class:`numpy.ndenumerate`
 * :class:`numpy.ndindex`
 * :class:`numpy.nditer` (only the first argument)

--- a/docs/upcoming_changes/10097.np_support.rst
+++ b/docs/upcoming_changes/10097.np_support.rst
@@ -1,0 +1,5 @@
+Add support for ``posinf`` and ``neginf`` in ``nan_to_num``
+-----------------------------------------------------------
+
+Numba's ``nan_to_num`` now supports ``posinf`` and ``neginf`` arguments of
+NumPy's ``nan_to_num``.

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -7089,11 +7089,34 @@ def nan_to_num_impl(x, copy=True, nan=0.0, posinf=None, neginf=None):
                 return output
         elif isinstance(x.dtype, types.Complex):
             def impl(x, copy=True, nan=0.0, posinf=None, neginf=None):
+                min_inf = (
+                    neginf
+                    if neginf is not None
+                    else np.finfo(x.dtype).min
+                )
+                max_inf = (
+                    posinf
+                    if posinf is not None
+                    else np.finfo(x.dtype).max
+                )
+
                 x_ = np.asarray(x)
                 output = np.copy(x_) if copy else x_
 
-                np.nan_to_num(output.real, copy=False, nan=nan)
-                np.nan_to_num(output.imag, copy=False, nan=nan)
+                np.nan_to_num(
+                    output.real,
+                    copy=False,
+                    nan=nan,
+                    posinf=max_inf,
+                    neginf=min_inf
+                )
+                np.nan_to_num(
+                    output.imag,
+                    copy=False,
+                    nan=nan,
+                    posinf=max_inf,
+                    neginf=min_inf
+                )
                 return output
         else:
             raise errors.TypingError(

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -7024,11 +7024,11 @@ def nan_to_num_impl(x, copy=True, nan=0.0, posinf=None, neginf=None):
     if isinstance(x, types.Number):
         if isinstance(x, types.Integer):
             # Integers do not have nans or infs
-            def impl(x, copy=True, nan=0.0):
+            def impl(x, copy=True, nan=0.0, posinf=None, neginf=None):
                 return x
 
         elif isinstance(x, types.Float):
-            def impl(x, copy=True, nan=0.0):
+            def impl(x, copy=True, nan=0.0, posinf=None, neginf=None):
                 min_inf = (
                     neginf
                     if neginf is not None
@@ -7048,7 +7048,7 @@ def nan_to_num_impl(x, copy=True, nan=0.0, posinf=None, neginf=None):
                     return max_inf
                 return x
         elif isinstance(x, types.Complex):
-            def impl(x, copy=True, nan=0.0):
+            def impl(x, copy=True, nan=0.0, posinf=None, neginf=None):
                 r = np.nan_to_num(x.real, nan=nan)
                 c = np.nan_to_num(x.imag, nan=nan)
                 return complex(r, c)
@@ -7060,10 +7060,10 @@ def nan_to_num_impl(x, copy=True, nan=0.0, posinf=None, neginf=None):
     elif type_can_asarray(x):
         if isinstance(x.dtype, types.Integer):
             # Integers do not have nans or infs
-            def impl(x, copy=True, nan=0.0):
+            def impl(x, copy=True, nan=0.0, posinf=None, neginf=None):
                 return x
         elif isinstance(x.dtype, types.Float):
-            def impl(x, copy=True, nan=0.0):
+            def impl(x, copy=True, nan=0.0, posinf=None, neginf=None):
                 min_inf = (
                     neginf
                     if neginf is not None
@@ -7088,7 +7088,7 @@ def nan_to_num_impl(x, copy=True, nan=0.0, posinf=None, neginf=None):
                         output_flat[i] = max_inf
                 return output
         elif isinstance(x.dtype, types.Complex):
-            def impl(x, copy=True, nan=0.0):
+            def impl(x, copy=True, nan=0.0, posinf=None, neginf=None):
                 x_ = np.asarray(x)
                 output = np.copy(x_) if copy else x_
 

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -7049,8 +7049,8 @@ def nan_to_num_impl(x, copy=True, nan=0.0, posinf=None, neginf=None):
                 return x
         elif isinstance(x, types.Complex):
             def impl(x, copy=True, nan=0.0, posinf=None, neginf=None):
-                r = np.nan_to_num(x.real, nan=nan)
-                c = np.nan_to_num(x.imag, nan=nan)
+                r = np.nan_to_num(x.real, nan=nan, posinf=posinf, neginf=neginf)
+                c = np.nan_to_num(x.imag, nan=nan, posinf=posinf, neginf=neginf)
                 return complex(r, c)
         else:
             raise errors.TypingError(
@@ -7089,17 +7089,6 @@ def nan_to_num_impl(x, copy=True, nan=0.0, posinf=None, neginf=None):
                 return output
         elif isinstance(x.dtype, types.Complex):
             def impl(x, copy=True, nan=0.0, posinf=None, neginf=None):
-                min_inf = (
-                    neginf
-                    if neginf is not None
-                    else np.finfo(x.dtype).min
-                )
-                max_inf = (
-                    posinf
-                    if posinf is not None
-                    else np.finfo(x.dtype).max
-                )
-
                 x_ = np.asarray(x)
                 output = np.copy(x_) if copy else x_
 
@@ -7107,15 +7096,15 @@ def nan_to_num_impl(x, copy=True, nan=0.0, posinf=None, neginf=None):
                     output.real,
                     copy=False,
                     nan=nan,
-                    posinf=max_inf,
-                    neginf=min_inf
+                    posinf=posinf,
+                    neginf=neginf
                 )
                 np.nan_to_num(
                     output.imag,
                     copy=False,
                     nan=nan,
-                    posinf=max_inf,
-                    neginf=min_inf
+                    posinf=posinf,
+                    neginf=neginf
                 )
                 return output
         else:

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -7020,7 +7020,7 @@ def arr_take_along_axis(arr, indices, axis):
 
 
 @overload(np.nan_to_num)
-def nan_to_num_impl(x, copy=True, nan=0.0):
+def nan_to_num_impl(x, copy=True, nan=0.0, posinf=None, neginf=None):
     if isinstance(x, types.Number):
         if isinstance(x, types.Integer):
             # Integers do not have nans or infs
@@ -7029,12 +7029,23 @@ def nan_to_num_impl(x, copy=True, nan=0.0):
 
         elif isinstance(x, types.Float):
             def impl(x, copy=True, nan=0.0):
+                min_inf = (
+                    neginf
+                    if neginf is not None
+                    else np.finfo(type(x)).min
+                )
+                max_inf = (
+                    posinf
+                    if posinf is not None
+                    else np.finfo(type(x)).max
+                )
+
                 if np.isnan(x):
                     return nan
                 elif np.isneginf(x):
-                    return np.finfo(type(x)).min
+                    return min_inf
                 elif np.isposinf(x):
-                    return np.finfo(type(x)).max
+                    return max_inf
                 return x
         elif isinstance(x, types.Complex):
             def impl(x, copy=True, nan=0.0):
@@ -7053,8 +7064,16 @@ def nan_to_num_impl(x, copy=True, nan=0.0):
                 return x
         elif isinstance(x.dtype, types.Float):
             def impl(x, copy=True, nan=0.0):
-                min_inf = np.finfo(x.dtype).min
-                max_inf = np.finfo(x.dtype).max
+                min_inf = (
+                    neginf
+                    if neginf is not None
+                    else np.finfo(x.dtype).min
+                )
+                max_inf = (
+                    posinf
+                    if posinf is not None
+                    else np.finfo(x.dtype).max
+                )
 
                 x_ = np.asarray(x)
                 output = np.copy(x_) if copy else x_

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -6236,13 +6236,15 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             np.array([-np.inf, np.nan, np.inf], dtype=np.float32)
         ]
         nans = [0.0, 10]
-        posinf = [None, 1000.0]
-        neginf = [None, -1000.0]
+        posinfs = [None, 1000.0]
+        neginfs = [None, -1000.0]
 
         pyfunc = nan_to_num
         cfunc = njit(nan_to_num)
 
-        for value, nan in product(values, nans, posinf, neginf):
+        for value, nan, posinf, neginf in product(
+            values, nans, posinfs, neginfs
+        ):
             expected = pyfunc(value, nan=nan, posinf=posinf, neginf=neginf)
             got = cfunc(value, nan=nan, posinf=posinf, neginf=neginf)
             self.assertPreciseEqual(expected, got)

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -477,7 +477,7 @@ def swapaxes(a, a1, a2):
 
 
 def nan_to_num(X, copy=True, nan=0.0, posinf=None, neginf=None):
-    return np.nan_to_num(X, copy=copy, nan=nan)
+    return np.nan_to_num(X, copy=copy, nan=nan, posinf=posinf, neginf=neginf)
 
 
 def np_indices(dimensions):


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

Closes #10089

Now Numba's `nan_to_num` supports all the arguments of `np.nan_to_num` (added missing `posinf` and `neginf`) -

```py
numpy.nan_to_num(x, copy=True, nan=0.0, posinf=None, neginf=None)
```