### PR TITLE
[WIP] Use the NVIDIA CUDA target by default

### DIFF
--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -229,6 +229,12 @@ def _try_enable_svml():
 
 _ensure_llvm()
 
+# Redirect the built-in CUDA target to the NVIDIA-maintained one
+from numba import cuda_redirector
+
+cuda_finder = cuda_redirector.NumbaCudaFinder()
+sys.meta_path.insert(0, cuda_finder)
+
 # we know llvmlite is working as the above tests passed, import it now as SVML
 # needs to mutate runtime options (sets the `-vector-library`).
 import llvmlite

--- a/numba/cuda_redirector.py
+++ b/numba/cuda_redirector.py
@@ -1,0 +1,82 @@
+import importlib
+import importlib.abc
+import pathlib
+import sys
+import warnings
+
+multiple_locations_msg = (
+    "Multiple submodule search locations for {}. "
+    "Cannot redirect numba.cuda to numba_cuda"
+)
+
+no_spec_msg = (
+    "Couldn't get spec for {}. Cannot redirect numba.cuda to numba_cuda"
+)
+
+
+class NumbaCudaFinder(importlib.abc.MetaPathFinder):
+    def __init__(self):
+        self.initialized = None
+
+    def ensure_initialized(self):
+        if self.initialized is not None:
+            return self.initialized
+
+        numba_spec = importlib.util.find_spec("numba")
+
+        if numba_spec is None:
+            warnings.warn(no_spec_msg.format("numba"))
+            self.initialized = False
+            return False
+
+        numba_cuda_spec = importlib.util.find_spec("numba_cuda")
+
+        if numba_cuda_spec is None:
+            warnings.warn(no_spec_msg.format("numba_cuda"))
+            self.initialized = False
+            return False
+
+        numba_search_locations = numba_spec.submodule_search_locations
+        numba_cuda_search_locations = numba_cuda_spec.submodule_search_locations
+
+        if len(numba_search_locations) != 1:
+            warnings.warn(multiple_locations_msg.format("numba"))
+            self.initialized = False
+            return False
+
+        if len(numba_cuda_search_locations) != 1:
+            warnings.warn(multiple_locations_msg.format("numba_cuda"))
+            self.initialized = False
+            return False
+
+        self.numba_path = numba_search_locations[0]
+
+        location = numba_cuda_search_locations[0]
+        self.numba_cuda_path = str((pathlib.Path(location) / "numba"))
+
+        self.initialized = True
+        return True
+
+    def find_spec(self, name, path, target=None):
+        if "numba.cuda" in name:
+            initialized = self.ensure_initialized()
+            if not initialized:
+                return None
+
+            if any(self.numba_cuda_path in p for p in path):
+                # Re-entrancy - return and carry on
+                return None
+
+            oot_path = [
+                p.replace(self.numba_path, self.numba_cuda_path) for p in path
+            ]
+            for finder in sys.meta_path:
+                try:
+                    spec = finder.find_spec(name, oot_path, target)
+                except AttributeError:
+                    # Finders written to a pre-Python 3.4 spec for finders will
+                    # not implement find_spec. We can skip those altogether.
+                    continue
+                else:
+                    if spec is not None:
+                        return spec

--- a/numba/cuda_redirector.py
+++ b/numba/cuda_redirector.py
@@ -10,7 +10,10 @@ multiple_locations_msg = (
 )
 
 no_spec_msg = (
-    "Couldn't get spec for {}. Cannot redirect numba.cuda to numba_cuda"
+    "The NVIDIA-maintained CUDA target (the `numba_cuda` module) has not been "
+    "found. Falling back to the built-in CUDA target. The NVIDIA-maintained "
+    "target should be installed - see https://numba.readthedocs.io/en/stable/cuda/overview.html#cuda-deprecation-status"
+    " - for installation instructions, see https://nvidia.github.io/numba-cuda/user/installation.html"
 )
 
 
@@ -23,16 +26,10 @@ class NumbaCudaFinder(importlib.abc.MetaPathFinder):
             return self.initialized
 
         numba_spec = importlib.util.find_spec("numba")
-
-        if numba_spec is None:
-            warnings.warn(no_spec_msg.format("numba"))
-            self.initialized = False
-            return False
-
         numba_cuda_spec = importlib.util.find_spec("numba_cuda")
 
         if numba_cuda_spec is None:
-            warnings.warn(no_spec_msg.format("numba_cuda"))
+            warnings.warn(no_spec_msg, DeprecationWarning)
             self.initialized = False
             return False
 


### PR DESCRIPTION
This PR switches to using the NVIDIA CUDA target by default, incorporating the logic that presently exists in numba-cuda for shadowing the built-in `numba.cuda` module (https://github.com/NVIDIA/numba-cuda/blob/main/site-packages/_numba_cuda_redirector.py). If it is not found, then a deprecation warning is emitted to prompt users to switch to the NVIDIA target

To-do:

- [ ] Add a config variable to explicitly opt in or out of the NVIDIA target. Opt-out would suppress the deprecation warning; opt-in would make it an error for the NVIDIA target to be absent.
- [ ] Update release notes and docs with the status.

Following a release of Numba containing this logic, the redirector logic would then be removed from numba-cuda (and it would make the new Numba release a requirement, since it will be the minimum required to ensure that it still gets loaded.