### PR TITLE
gha/migrate windows 2019 to 2025

### DIFF
--- a/.github/workflows/numba_linux-64_wheel_builder.yml
+++ b/.github/workflows/numba_linux-64_wheel_builder.yml
@@ -41,10 +41,20 @@ jobs:
         run: |
           BUILD_MATRIX_JSON=$(jq -c .wheel_build_matrix .github/workflows/workflow_matrix.json)
           TEST_MATRIX_JSON=$(jq -c .wheel_test_matrix .github/workflows/workflow_matrix.json)
-          echo "Build Matrix JSON: $BUILD_MATRIX_JSON"
-          echo "Test Matrix JSON: $TEST_MATRIX_JSON"
-          echo "build-matrix-json=$BUILD_MATRIX_JSON" >> $GITHUB_OUTPUT
-          echo "test-matrix-json=$TEST_MATRIX_JSON" >> $GITHUB_OUTPUT
+
+          # Add canonical python versions to both matrices
+          BUILD_MATRIX_EXTENDED=$(echo "$BUILD_MATRIX_JSON" | jq -c '
+            map(. + {"python_canonical": (.["python-version"] | split(".") | .[:2] | join("."))})
+          ')
+
+          TEST_MATRIX_EXTENDED=$(echo "$TEST_MATRIX_JSON" | jq -c '
+            map(. + {"python_canonical": (.["python-version"] | split(".") | .[:2] | join("."))})
+          ')
+
+          echo "Build Matrix JSON: $BUILD_MATRIX_EXTENDED"
+          echo "Test Matrix JSON: $TEST_MATRIX_EXTENDED"
+          echo "build-matrix-json=$BUILD_MATRIX_EXTENDED" >> $GITHUB_OUTPUT
+          echo "test-matrix-json=$TEST_MATRIX_EXTENDED" >> $GITHUB_OUTPUT
 
   linux-64-build:
     name: linux-64-build-wheel (py ${{ matrix.python-version }}, np ${{ matrix.numpy_build }})
@@ -68,7 +78,7 @@ jobs:
         if: inputs.llvmlite_wheel_runid != ''
         uses: actions/download-artifact@v4
         with:
-          name: llvmlite-linux-64-py${{ matrix.python-version }}
+          name: llvmlite-linux-64-py${{ matrix.python_canonical }}
           path: llvmlite_wheels
           run-id: ${{ inputs.llvmlite_wheel_runid }}
           repository: numba/llvmlite
@@ -120,7 +130,7 @@ jobs:
       - name: Upload numba wheel
         uses: actions/upload-artifact@v4
         with:
-          name: numba-linux-64-py${{ matrix.python-version }}
+          name: numba-linux-64-py${{ matrix.python_canonical }}
           path: wheelhouse/*.whl
           compression-level: 0
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
@@ -159,14 +169,14 @@ jobs:
       - name: Download Numba wheel artifact
         uses: actions/download-artifact@v4
         with:
-          name: numba-linux-64-py${{ matrix.python-version }}
+          name: numba-linux-64-py${{ matrix.python_canonical }}
           path: dist
 
       - name: Download llvmlite wheel
         if: inputs.llvmlite_wheel_runid != ''
         uses: actions/download-artifact@v4
         with:
-          name: llvmlite-linux-64-py${{ matrix.python-version }}
+          name: llvmlite-linux-64-py${{ matrix.python_canonical }}
           path: llvmlite_wheels
           run-id: ${{ inputs.llvmlite_wheel_runid }}
           repository: numba/llvmlite
@@ -174,7 +184,7 @@ jobs:
 
       - name: Validate and test wheel
         run: |
-          PYTHON_PATH=$(which python${{ matrix.python-version }})
+          PYTHON_PATH=$(which python${{ matrix.python_canonical }})
           $PYTHON_PATH -m pip install --upgrade pip twine
           ls -l dist
           if [ "${{ inputs.llvmlite_wheel_runid }}" != "" ]; then

--- a/.github/workflows/numba_linux-64_wheel_builder.yml
+++ b/.github/workflows/numba_linux-64_wheel_builder.yml
@@ -32,15 +32,19 @@ jobs:
   load-matrix:
     runs-on: ubuntu-latest
     outputs:
-      wheel-matrix-json: ${{ steps.load_matrix_json.outputs.wheel-matrix-json }}
+      build-matrix-json: ${{ steps.load_matrix_json.outputs.build-matrix-json }}
+      test-matrix-json: ${{ steps.load_matrix_json.outputs.test-matrix-json }}
     steps:
       - uses: actions/checkout@v4
       - id: load_matrix_json
         name: Load Workflow Matrix JSON
         run: |
-          MATRIX_JSON=$(jq -c .wheel_matrix .github/workflows/workflow_matrix.json)
-          echo "Workflow Matrix JSON: $MATRIX_JSON"
-          echo "wheel-matrix-json=$MATRIX_JSON" >> $GITHUB_OUTPUT
+          BUILD_MATRIX_JSON=$(jq -c .wheel_build_matrix .github/workflows/workflow_matrix.json)
+          TEST_MATRIX_JSON=$(jq -c .wheel_test_matrix .github/workflows/workflow_matrix.json)
+          echo "Build Matrix JSON: $BUILD_MATRIX_JSON"
+          echo "Test Matrix JSON: $TEST_MATRIX_JSON"
+          echo "build-matrix-json=$BUILD_MATRIX_JSON" >> $GITHUB_OUTPUT
+          echo "test-matrix-json=$TEST_MATRIX_JSON" >> $GITHUB_OUTPUT
 
   linux-64-build:
     name: linux-64-build-wheel (py ${{ matrix.python-version }}, np ${{ matrix.numpy_build }})
@@ -51,7 +55,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        include: ${{ fromJson(needs.load-matrix.outputs.wheel-matrix-json) }}
+        include: ${{ fromJson(needs.load-matrix.outputs.build-matrix-json) }}
       fail-fast: false
 
     steps:
@@ -116,7 +120,7 @@ jobs:
       - name: Upload numba wheel
         uses: actions/upload-artifact@v4
         with:
-          name: numba-linux-64-py${{ matrix.python-version }}-np${{ matrix.numpy_build }}
+          name: numba-linux-64-py${{ matrix.python-version }}
           path: wheelhouse/*.whl
           compression-level: 0
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
@@ -133,7 +137,7 @@ jobs:
             if-no-files-found: error
 
   linux-64-test:
-    name: linux-64-test (py ${{ matrix.python-version }}, np ${{ matrix.numpy_build }})
+    name: linux-64-test (py ${{ matrix.python-version }}, np ${{ matrix.numpy_test }})
     needs: [load-matrix, linux-64-build]
     runs-on: ubuntu-latest
     env:
@@ -143,7 +147,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        include: ${{ fromJson(needs.load-matrix.outputs.wheel-matrix-json) }}
+        include: ${{ fromJson(needs.load-matrix.outputs.test-matrix-json) }}
       fail-fast: false
 
     steps:
@@ -155,7 +159,7 @@ jobs:
       - name: Download Numba wheel artifact
         uses: actions/download-artifact@v4
         with:
-          name: numba-linux-64-py${{ matrix.python-version }}-np${{ matrix.numpy_build }}
+          name: numba-linux-64-py${{ matrix.python-version }}
           path: dist
 
       - name: Download llvmlite wheel
@@ -180,7 +184,7 @@ jobs:
           fi
           $PYTHON_PATH -m twine check dist/*.whl
 
-          $PYTHON_PATH -m pip install dist/numba*.whl numpy==${{ matrix.numpy_build }} setuptools
+          $PYTHON_PATH -m pip install dist/numba*.whl numpy==${{ matrix.numpy_test }} setuptools
 
           if [ "$USE_TBB" = "true" ]; then
             $PYTHON_PATH -m pip install tbb

--- a/.github/workflows/numba_linux-arm64_wheel_builder.yml
+++ b/.github/workflows/numba_linux-arm64_wheel_builder.yml
@@ -35,10 +35,20 @@ jobs:
         run: |
           BUILD_MATRIX_JSON=$(jq -c .wheel_build_matrix .github/workflows/workflow_matrix.json)
           TEST_MATRIX_JSON=$(jq -c .wheel_test_matrix .github/workflows/workflow_matrix.json)
-          echo "Build Matrix JSON: $BUILD_MATRIX_JSON"
-          echo "Test Matrix JSON: $TEST_MATRIX_JSON"
-          echo "build-matrix-json=$BUILD_MATRIX_JSON" >> $GITHUB_OUTPUT
-          echo "test-matrix-json=$TEST_MATRIX_JSON" >> $GITHUB_OUTPUT
+
+          # Add canonical python versions to both matrices
+          BUILD_MATRIX_EXTENDED=$(echo "$BUILD_MATRIX_JSON" | jq -c '
+            map(. + {"python_canonical": (.["python-version"] | split(".") | .[:2] | join("."))})
+          ')
+
+          TEST_MATRIX_EXTENDED=$(echo "$TEST_MATRIX_JSON" | jq -c '
+            map(. + {"python_canonical": (.["python-version"] | split(".") | .[:2] | join("."))})
+          ')
+
+          echo "Build Matrix JSON: $BUILD_MATRIX_EXTENDED"
+          echo "Test Matrix JSON: $TEST_MATRIX_EXTENDED"
+          echo "build-matrix-json=$BUILD_MATRIX_EXTENDED" >> $GITHUB_OUTPUT
+          echo "test-matrix-json=$TEST_MATRIX_EXTENDED" >> $GITHUB_OUTPUT
 
   linux-arm64-build:
     name: linux-arm64-build-wheel (py ${{ matrix.python-version }}, np ${{ matrix.numpy_build }})
@@ -62,7 +72,7 @@ jobs:
         if: inputs.llvmlite_wheel_runid != ''
         uses: actions/download-artifact@v4
         with:
-          name: llvmlite-linux-arm64-py${{ matrix.python-version }}
+          name: llvmlite-linux-arm64-py${{ matrix.python_canonical }}
           path: llvmlite_wheels
           run-id: ${{ inputs.llvmlite_wheel_runid }}
           repository: numba/llvmlite
@@ -114,7 +124,7 @@ jobs:
       - name: Upload numba wheel
         uses: actions/upload-artifact@v4
         with:
-          name: numba-linux-arm64-py${{ matrix.python-version }}
+          name: numba-linux-arm64-py${{ matrix.python_canonical }}
           path: wheelhouse/*.whl
           compression-level: 0
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
@@ -151,14 +161,14 @@ jobs:
       - name: Download Numba wheel artifact
         uses: actions/download-artifact@v4
         with:
-          name: numba-linux-arm64-py${{ matrix.python-version }}
+          name: numba-linux-arm64-py${{ matrix.python_canonical }}
           path: dist
 
       - name: Download llvmlite wheel
         if: inputs.llvmlite_wheel_runid != ''
         uses: actions/download-artifact@v4
         with:
-          name: llvmlite-linux-arm64-py${{ matrix.python-version }}
+          name: llvmlite-linux-arm64-py${{ matrix.python_canonical }}
           path: llvmlite_wheels
           run-id: ${{ inputs.llvmlite_wheel_runid }}
           repository: numba/llvmlite
@@ -166,7 +176,7 @@ jobs:
 
       - name: Validate and test wheel
         run: |
-          PYTHON_PATH=$(which python${{ matrix.python-version }})
+          PYTHON_PATH=$(which python${{ matrix.python_canonical }})
           $PYTHON_PATH -m pip install --upgrade pip twine
           ls -l dist
           if [ "${{ inputs.llvmlite_wheel_runid }}" != "" ]; then

--- a/.github/workflows/numba_linux-arm64_wheel_builder.yml
+++ b/.github/workflows/numba_linux-arm64_wheel_builder.yml
@@ -26,15 +26,19 @@ jobs:
   load-matrix:
     runs-on: ubuntu-latest
     outputs:
-      wheel-matrix-json: ${{ steps.load_matrix_json.outputs.wheel-matrix-json }}
+      build-matrix-json: ${{ steps.load_matrix_json.outputs.build-matrix-json }}
+      test-matrix-json: ${{ steps.load_matrix_json.outputs.test-matrix-json }}
     steps:
       - uses: actions/checkout@v4
       - id: load_matrix_json
         name: Load Workflow Matrix JSON
         run: |
-          MATRIX_JSON=$(jq -c .wheel_matrix .github/workflows/workflow_matrix.json)
-          echo "Workflow Matrix JSON: $MATRIX_JSON"
-          echo "wheel-matrix-json=$MATRIX_JSON" >> $GITHUB_OUTPUT
+          BUILD_MATRIX_JSON=$(jq -c .wheel_build_matrix .github/workflows/workflow_matrix.json)
+          TEST_MATRIX_JSON=$(jq -c .wheel_test_matrix .github/workflows/workflow_matrix.json)
+          echo "Build Matrix JSON: $BUILD_MATRIX_JSON"
+          echo "Test Matrix JSON: $TEST_MATRIX_JSON"
+          echo "build-matrix-json=$BUILD_MATRIX_JSON" >> $GITHUB_OUTPUT
+          echo "test-matrix-json=$TEST_MATRIX_JSON" >> $GITHUB_OUTPUT
 
   linux-arm64-build:
     name: linux-arm64-build-wheel (py ${{ matrix.python-version }}, np ${{ matrix.numpy_build }})
@@ -45,7 +49,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        include: ${{ fromJson(needs.load-matrix.outputs.wheel-matrix-json) }}
+        include: ${{ fromJson(needs.load-matrix.outputs.build-matrix-json) }}
       fail-fast: false
 
     steps:
@@ -110,7 +114,7 @@ jobs:
       - name: Upload numba wheel
         uses: actions/upload-artifact@v4
         with:
-          name: numba-linux-arm64-py${{ matrix.python-version }}-np${{ matrix.numpy_build }}
+          name: numba-linux-arm64-py${{ matrix.python-version }}
           path: wheelhouse/*.whl
           compression-level: 0
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
@@ -127,7 +131,7 @@ jobs:
             if-no-files-found: error
 
   linux-arm64-test:
-    name: linux-arm64-test (py ${{ matrix.python-version }}, np ${{ matrix.numpy_build }})
+    name: linux-arm64-test (py ${{ matrix.python-version }}, np ${{ matrix.numpy_test }})
     needs: [load-matrix, linux-arm64-build]
     runs-on: ubuntu-24.04-arm
     defaults:
@@ -135,7 +139,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        include: ${{ fromJson(needs.load-matrix.outputs.wheel-matrix-json) }}
+        include: ${{ fromJson(needs.load-matrix.outputs.test-matrix-json) }}
       fail-fast: false
 
     steps:
@@ -147,7 +151,7 @@ jobs:
       - name: Download Numba wheel artifact
         uses: actions/download-artifact@v4
         with:
-          name: numba-linux-arm64-py${{ matrix.python-version }}-np${{ matrix.numpy_build }}
+          name: numba-linux-arm64-py${{ matrix.python-version }}
           path: dist
 
       - name: Download llvmlite wheel
@@ -171,7 +175,7 @@ jobs:
               $PYTHON_PATH -m pip install --no-cache-dir -i $WHEELS_INDEX_URL llvmlite
           fi
           $PYTHON_PATH -m twine check dist/*.whl
-          $PYTHON_PATH -m pip install dist/numba*.whl numpy==${{ matrix.numpy_build }} setuptools
+          $PYTHON_PATH -m pip install dist/numba*.whl numpy==${{ matrix.numpy_test }} setuptools
 
           # print Numba system information
           $PYTHON_PATH -m numba -s

--- a/.github/workflows/numba_osx-64_wheel_builder.yml
+++ b/.github/workflows/numba_osx-64_wheel_builder.yml
@@ -34,10 +34,20 @@ jobs:
         run: |
           BUILD_MATRIX_JSON=$(jq -c .wheel_build_matrix .github/workflows/workflow_matrix.json)
           TEST_MATRIX_JSON=$(jq -c .wheel_test_matrix .github/workflows/workflow_matrix.json)
-          echo "Build Matrix JSON: $BUILD_MATRIX_JSON"
-          echo "Test Matrix JSON: $TEST_MATRIX_JSON"
-          echo "build-matrix-json=$BUILD_MATRIX_JSON" >> $GITHUB_OUTPUT
-          echo "test-matrix-json=$TEST_MATRIX_JSON" >> $GITHUB_OUTPUT
+
+          # Add canonical python versions to both matrices
+          BUILD_MATRIX_EXTENDED=$(echo "$BUILD_MATRIX_JSON" | jq -c '
+            map(. + {"python_canonical": (.["python-version"] | split(".") | .[:2] | join("."))})
+          ')
+
+          TEST_MATRIX_EXTENDED=$(echo "$TEST_MATRIX_JSON" | jq -c '
+            map(. + {"python_canonical": (.["python-version"] | split(".") | .[:2] | join("."))})
+          ')
+
+          echo "Build Matrix JSON: $BUILD_MATRIX_EXTENDED"
+          echo "Test Matrix JSON: $TEST_MATRIX_EXTENDED"
+          echo "build-matrix-json=$BUILD_MATRIX_EXTENDED" >> $GITHUB_OUTPUT
+          echo "test-matrix-json=$TEST_MATRIX_EXTENDED" >> $GITHUB_OUTPUT
 
   osx-64-build:
     name: osx-64-build-wheel (py ${{ matrix.python-version }}, np ${{ matrix.numpy_build }})
@@ -73,7 +83,7 @@ jobs:
         if: inputs.llvmlite_wheel_runid != ''
         uses: actions/download-artifact@v4
         with:
-          name: llvmlite-osx-64-py${{ matrix.python-version }}
+          name: llvmlite-osx-64-py${{ matrix.python_canonical }}
           path: llvmlite_wheels
           run-id: ${{ inputs.llvmlite_wheel_runid }}
           repository: numba/llvmlite
@@ -110,7 +120,7 @@ jobs:
       - name: Upload numba wheel
         uses: actions/upload-artifact@v4
         with:
-          name: numba-osx-64-py${{ matrix.python-version }}
+          name: numba-osx-64-py${{ matrix.python_canonical }}
           path: dist/*.whl
           compression-level: 0
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
@@ -147,14 +157,14 @@ jobs:
       - name: Download Numba wheel artifact
         uses: actions/download-artifact@v4
         with:
-          name: numba-osx-64-py${{ matrix.python-version }}
+          name: numba-osx-64-py${{ matrix.python_canonical }}
           path: dist
 
       - name: Download llvmlite wheel
         if: inputs.llvmlite_wheel_runid != ''
         uses: actions/download-artifact@v4
         with:
-          name: llvmlite-osx-64-py${{ matrix.python-version }}
+          name: llvmlite-osx-64-py${{ matrix.python_canonical }}
           path: llvmlite_wheels
           run-id: ${{ inputs.llvmlite_wheel_runid }}
           repository: numba/llvmlite
@@ -168,7 +178,7 @@ jobs:
 
       - name: Validate and test wheel
         run: |
-          PYTHON_PATH=$(which python${{ matrix.python-version }})
+          PYTHON_PATH=$(which python${{ matrix.python_canonical }})
           $PYTHON_PATH -m pip install --upgrade pip twine
           ls -l dist
           if [ "${{ inputs.llvmlite_wheel_runid }}" != "" ]; then

--- a/.github/workflows/numba_osx-64_wheel_builder.yml
+++ b/.github/workflows/numba_osx-64_wheel_builder.yml
@@ -25,15 +25,19 @@ jobs:
   load-matrix:
     runs-on: ubuntu-latest
     outputs:
-      matrix-json: ${{ steps.load_matrix_json.outputs.matrix-json }}
+      build-matrix-json: ${{ steps.load_matrix_json.outputs.build-matrix-json }}
+      test-matrix-json: ${{ steps.load_matrix_json.outputs.test-matrix-json }}
     steps:
       - uses: actions/checkout@v4
       - id: load_matrix_json
         name: Load Workflow Matrix JSON
         run: |
-          MATRIX_JSON=$(jq -c .wheel_matrix .github/workflows/workflow_matrix.json)
-          echo "Workflow Matrix JSON: $MATRIX_JSON"
-          echo "matrix-json=$MATRIX_JSON" >> $GITHUB_OUTPUT
+          BUILD_MATRIX_JSON=$(jq -c .wheel_build_matrix .github/workflows/workflow_matrix.json)
+          TEST_MATRIX_JSON=$(jq -c .wheel_test_matrix .github/workflows/workflow_matrix.json)
+          echo "Build Matrix JSON: $BUILD_MATRIX_JSON"
+          echo "Test Matrix JSON: $TEST_MATRIX_JSON"
+          echo "build-matrix-json=$BUILD_MATRIX_JSON" >> $GITHUB_OUTPUT
+          echo "test-matrix-json=$TEST_MATRIX_JSON" >> $GITHUB_OUTPUT
 
   osx-64-build:
     name: osx-64-build-wheel (py ${{ matrix.python-version }}, np ${{ matrix.numpy_build }})
@@ -44,7 +48,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        include: ${{ fromJson(needs.load-matrix.outputs.matrix-json) }}
+        include: ${{ fromJson(needs.load-matrix.outputs.build-matrix-json) }}
       fail-fast: false
 
     steps:
@@ -106,7 +110,7 @@ jobs:
       - name: Upload numba wheel
         uses: actions/upload-artifact@v4
         with:
-          name: numba-osx-64-py${{ matrix.python-version }}-np${{ matrix.numpy_build }}
+          name: numba-osx-64-py${{ matrix.python-version }}
           path: dist/*.whl
           compression-level: 0
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
@@ -123,7 +127,7 @@ jobs:
             if-no-files-found: error
 
   osx-64-test:
-    name: osx-64-test (py ${{ matrix.python-version }}, np ${{ matrix.numpy_build }})
+    name: osx-64-test (py ${{ matrix.python-version }}, np ${{ matrix.numpy_test }})
     needs: [load-matrix, osx-64-build]
     runs-on: macos-13
     defaults:
@@ -131,7 +135,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        include: ${{ fromJson(needs.load-matrix.outputs.matrix-json) }}
+        include: ${{ fromJson(needs.load-matrix.outputs.test-matrix-json) }}
       fail-fast: false
 
     steps:
@@ -143,7 +147,7 @@ jobs:
       - name: Download Numba wheel artifact
         uses: actions/download-artifact@v4
         with:
-          name: numba-osx-64-py${{ matrix.python-version }}-np${{ matrix.numpy_build }}
+          name: numba-osx-64-py${{ matrix.python-version }}
           path: dist
 
       - name: Download llvmlite wheel
@@ -173,7 +177,7 @@ jobs:
               $PYTHON_PATH -m pip install -i $WHEELS_INDEX_URL llvmlite
           fi
           $PYTHON_PATH -m twine check dist/*.whl
-          $PYTHON_PATH -m pip install dist/numba*.whl numpy==${{ matrix.numpy_build }}
+          $PYTHON_PATH -m pip install dist/numba*.whl numpy==${{ matrix.numpy_test }}
 
           # print Numba system information
           $PYTHON_PATH -m numba -s

--- a/.github/workflows/numba_osx-arm64_wheel_builder.yml
+++ b/.github/workflows/numba_osx-arm64_wheel_builder.yml
@@ -25,15 +25,19 @@ jobs:
   load-matrix:
     runs-on: ubuntu-latest
     outputs:
-      matrix-json: ${{ steps.load_matrix_json.outputs.matrix-json }}
+      build-matrix-json: ${{ steps.load_matrix_json.outputs.build-matrix-json }}
+      test-matrix-json: ${{ steps.load_matrix_json.outputs.test-matrix-json }}
     steps:
       - uses: actions/checkout@v4
       - id: load_matrix_json
-        name: parse_matrix
+        name: Load Workflow Matrix JSON
         run: |
-          MATRIX_JSON=$(jq -c .wheel_matrix .github/workflows/workflow_matrix.json)
-          echo "matrix: $MATRIX_JSON"
-          echo "matrix-json=$MATRIX_JSON" >> $GITHUB_OUTPUT
+          BUILD_MATRIX_JSON=$(jq -c .wheel_build_matrix .github/workflows/workflow_matrix.json)
+          TEST_MATRIX_JSON=$(jq -c .wheel_test_matrix .github/workflows/workflow_matrix.json)
+          echo "Build Matrix JSON: $BUILD_MATRIX_JSON"
+          echo "Test Matrix JSON: $TEST_MATRIX_JSON"
+          echo "build-matrix-json=$BUILD_MATRIX_JSON" >> $GITHUB_OUTPUT
+          echo "test-matrix-json=$TEST_MATRIX_JSON" >> $GITHUB_OUTPUT
 
   osx-arm64-build:
     name: osx-arm64-build-wheel (py ${{ matrix.python-version }}, np ${{ matrix.numpy_build }})
@@ -44,7 +48,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        include: ${{ fromJson(needs.load-matrix.outputs.matrix-json) }}
+        include: ${{ fromJson(needs.load-matrix.outputs.build-matrix-json) }}
       fail-fast: false
 
     steps:
@@ -100,7 +104,7 @@ jobs:
       - name: Upload numba wheel
         uses: actions/upload-artifact@v4
         with:
-          name: numba-osx-arm64-py${{ matrix.python-version }}-np${{ matrix.numpy_build }}
+          name: numba-osx-arm64-py${{ matrix.python-version }}
           path: dist/*.whl
           compression-level: 0
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
@@ -117,7 +121,7 @@ jobs:
             if-no-files-found: error
 
   osx-arm64-test:
-    name: osx-arm64-test (py ${{ matrix.python-version }}, np ${{ matrix.numpy_build }})
+    name: osx-arm64-test (py ${{ matrix.python-version }}, np ${{ matrix.numpy_test }})
     needs: [load-matrix, osx-arm64-build]
     runs-on: macos-14
     defaults:
@@ -125,7 +129,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        include: ${{ fromJson(needs.load-matrix.outputs.matrix-json) }}
+        include: ${{ fromJson(needs.load-matrix.outputs.test-matrix-json) }}
       fail-fast: false
 
     steps:
@@ -137,7 +141,7 @@ jobs:
       - name: Download Numba wheel artifact
         uses: actions/download-artifact@v4
         with:
-          name: numba-osx-arm64-py${{ matrix.python-version }}-np${{ matrix.numpy_build }}
+          name: numba-osx-arm64-py${{ matrix.python-version }}
           path: dist
 
       - name: Download llvmlite wheel
@@ -168,7 +172,7 @@ jobs:
               arch -arm64 python -m pip install -i $WHEELS_INDEX_URL llvmlite
           fi
           arch -arm64 python -m twine check dist/*.whl
-          arch -arm64 python -m pip install dist/numba*.whl numpy==${{ matrix.numpy_build }}
+          arch -arm64 python -m pip install dist/numba*.whl numpy==${{ matrix.numpy_test }}
 
           # print Numba system information
           arch -arm64 python -m numba -s

--- a/.github/workflows/numba_osx-arm64_wheel_builder.yml
+++ b/.github/workflows/numba_osx-arm64_wheel_builder.yml
@@ -34,10 +34,20 @@ jobs:
         run: |
           BUILD_MATRIX_JSON=$(jq -c .wheel_build_matrix .github/workflows/workflow_matrix.json)
           TEST_MATRIX_JSON=$(jq -c .wheel_test_matrix .github/workflows/workflow_matrix.json)
-          echo "Build Matrix JSON: $BUILD_MATRIX_JSON"
-          echo "Test Matrix JSON: $TEST_MATRIX_JSON"
-          echo "build-matrix-json=$BUILD_MATRIX_JSON" >> $GITHUB_OUTPUT
-          echo "test-matrix-json=$TEST_MATRIX_JSON" >> $GITHUB_OUTPUT
+
+          # Add canonical python versions to both matrices
+          BUILD_MATRIX_EXTENDED=$(echo "$BUILD_MATRIX_JSON" | jq -c '
+            map(. + {"python_canonical": (.["python-version"] | split(".") | .[:2] | join("."))})
+          ')
+
+          TEST_MATRIX_EXTENDED=$(echo "$TEST_MATRIX_JSON" | jq -c '
+            map(. + {"python_canonical": (.["python-version"] | split(".") | .[:2] | join("."))})
+          ')
+
+          echo "Build Matrix JSON: $BUILD_MATRIX_EXTENDED"
+          echo "Test Matrix JSON: $TEST_MATRIX_EXTENDED"
+          echo "build-matrix-json=$BUILD_MATRIX_EXTENDED" >> $GITHUB_OUTPUT
+          echo "test-matrix-json=$TEST_MATRIX_EXTENDED" >> $GITHUB_OUTPUT
 
   osx-arm64-build:
     name: osx-arm64-build-wheel (py ${{ matrix.python-version }}, np ${{ matrix.numpy_build }})
@@ -69,7 +79,7 @@ jobs:
         if: inputs.llvmlite_wheel_runid != ''
         uses: actions/download-artifact@v4
         with:
-          name: llvmlite-osx-arm64-py${{ matrix.python-version }}
+          name: llvmlite-osx-arm64-py${{ matrix.python_canonical }}
           path: llvmlite_wheels
           run-id: ${{ inputs.llvmlite_wheel_runid }}
           repository: numba/llvmlite
@@ -104,7 +114,7 @@ jobs:
       - name: Upload numba wheel
         uses: actions/upload-artifact@v4
         with:
-          name: numba-osx-arm64-py${{ matrix.python-version }}
+          name: numba-osx-arm64-py${{ matrix.python_canonical }}
           path: dist/*.whl
           compression-level: 0
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
@@ -133,6 +143,17 @@ jobs:
       fail-fast: false
 
     steps:
+      - name: Set Python versions
+        run: |
+          FULL_VERSION="${{ matrix.python-version }}"
+          CANONICAL_VERSION=$(echo "$FULL_VERSION" | cut -d. -f1,2)
+
+          echo "PYTHON_INSTALL_VERSION=$FULL_VERSION" >> $GITHUB_ENV
+          echo "PYTHON_CANONICAL_VERSION=$CANONICAL_VERSION" >> $GITHUB_ENV
+
+          echo "Using install version: $FULL_VERSION"
+          echo "Using canonical version: $CANONICAL_VERSION"
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -141,14 +162,14 @@ jobs:
       - name: Download Numba wheel artifact
         uses: actions/download-artifact@v4
         with:
-          name: numba-osx-arm64-py${{ matrix.python-version }}
+          name: numba-osx-arm64-py${{ matrix.python_canonical }}
           path: dist
 
       - name: Download llvmlite wheel
         if: inputs.llvmlite_wheel_runid != ''
         uses: actions/download-artifact@v4
         with:
-          name: llvmlite-osx-arm64-py${{ matrix.python-version }}
+          name: llvmlite-osx-arm64-py${{ matrix.python_canonical }}
           path: llvmlite_wheels
           run-id: ${{ inputs.llvmlite_wheel_runid }}
           repository: numba/llvmlite
@@ -162,7 +183,7 @@ jobs:
 
       - name: Validate and test wheel
         run: |
-          PYTHON_PATH=$(which python${{ matrix.python-version }})
+          PYTHON_PATH=$(which python${{ matrix.python_canonical }})
           "$PYTHON_PATH" -m venv .venv && source .venv/bin/activate
           arch -arm64 python -m pip install --upgrade pip twine
           ls -l dist

--- a/.github/workflows/numba_win-64_builder.yml
+++ b/.github/workflows/numba_win-64_builder.yml
@@ -41,7 +41,7 @@ jobs:
   win-64-build-conda:
     name: win-64-build-conda (py ${{ matrix.python-version }}, np ${{ matrix.numpy_build }})
     needs: load-matrix
-    runs-on: windows-2019
+    runs-on: windows-2025
     defaults:
       run:
         shell: bash -elx {0}
@@ -107,7 +107,7 @@ jobs:
   win-64-test:
     name: win-64-test-conda (py ${{ matrix.python-version }}, np ${{ matrix.numpy_test }})
     needs: [load-matrix, win-64-build-conda]
-    runs-on: windows-2019
+    runs-on: windows-2025
     defaults:
       run:
         shell: bash -elx {0}

--- a/.github/workflows/numba_win-64_wheel_builder.yml
+++ b/.github/workflows/numba_win-64_wheel_builder.yml
@@ -25,15 +25,19 @@ jobs:
   load-matrix:
     runs-on: ubuntu-latest
     outputs:
-      matrix-json: ${{ steps.load_matrix_json.outputs.matrix-json }}
+      build-matrix-json: ${{ steps.load_matrix_json.outputs.build-matrix-json }}
+      test-matrix-json: ${{ steps.load_matrix_json.outputs.test-matrix-json }}
     steps:
       - uses: actions/checkout@v4
       - id: load_matrix_json
         name: Load Workflow Matrix JSON
         run: |
-          MATRIX_JSON=$(jq -c .wheel_matrix .github/workflows/workflow_matrix.json)
-          echo "Workflow Matrix JSON: $MATRIX_JSON"
-          echo "matrix-json=$MATRIX_JSON" >> $GITHUB_OUTPUT
+          BUILD_MATRIX_JSON=$(jq -c .wheel_build_matrix .github/workflows/workflow_matrix.json)
+          TEST_MATRIX_JSON=$(jq -c .wheel_test_matrix .github/workflows/workflow_matrix.json)
+          echo "Build Matrix JSON: $BUILD_MATRIX_JSON"
+          echo "Test Matrix JSON: $TEST_MATRIX_JSON"
+          echo "build-matrix-json=$BUILD_MATRIX_JSON" >> $GITHUB_OUTPUT
+          echo "test-matrix-json=$TEST_MATRIX_JSON" >> $GITHUB_OUTPUT
 
   win-64-build:
     name: win-64-build-wheel (py ${{ matrix.python-version }}, np ${{ matrix.numpy_build }})
@@ -44,7 +48,7 @@ jobs:
         shell: bash -el {0}
     strategy:
       matrix:
-        include: ${{ fromJson(needs.load-matrix.outputs.matrix-json) }}
+        include: ${{ fromJson(needs.load-matrix.outputs.build-matrix-json) }}
       fail-fast: false
 
     steps:
@@ -87,14 +91,14 @@ jobs:
       - name: Upload numba wheel
         uses: actions/upload-artifact@v4
         with:
-          name: numba-win-64-py${{ matrix.python-version }}-np${{ matrix.numpy_build }}
+          name: numba-win-64-py${{ matrix.python-version }}
           path: dist/*.whl
           compression-level: 0
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
           if-no-files-found: error
 
   win-64-test:
-    name: win-64-test-wheel (py ${{ matrix.python-version }}, np ${{ matrix.numpy_build }})
+    name: win-64-test-wheel (py ${{ matrix.python-version }}, np ${{ matrix.numpy_test }})
     needs: [load-matrix, win-64-build]
     runs-on: windows-2019
     defaults:
@@ -102,7 +106,7 @@ jobs:
         shell: bash -el {0}
     strategy:
       matrix:
-        include: ${{ fromJson(needs.load-matrix.outputs.matrix-json) }}
+        include: ${{ fromJson(needs.load-matrix.outputs.test-matrix-json) }}
       fail-fast: false
 
     steps:
@@ -114,7 +118,7 @@ jobs:
       - name: Download Numba wheel artifact
         uses: actions/download-artifact@v4
         with:
-          name: numba-win-64-py${{ matrix.python-version }}-np${{ matrix.numpy_build }}
+          name: numba-win-64-py${{ matrix.python-version }}
           path: dist
 
       - name: Download llvmlite wheel
@@ -131,7 +135,7 @@ jobs:
       - name: Validate and test wheel
         run: |
           python -m pip install --upgrade pip twine
-          python -m pip install numpy==${{ matrix.numpy_build }} tbb==2021.6 tbb-devel==2021.6
+          python -m pip install numpy==${{ matrix.numpy_test }} tbb==2021.6 tbb-devel==2021.6
           if [ "${{ inputs.llvmlite_wheel_runid }}" != "" ]; then
               python -m pip install llvmlite_wheels/*.whl
           else

--- a/.github/workflows/numba_win-64_wheel_builder.yml
+++ b/.github/workflows/numba_win-64_wheel_builder.yml
@@ -52,7 +52,7 @@ jobs:
   win-64-build:
     name: win-64-build-wheel (py ${{ matrix.python-version }}, np ${{ matrix.numpy_build }})
     needs: load-matrix
-    runs-on: windows-2019
+    runs-on: windows-2025
     defaults:
       run:
         shell: bash -el {0}
@@ -110,7 +110,7 @@ jobs:
   win-64-test:
     name: win-64-test-wheel (py ${{ matrix.python-version }}, np ${{ matrix.numpy_test }})
     needs: [load-matrix, win-64-build]
-    runs-on: windows-2019
+    runs-on: windows-2025
     defaults:
       run:
         shell: bash -el {0}

--- a/.github/workflows/numba_win-64_wheel_builder.yml
+++ b/.github/workflows/numba_win-64_wheel_builder.yml
@@ -34,10 +34,20 @@ jobs:
         run: |
           BUILD_MATRIX_JSON=$(jq -c .wheel_build_matrix .github/workflows/workflow_matrix.json)
           TEST_MATRIX_JSON=$(jq -c .wheel_test_matrix .github/workflows/workflow_matrix.json)
-          echo "Build Matrix JSON: $BUILD_MATRIX_JSON"
-          echo "Test Matrix JSON: $TEST_MATRIX_JSON"
-          echo "build-matrix-json=$BUILD_MATRIX_JSON" >> $GITHUB_OUTPUT
-          echo "test-matrix-json=$TEST_MATRIX_JSON" >> $GITHUB_OUTPUT
+
+          # Add canonical python versions to both matrices
+          BUILD_MATRIX_EXTENDED=$(echo "$BUILD_MATRIX_JSON" | jq -c '
+            map(. + {"python_canonical": (.["python-version"] | split(".") | .[:2] | join("."))})
+          ')
+
+          TEST_MATRIX_EXTENDED=$(echo "$TEST_MATRIX_JSON" | jq -c '
+            map(. + {"python_canonical": (.["python-version"] | split(".") | .[:2] | join("."))})
+          ')
+
+          echo "Build Matrix JSON: $BUILD_MATRIX_EXTENDED"
+          echo "Test Matrix JSON: $TEST_MATRIX_EXTENDED"
+          echo "build-matrix-json=$BUILD_MATRIX_EXTENDED" >> $GITHUB_OUTPUT
+          echo "test-matrix-json=$TEST_MATRIX_EXTENDED" >> $GITHUB_OUTPUT
 
   win-64-build:
     name: win-64-build-wheel (py ${{ matrix.python-version }}, np ${{ matrix.numpy_build }})
@@ -69,7 +79,7 @@ jobs:
         if: inputs.llvmlite_wheel_runid != ''
         uses: actions/download-artifact@v4
         with:
-          name: llvmlite-win-64-py${{ matrix.python-version }}
+          name: llvmlite-win-64-py${{ matrix.python_canonical }}
           path: llvmlite_wheels
           run-id: ${{ inputs.llvmlite_wheel_runid }}
           repository: numba/llvmlite
@@ -91,7 +101,7 @@ jobs:
       - name: Upload numba wheel
         uses: actions/upload-artifact@v4
         with:
-          name: numba-win-64-py${{ matrix.python-version }}
+          name: numba-win-64-py${{ matrix.python_canonical }}
           path: dist/*.whl
           compression-level: 0
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
@@ -118,19 +128,18 @@ jobs:
       - name: Download Numba wheel artifact
         uses: actions/download-artifact@v4
         with:
-          name: numba-win-64-py${{ matrix.python-version }}
+          name: numba-win-64-py${{ matrix.python_canonical }}
           path: dist
 
       - name: Download llvmlite wheel
         if: inputs.llvmlite_wheel_runid != ''
         uses: actions/download-artifact@v4
         with:
-          name: llvmlite-win-64-py${{ matrix.python-version }}
+          name: llvmlite-win-64-py${{ matrix.python_canonical }}
           path: llvmlite_wheels
           run-id: ${{ inputs.llvmlite_wheel_runid }}
           repository: numba/llvmlite
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
 
       - name: Validate and test wheel
         run: |

--- a/.github/workflows/workflow_matrix.json
+++ b/.github/workflows/workflow_matrix.json
@@ -3,7 +3,7 @@
       { "python-version": "3.10", "numpy_build": "2.0" },
       { "python-version": "3.11", "numpy_build": "2.0" },
       { "python-version": "3.12", "numpy_build": "2.0" },
-      { "python-version": "3.13.3", "numpy_build": "2.1" }
+      { "python-version": "3.13", "numpy_build": "2.1" }
     ],
     "conda_test_matrix": [
       { "python-version": "3.10", "numpy_test": "1.24" },
@@ -14,7 +14,7 @@
       { "python-version": "3.12", "numpy_test": "1.26" },
       { "python-version": "3.12", "numpy_test": "2.0" },
       { "python-version": "3.12", "numpy_test": "2.2" },
-      { "python-version": "3.13.3", "numpy_test": "2.2" }
+      { "python-version": "3.13", "numpy_test": "2.2" }
     ],
     "wheel_build_matrix": [
       { "python-version": "3.10", "numpy_build": "2.0.2", "python_tag": "cp310" },

--- a/.github/workflows/workflow_matrix.json
+++ b/.github/workflows/workflow_matrix.json
@@ -16,10 +16,23 @@
       { "python-version": "3.12", "numpy_test": "2.2" },
       { "python-version": "3.13", "numpy_test": "2.2" }
     ],
-    "wheel_matrix": [
+    "wheel_build_matrix": [
       { "python-version": "3.10", "numpy_build": "2.0.2", "python_tag": "cp310" },
       { "python-version": "3.11", "numpy_build": "2.0.2", "python_tag": "cp311" },
       { "python-version": "3.12", "numpy_build": "2.0.2", "python_tag": "cp312" },
       { "python-version": "3.13", "numpy_build": "2.1.3", "python_tag": "cp313" }
+    ],
+    "wheel_test_matrix": [
+      { "python-version": "3.10", "numpy_test": "1.24" },
+      { "python-version": "3.10", "numpy_test": "1.25" },
+      { "python-version": "3.10", "numpy_test": "2.0" },
+      { "python-version": "3.10", "numpy_test": "2.2" },
+      { "python-version": "3.11", "numpy_test": "1.26" },
+      { "python-version": "3.11", "numpy_test": "2.0" },
+      { "python-version": "3.11", "numpy_test": "2.2" },
+      { "python-version": "3.12", "numpy_test": "1.26" },
+      { "python-version": "3.12", "numpy_test": "2.0" },
+      { "python-version": "3.12", "numpy_test": "2.2" },
+      { "python-version": "3.13", "numpy_test": "2.2" }
     ]
 }

--- a/.github/workflows/workflow_matrix.json
+++ b/.github/workflows/workflow_matrix.json
@@ -23,16 +23,11 @@
       { "python-version": "3.13", "numpy_build": "2.1.3", "python_tag": "cp313" }
     ],
     "wheel_test_matrix": [
-      { "python-version": "3.10", "numpy_test": "1.24" },
-      { "python-version": "3.10", "numpy_test": "1.25" },
-      { "python-version": "3.10", "numpy_test": "2.0" },
       { "python-version": "3.10", "numpy_test": "2.2" },
-      { "python-version": "3.11", "numpy_test": "1.26" },
-      { "python-version": "3.11", "numpy_test": "2.0" },
       { "python-version": "3.11", "numpy_test": "2.2" },
-      { "python-version": "3.12", "numpy_test": "1.26" },
-      { "python-version": "3.12", "numpy_test": "2.0" },
       { "python-version": "3.12", "numpy_test": "2.2" },
-      { "python-version": "3.13", "numpy_test": "2.2" }
+      { "python-version": "3.12", "numpy_test": "2.3" },
+      { "python-version": "3.13", "numpy_test": "2.2" },
+      { "python-version": "3.13", "numpy_test": "2.3" }
     ]
 }

--- a/.github/workflows/workflow_matrix.json
+++ b/.github/workflows/workflow_matrix.json
@@ -3,7 +3,7 @@
       { "python-version": "3.10", "numpy_build": "2.0" },
       { "python-version": "3.11", "numpy_build": "2.0" },
       { "python-version": "3.12", "numpy_build": "2.0" },
-      { "python-version": "3.13", "numpy_build": "2.1" }
+      { "python-version": "3.13.3", "numpy_build": "2.1" }
     ],
     "conda_test_matrix": [
       { "python-version": "3.10", "numpy_test": "1.24" },
@@ -14,20 +14,23 @@
       { "python-version": "3.12", "numpy_test": "1.26" },
       { "python-version": "3.12", "numpy_test": "2.0" },
       { "python-version": "3.12", "numpy_test": "2.2" },
-      { "python-version": "3.13", "numpy_test": "2.2" }
+      { "python-version": "3.13.3", "numpy_test": "2.2" }
     ],
     "wheel_build_matrix": [
       { "python-version": "3.10", "numpy_build": "2.0.2", "python_tag": "cp310" },
       { "python-version": "3.11", "numpy_build": "2.0.2", "python_tag": "cp311" },
       { "python-version": "3.12", "numpy_build": "2.0.2", "python_tag": "cp312" },
-      { "python-version": "3.13", "numpy_build": "2.1.3", "python_tag": "cp313" }
+      { "python-version": "3.13.3", "numpy_build": "2.1.3", "python_tag": "cp313" }
     ],
     "wheel_test_matrix": [
-      { "python-version": "3.10", "numpy_test": "2.2" },
+      { "python-version": "3.10", "numpy_test": "1.24" },
+      { "python-version": "3.10", "numpy_test": "1.25" },
+      { "python-version": "3.11", "numpy_test": "1.26" },
+      { "python-version": "3.11", "numpy_test": "2.0" },
       { "python-version": "3.11", "numpy_test": "2.2" },
+      { "python-version": "3.12", "numpy_test": "1.26" },
+      { "python-version": "3.12", "numpy_test": "2.0" },
       { "python-version": "3.12", "numpy_test": "2.2" },
-      { "python-version": "3.12", "numpy_test": "2.3" },
-      { "python-version": "3.13", "numpy_test": "2.2" },
-      { "python-version": "3.13", "numpy_test": "2.3" }
+      { "python-version": "3.13.3", "numpy_test": "2.2" }
     ]
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -122,4 +122,4 @@ jobs:
 - template: buildscripts/azure/azure-windows.yml
   parameters:
     name: Windows
-    vmImage: windows-2019
+    vmImage: windows-2025


### PR DESCRIPTION
Addressing - 
https://github.com/numba/llvmlite/issues/1214
https://github.com/actions/runner-images/issues/12045

GitHub is retiring Windows Server 2019 hosted runners on June 30, 2025 as part of their N-1 OS support policy. 
To ensure CI functions without disruption, we need to migrate to newer Windows runner images. 
