### PR TITLE
Bug: Reproducer for platform dependent compilation issue with OS X

### DIFF
--- a/numba/tests/test_compilation_issue.py
+++ b/numba/tests/test_compilation_issue.py
@@ -1,0 +1,43 @@
+import numpy as np
+import numba
+
+# Small reproducer for compilation issue
+# on OS X with Python 3.13; numba 0.61.2
+# See also https://github.com/LiberTEM/LiberTEM/pull/1748 for failure
+
+@numba.njit(boundscheck=True, nogil=True)
+def numba_ravel_multi_index_single(multi_index, dims):
+    # only supports the "single index" case
+    idxs = range(len(dims) - 1, -1, -1)
+    res = 0
+    for idx in idxs:
+        stride = 1
+        for dimidx in range(idx + 1, len(dims)):
+            stride *= dims[dimidx]
+        res += multi_index[idx] * stride
+    return res
+
+
+@numba.njit(boundscheck=True, cache=True, nogil=True)
+def read_ranges(
+    slices_arr, sig_shape
+):
+    sig_origins = np.array([
+        numba_ravel_multi_index_single(slices_arr[slice_idx][0], sig_shape)
+        for slice_idx in range(slices_arr.shape[0])
+    ])
+
+    return sig_origins
+
+
+def test_numbastuff():
+    read_ranges(
+        slices_arr=np.array([[[0,  0], [16, 16]]]),
+        sig_shape=(16, 16),
+    )
+
+
+if __name__ == "__main__":
+    print("running tests")
+    test_numbastuff()
+    print("Test passed successfully.")


### PR DESCRIPTION
This seems to trigger a platform dependent compilation bug?

See https://github.com/LiberTEM/LiberTEM/pull/1748 for context and differential CI runs.

## How to reproduce

Run the reproducer

## What happens

Linux: works
Recent stand-alone mac: works
OS X runner for GitHub Actions and Python 3.12: works
OS X runner for GitHub Actions and Python 3.13: breaks

Both 3.12 and 3.13 used the same NumPy, Numba and llvm-lite versions on OS X.

## What should happen

Also works on OS X and Python 3.13

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
