### PR TITLE
Include `typing.NamedTuple` in docs as supported

### DIFF
--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -1018,7 +1018,7 @@ The following functions from the :mod:`cmath` module are supported:
 ``collections``
 ---------------
 
-Named tuple classes, as returned by :func:`collections.namedtuple`, are
+Named tuple classes, as returned by :func:`collections.namedtuple` or implicitly created by :class:`typing.NamedTuple`, are
 supported in the same way regular tuples are supported.  Attribute access
 and named parameters in the constructor are also supported.
 


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

I recently noticed that `typing.NamedTuple` (modern counterpart of `collections.namedtuple`) is working with `numba.jit` .

This PR includes this fact in the documentation.

```py
from __future__ import annotations

from typing import NamedTuple

import numba


class C(NamedTuple):
    """Modern namedtuple."""

    a: int
    b: str


@numba.njit
def f(c: C) -> C:
    """Create namedtuple instance inside."""
    return C(c.a + 1, f"{c.a}x + {c.b}")


f(C(3, "2"))  # C(a=4, b='3x + 2')
```

### Memo

See https://docs.python.org/3.13/library/typing.html#typing.NamedTuple for why I used the word *implicitly* here.
