### PR TITLE
Fix error for unsupported `axis` kwarg in `average`

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -422,6 +422,8 @@ The following reduction functions are supported:
   unsupported)
 * :func:`numpy.quantile` (only the 2 first arguments, complex dtypes
   unsupported)
+* :func:`np.average` (`axis` argument is not supported)
+
 
 Polynomials
 -----------

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -976,7 +976,7 @@ The following functions are now supported:
 * ``np.cbrt``
 * ``np.logspace``
 * ``np.take_along_axis``
-* ``np.average`` (``axis`` kwarg is not supported)
+* ``np.average``
 * ``np.argmin`` gains support for the ``axis`` kwarg.
 * ``np.ndarray.astype`` gains support for types expressed as literal strings.
 

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -976,7 +976,7 @@ The following functions are now supported:
 * ``np.cbrt``
 * ``np.logspace``
 * ``np.take_along_axis``
-* ``np.average``
+* ``np.average`` (``axis`` kwarg is not supported)
 * ``np.argmin`` gains support for the ``axis`` kwarg.
 * ``np.ndarray.astype`` gains support for types expressed as literal strings.
 

--- a/docs/upcoming_changes/10102.bug_fix.rst
+++ b/docs/upcoming_changes/10102.bug_fix.rst
@@ -1,0 +1,5 @@
+Fix error for unsupported ``axis`` kwarg in ``average``
+-------------------------------------------------------
+
+Be explicit about the ``axis`` kwarg not being supported and fix logic in error
+handling

--- a/numba/np/old_arraymath.py
+++ b/numba/np/old_arraymath.py
@@ -917,22 +917,20 @@ def np_any(a):
 
 @overload(np.average)
 def np_average(a, axis=None, weights=None):
-
-    if weights is None or isinstance(weights, types.NoneType):
+    if axis is not None or not isinstance(axis, types.NoneType):
         def np_average_impl(a, axis=None, weights=None):
-            arr = np.asarray(a)
-            return np.mean(arr)
+            raise TypeError("Numba does not support average with axis.")
     else:
-        if axis is None or isinstance(axis, types.NoneType):
+        if weights is None or isinstance(weights, types.NoneType):
+            def np_average_impl(a, axis=None, weights=None):
+                arr = np.asarray(a)
+                return np.mean(arr)
+        else:
             def np_average_impl(a, axis=None, weights=None):
                 arr = np.asarray(a)
                 weights = np.asarray(weights)
 
                 if arr.shape != weights.shape:
-                    if axis is None:
-                        raise TypeError(
-                            "Numba does not support average when shapes of "
-                            "a and weights differ.")
                     if weights.ndim != 1:
                         raise TypeError(
                             "1D weights expected when shapes of "
@@ -945,9 +943,6 @@ def np_average(a, axis=None, weights=None):
 
                 avg = np.sum(np.multiply(arr, weights)) / scl
                 return avg
-        else:
-            def np_average_impl(a, axis=None, weights=None):
-                raise TypeError("Numba does not support average with axis.")
 
     return np_average_impl
 

--- a/numba/np/old_arraymath.py
+++ b/numba/np/old_arraymath.py
@@ -917,7 +917,7 @@ def np_any(a):
 
 @overload(np.average)
 def np_average(a, axis=None, weights=None):
-    if axis is not None or not isinstance(axis, types.NoneType):
+    if axis is not None and not isinstance(axis, types.NoneType):
         def np_average_impl(a, axis=None, weights=None):
             raise TypeError("Numba does not support average with axis.")
     else:

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -4351,7 +4351,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
 
         #small case to test exceptions for 2D array and 1D weights
         data = np.arange(6).reshape((3,2,1))
-        w = np.asarray([1. / 4, 3. / 4])
+        w = np.asarray([[1. / 4, 3. / 4]])
 
         #test axis
         test_axis(data, axis=1)

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -4332,12 +4332,19 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
                 cfunc(data, weights=weights)
             err = e.exception
             self.assertEqual(str(err),
-                             "Numba does not support average when shapes of "
+                             "1D weights expected when shapes of "
                              "a and weights differ.")
 
         def test_1D_weights_axis(data, axis, weights):
             with self.assertRaises(TypeError) as e:
-                cfunc(data,axis=axis, weights=weights)
+                cfunc(data, axis=axis, weights=weights)
+            err = e.exception
+            self.assertEqual(str(err),
+                             "Numba does not support average with axis.")
+
+        def test_axis(data, axis):
+            with self.assertRaises(TypeError) as e:
+                cfunc(data, axis=axis)
             err = e.exception
             self.assertEqual(str(err),
                              "Numba does not support average with axis.")
@@ -4346,10 +4353,13 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         data = np.arange(6).reshape((3,2,1))
         w = np.asarray([1. / 4, 3. / 4])
 
-        #test without axis argument
+        #test axis
+        test_axis(data, axis=1)
+
+        #test shape mismatch
         test_1D_weights(data, weights=w)
 
-        #test with axis argument
+        #test axis and with weights provided
         test_1D_weights_axis(data, axis=1, weights=w)
 
     def test_allclose(self):


### PR DESCRIPTION
Fixes #10092

Be explicit about the `axis` kwarg not being supported + fix logic in error handling

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
