### PR TITLE
gha/fix gha ci issues

### DIFF
--- a/.github/workflows/numba_linux-aarch64_conda_builder.yml
+++ b/.github/workflows/numba_linux-aarch64_conda_builder.yml
@@ -1,9 +1,9 @@
-name: numba_linux-arm64_conda_builder
+name: numba_linux-aarch64_conda_builder
 
 on:
   pull_request:
     paths:
-      - .github/workflows/numba_linux-arm64_conda_builder.yml
+      - .github/workflows/numba_linux-aarch64_conda_builder.yml
       - buildscripts/condarecipe.local/**
       - .github/workflows/conda_workflow_matrix.json
   workflow_dispatch:
@@ -39,8 +39,8 @@ jobs:
           echo "build-matrix-json=$BUILD_JSON" >> $GITHUB_OUTPUT
           echo "test-matrix-json=$TEST_JSON" >> $GITHUB_OUTPUT
 
-  linux-arm64-build-conda:
-    name: linux-arm64-build-conda (py ${{ matrix.python-version }}, np ${{ matrix.numpy_build }})
+  linux-aarch64-build-conda:
+    name: linux-aarch64-build-conda (py ${{ matrix.python-version }}, np ${{ matrix.numpy_build }})
     needs: load-matrix
     runs-on: ubuntu-24.04-arm
     defaults:
@@ -69,7 +69,7 @@ jobs:
         if: ${{ inputs.llvmlite_run_id != '' }}
         uses: actions/download-artifact@v4
         with:
-          name: llvmlite-linux-arm64-py${{ matrix.python-version }}
+          name: llvmlite-linux-aarch64-py${{ matrix.python-version }}
           path: llvmlite_conda
           run-id: ${{ inputs.llvmlite_run_id }}
           repository: numba/llvmlite
@@ -100,15 +100,15 @@ jobs:
       - name: Upload numba conda package
         uses: actions/upload-artifact@v4
         with:
-          name: numba_linux-arm64_conda_py${{ matrix.python-version }}
+          name: numba_linux-aarch64_conda_py${{ matrix.python-version }}
           path: conda_channel_dir
           compression-level: 0
           retention-days: 7
           if-no-files-found: error
 
-  linux-arm64-test:
-    name: linux-arm64-test-conda (py ${{ matrix.python-version }}, np ${{ matrix.numpy_test }})
-    needs: [load-matrix, linux-arm64-build-conda]
+  linux-aarch64-test:
+    name: linux-aarch64-test-conda (py ${{ matrix.python-version }}, np ${{ matrix.numpy_test }})
+    needs: [load-matrix, linux-aarch64-build-conda]
     runs-on: ubuntu-24.04-arm
     defaults:
       run:
@@ -136,7 +136,7 @@ jobs:
         if: ${{ inputs.llvmlite_run_id != '' }}
         uses: actions/download-artifact@v4
         with:
-          name: llvmlite-linux-arm64-py${{ matrix.python-version }}
+          name: llvmlite-linux-aarch64-py${{ matrix.python-version }}
           path: llvmlite_conda
           run-id: ${{ inputs.llvmlite_run_id }}
           repository: numba/llvmlite
@@ -145,7 +145,7 @@ jobs:
       - name: Download numba artifact
         uses: actions/download-artifact@v4
         with:
-          name: numba_linux-arm64_conda_py${{ matrix.python-version }}
+          name: numba_linux-aarch64_conda_py${{ matrix.python-version }}
 
       - name: Install conda-build
         run: |

--- a/.github/workflows/numba_linux-aarch64_wheel_builder.yml
+++ b/.github/workflows/numba_linux-aarch64_wheel_builder.yml
@@ -1,9 +1,9 @@
-name: numba_linux-arm64_wheel_builder
+name: numba_linux-aarch64_wheel_builder
 
 on:
   pull_request:
     paths:
-      - .github/workflows/numba_linux-arm64_wheel_builder.yml
+      - .github/workflows/numba_linux-aarch64_wheel_builder.yml
       - .github/workflows/wheel_workflow_matrix.json
   workflow_dispatch:
     inputs:
@@ -51,8 +51,8 @@ jobs:
           echo "build-matrix-json=$BUILD_MATRIX_EXTENDED" >> $GITHUB_OUTPUT
           echo "test-matrix-json=$TEST_MATRIX_EXTENDED" >> $GITHUB_OUTPUT
 
-  linux-arm64-build:
-    name: linux-arm64-build-wheel (py ${{ matrix.python-version }}, np ${{ matrix.numpy_build }})
+  linux-aarch64-build:
+    name: linux-aarch64-build-wheel (py ${{ matrix.python-version }}, np ${{ matrix.numpy_build }})
     needs: load-matrix
     runs-on: ubuntu-24.04-arm
     defaults:
@@ -73,7 +73,7 @@ jobs:
         if: inputs.llvmlite_wheel_runid != ''
         uses: actions/download-artifact@v4
         with:
-          name: llvmlite-linux-arm64-py${{ matrix.python_canonical }}
+          name: llvmlite-linux-aarch64-py${{ matrix.python_canonical }}
           path: llvmlite_wheels
           run-id: ${{ inputs.llvmlite_wheel_runid }}
           repository: numba/llvmlite
@@ -125,7 +125,7 @@ jobs:
       - name: Upload numba wheel
         uses: actions/upload-artifact@v4
         with:
-          name: numba-linux-arm64-py${{ matrix.python_canonical }}
+          name: numba-linux-aarch64-py${{ matrix.python_canonical }}
           path: wheelhouse/*.whl
           compression-level: 0
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
@@ -141,9 +141,9 @@ jobs:
             retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
             if-no-files-found: error
 
-  linux-arm64-test:
-    name: linux-arm64-test (py ${{ matrix.python-version }}, np ${{ matrix.numpy_test }})
-    needs: [load-matrix, linux-arm64-build]
+  linux-aarch64-test:
+    name: linux-aarch64-test (py ${{ matrix.python-version }}, np ${{ matrix.numpy_test }})
+    needs: [load-matrix, linux-aarch64-build]
     runs-on: ubuntu-24.04-arm
     defaults:
       run:
@@ -162,14 +162,14 @@ jobs:
       - name: Download Numba wheel artifact
         uses: actions/download-artifact@v4
         with:
-          name: numba-linux-arm64-py${{ matrix.python_canonical }}
+          name: numba-linux-aarch64-py${{ matrix.python_canonical }}
           path: dist
 
       - name: Download llvmlite wheel
         if: inputs.llvmlite_wheel_runid != ''
         uses: actions/download-artifact@v4
         with:
-          name: llvmlite-linux-arm64-py${{ matrix.python_canonical }}
+          name: llvmlite-linux-aarch64-py${{ matrix.python_canonical }}
           path: llvmlite_wheels
           run-id: ${{ inputs.llvmlite_wheel_runid }}
           repository: numba/llvmlite

--- a/.github/workflows/numba_osx-64_wheel_builder.yml
+++ b/.github/workflows/numba_osx-64_wheel_builder.yml
@@ -97,7 +97,7 @@ jobs:
           else
               conda install -c ${{ env.CONDA_CHANNEL_NUMBA }} llvmlite
           fi
-          conda install -c ${{ env.CONDA_CHANNEL_NUMBA }} python-build numpy==${{ matrix.numpy_build }} clang_osx-64 clangxx_osx-64
+          conda install -c defaults python-build numpy==${{ matrix.numpy_build }} clang_osx-64 clangxx_osx-64
           conda install --yes llvm-openmp
 
       - name: Build sdist [once - py3.10]

--- a/.github/workflows/numba_osx-arm64_wheel_builder.yml
+++ b/.github/workflows/numba_osx-arm64_wheel_builder.yml
@@ -93,7 +93,7 @@ jobs:
           else
               conda install -c ${{ env.CONDA_CHANNEL_NUMBA }} llvmlite
           fi
-          conda install -c ${{ env.CONDA_CHANNEL_NUMBA }} python-build numpy==${{ matrix.numpy_build }} clang_osx-arm64 clangxx_osx-arm64
+          conda install -c defaults python-build numpy==${{ matrix.numpy_build }} clang_osx-arm64 clangxx_osx-arm64
           conda install --yes llvm-openmp
 
       - name: Build sdist [once - py3.10]

--- a/.github/workflows/numba_win-64_conda_builder.yml
+++ b/.github/workflows/numba_win-64_conda_builder.yml
@@ -1,9 +1,9 @@
-name: numba_win-64_builder
+name: numba_win-64_conda_builder
 
 on:
   pull_request:
     paths:
-      - .github/workflows/numba_win-64_builder.yml
+      - .github/workflows/numba_win-64_conda_builder.yml
       - buildscripts/condarecipe.local/**
       - .github/workflows/conda_workflow_matrix.json
   workflow_dispatch:
@@ -68,7 +68,7 @@ jobs:
         if: ${{ inputs.llvmlite_run_id != '' }}
         uses: actions/download-artifact@v4
         with:
-          name: llvmlite_win-64_conda_py${{ matrix.python-version }}
+          name: llvmlite-win-64-py${{ matrix.python-version }}
           path: llvmlite_conda
           run-id: ${{ inputs.llvmlite_run_id }}
           repository: numba/llvmlite

--- a/.github/workflows/numba_win-64_conda_builder.yml
+++ b/.github/workflows/numba_win-64_conda_builder.yml
@@ -84,7 +84,7 @@ jobs:
 
           # Set channel based on whether llvmlite artifact was downloaded
           if [ "${{ inputs.llvmlite_run_id }}" != "" ]; then
-            LLVMLITE_CHANNEL="file://${{ github.workspace }}/llvmlite_conda"
+            LLVMLITE_CHANNEL="${{ github.workspace }}/llvmlite_conda"
           else
             LLVMLITE_CHANNEL="${{ env.CONDA_CHANNEL_NUMBA }}"
           fi

--- a/.github/workflows/numba_win-64_wheel_builder.yml
+++ b/.github/workflows/numba_win-64_wheel_builder.yml
@@ -93,7 +93,7 @@ jobs:
           else
               conda install -c ${{ env.CONDA_CHANNEL_NUMBA }} llvmlite
           fi
-          conda install -c ${{ env.CONDA_CHANNEL_NUMBA }} python-build numpy==${{ matrix.numpy_build }} setuptools
+          conda install -c defaults python-build numpy==${{ matrix.numpy_build }} setuptools
           python -m pip install tbb==2021.6 tbb-devel==2021.6
 
       - name: Build wheel


### PR DESCRIPTION
This PR is to correct following issues-
- make win-64 conda builder workflow naming consistent with others 
- standardize identifier for linux arm system to 'linux-aarch64' inline with downstream workflows and conda
- correct llvmlite artifact naming scheme
- fix artifact path on win-64 conda builder
- separate conda packages installation commands using `-c defaults` channel which is now needed explicitly.