### PR TITLE
ci/numba update win-2019 to 2025

### DIFF
--- a/.github/workflows/numba_win-64_builder.yml
+++ b/.github/workflows/numba_win-64_builder.yml
@@ -42,7 +42,7 @@ jobs:
   win-64-build-conda:
     name: win-64-build-conda (py ${{ matrix.python-version }}, np ${{ matrix.numpy_build }})
     needs: load-matrix
-    runs-on: windows-2019
+    runs-on: windows-2025
     defaults:
       run:
         shell: bash -elx {0}
@@ -108,7 +108,7 @@ jobs:
   win-64-test:
     name: win-64-test-conda (py ${{ matrix.python-version }}, np ${{ matrix.numpy_test }})
     needs: [load-matrix, win-64-build-conda]
-    runs-on: windows-2019
+    runs-on: windows-2025
     defaults:
       run:
         shell: bash -elx {0}

--- a/.github/workflows/numba_win-64_wheel_builder.yml
+++ b/.github/workflows/numba_win-64_wheel_builder.yml
@@ -53,7 +53,7 @@ jobs:
   win-64-build:
     name: win-64-build-wheel (py ${{ matrix.python-version }}, np ${{ matrix.numpy_build }})
     needs: load-matrix
-    runs-on: windows-2019
+    runs-on: windows-2025
     defaults:
       run:
         shell: bash -el {0}
@@ -111,7 +111,7 @@ jobs:
   win-64-test:
     name: win-64-test-wheel (py ${{ matrix.python-version }}, np ${{ matrix.numpy_test }})
     needs: [load-matrix, win-64-build]
-    runs-on: windows-2019
+    runs-on: windows-2025
     defaults:
       run:
         shell: bash -el {0}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -122,4 +122,4 @@ jobs:
 - template: buildscripts/azure/azure-windows.yml
   parameters:
     name: Windows
-    vmImage: windows-2019
+    vmImage: windows-2025


### PR DESCRIPTION
GitHub is retiring Windows Server 2019 hosted runners on June 30, 2025 as part of their N-1 OS support policy.
To ensure CI functions without disruption, we need to migrate to newer Windows runner image - windows-2025.

This PR makes needed changes to numba workflow and build scripts.