### PR TITLE
Fix NumPy 2.3-related test bugs

### DIFF
--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -2936,6 +2936,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             for k in range(-3, 3):
                 check(arr, k)
 
+    @unittest.skipIf(numpy_version >= (2, 3), "Removed in NumPy 2.3")
     def test_partition_boolean_inputs(self):
         pyfunc = partition
         cfunc = jit(nopython=True)(pyfunc)
@@ -2944,6 +2945,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             for kth in True, False, -1, 0, 1:
                 self.partition_sanity_check(pyfunc, cfunc, d, kth)
 
+    @unittest.skipIf(numpy_version >= (2, 3), "Removed in NumPy 2.3")
     def test_argpartition_boolean_inputs(self):
         pyfunc = argpartition
         cfunc = jit(nopython=True)(pyfunc)

--- a/numba/tests/test_types.py
+++ b/numba/tests/test_types.py
@@ -561,15 +561,6 @@ class TestSignatures(TestCase):
 
 
 class TestRecordDtype(unittest.TestCase):
-    def test_record_type_equiv(self):
-        rec_dt = np.dtype([('a', np.int32), ('b', np.float32)])
-        rec_ty = typeof(rec_dt)
-        art1 = rec_ty[::1]
-        arr = np.zeros(5, dtype=rec_dt)
-        art2 = typeof(arr)
-        self.assertEqual(art2.dtype.dtype, rec_ty)
-        self.assertEqual(art1, art2)
-
     def test_user_specified(self):
         rec_dt = np.dtype([('a', np.int32), ('b', np.float32)])
         rec_type = typeof(rec_dt)


### PR DESCRIPTION
NumPy 2.3 removed some long-standing deprecated features, so this PR makes the associated testing fixes, resolving #10105.  Note that the NumPy 2.3 removal of `.tostring()` was already fixed in #10081.