### PR TITLE
fix/handle curly braces paths

### DIFF
--- a/docs/upcoming_changes/10171.bug_fix.rst
+++ b/docs/upcoming_changes/10171.bug_fix.rst
@@ -1,0 +1,6 @@
+Fix error formatting when paths contain curly braces
+----------------------------------------------------
+
+Fix ``KeyError`` in error formatting for file paths containing curly braces
+(e.g., ``C:\\Users\\{GUID}\\...`` on Windows). Preformatted messages without
+formatting arguments are now preserved as-is.

--- a/docs/upcoming_changes/10171.bug_fix.rst
+++ b/docs/upcoming_changes/10171.bug_fix.rst
@@ -2,5 +2,5 @@ Fix error formatting when paths contain curly braces
 ----------------------------------------------------
 
 Fix ``KeyError`` in error formatting for file paths containing curly braces
-(e.g., ``C:\\Users\\{GUID}\\...`` on Windows). Preformatted messages without
+(e.g., ``C:\\Users\\{GUID}\\...`` on Windows). Pre-formatted messages without
 formatting arguments are now preserved as-is.

--- a/numba/core/compiler_machinery.py
+++ b/numba/core/compiler_machinery.py
@@ -303,7 +303,7 @@ class PassManager(object):
             args=str(internal_state.args),
             return_type=str(internal_state.return_type),
         )
-        errctx = errors.new_error_context(f"Pass {pss.name()}")
+        errctx = errors.new_error_context("Pass {name}", name=pss.name())
         with ev.trigger_event("numba:run_pass", data=ev_details), errctx:
             with SimpleTimer() as init_time:
                 mutated |= check(pss.run_initialization, internal_state)

--- a/numba/core/errors.py
+++ b/numba/core/errors.py
@@ -837,6 +837,11 @@ class NumbaRuntimeError(NumbaError):
 
 
 def _format_msg(fmt, args, kwargs):
+    # If no formatting arguments are supplied, return the string unchanged.
+    # This avoids KeyError when fmt contains curly braces, which can be
+    # interpreted as format fields.
+    if not args and not kwargs:
+        return fmt
     return fmt.format(*args, **kwargs)
 
 

--- a/numba/core/typeinfer.py
+++ b/numba/core/typeinfer.py
@@ -182,7 +182,7 @@ class Propagate(object):
         self.loc = loc
 
     def __call__(self, typeinfer):
-        with new_error_context("typing of assignment at {0}", self.loc,
+        with new_error_context("typing of assignment at {loc}",
                                loc=self.loc):
             typeinfer.copy_type(self.src, self.dst, loc=self.loc)
             # If `dst` is refined, notify us
@@ -203,7 +203,7 @@ class ArgConstraint(object):
         self.loc = loc
 
     def __call__(self, typeinfer):
-        with new_error_context("typing of argument at {0}", self.loc):
+        with new_error_context("typing of argument at {loc}", loc=self.loc):
             typevars = typeinfer.typevars
             src = typevars[self.src]
             if not src.defined:
@@ -225,7 +225,7 @@ class BuildTupleConstraint(object):
         self.loc = loc
 
     def __call__(self, typeinfer):
-        with new_error_context("typing of tuple at {0}", self.loc):
+        with new_error_context("typing of tuple at {loc}", loc=self.loc):
             typevars = typeinfer.typevars
             tsets = [typevars[i.name].get() for i in self.items]
             for vals in itertools.product(*tsets):
@@ -246,8 +246,9 @@ class _BuildContainerConstraint(object):
         self.loc = loc
 
     def __call__(self, typeinfer):
-        with new_error_context("typing of {0} at {1}",
-                               self.container_type, self.loc):
+        with new_error_context("typing of {container_type} at {loc}",
+                               container_type=self.container_type,
+                               loc=self.loc):
             typevars = typeinfer.typevars
             tsets = [typevars[i.name].get() for i in self.items]
             if not tsets:
@@ -271,8 +272,8 @@ class BuildListConstraint(_BuildContainerConstraint):
         self.loc = loc
 
     def __call__(self, typeinfer):
-        with new_error_context("typing of {0} at {1}",
-                               types.List, self.loc):
+        with new_error_context("typing of {container_type} at {loc}",
+                               container_type=types.List, loc=self.loc):
             typevars = typeinfer.typevars
             tsets = [typevars[i.name].get() for i in self.items]
             if not tsets:
@@ -313,7 +314,7 @@ class BuildMapConstraint(object):
 
     def __call__(self, typeinfer):
 
-        with new_error_context("typing of dict at {0}", self.loc):
+        with new_error_context("typing of dict at {loc}", loc=self.loc):
             typevars = typeinfer.typevars
 
             # figure out what sort of dict is being dealt with
@@ -379,7 +380,8 @@ class ExhaustIterConstraint(object):
         self.loc = loc
 
     def __call__(self, typeinfer):
-        with new_error_context("typing of exhaust iter at {0}", self.loc):
+        with new_error_context("typing of exhaust iter at {loc}",
+                               loc=self.loc):
             typevars = typeinfer.typevars
             for tp in typevars[self.iterator.name].get():
                 # unpack optional
@@ -411,7 +413,8 @@ class PairFirstConstraint(object):
         self.loc = loc
 
     def __call__(self, typeinfer):
-        with new_error_context("typing of pair-first at {0}", self.loc):
+        with new_error_context("typing of pair-first at {loc}",
+                               loc=self.loc):
             typevars = typeinfer.typevars
             for tp in typevars[self.pair.name].get():
                 if not isinstance(tp, types.Pair):
@@ -429,7 +432,8 @@ class PairSecondConstraint(object):
         self.loc = loc
 
     def __call__(self, typeinfer):
-        with new_error_context("typing of pair-second at {0}", self.loc):
+        with new_error_context("typing of pair-second at {loc}",
+                               loc=self.loc):
             typevars = typeinfer.typevars
             for tp in typevars[self.pair.name].get():
                 if not isinstance(tp, types.Pair):
@@ -453,7 +457,8 @@ class StaticGetItemConstraint(object):
         self.loc = loc
 
     def __call__(self, typeinfer):
-        with new_error_context("typing of static-get-item at {0}", self.loc):
+        with new_error_context("typing of static-get-item at {loc}",
+                               loc=self.loc):
             typevars = typeinfer.typevars
             for ty in typevars[self.value.name].get():
                 sig = typeinfer.context.resolve_static_getitem(
@@ -482,7 +487,8 @@ class TypedGetItemConstraint(object):
         self.loc = loc
 
     def __call__(self, typeinfer):
-        with new_error_context("typing of typed-get-item at {0}", self.loc):
+        with new_error_context("typing of typed-get-item at {loc}",
+                               loc=self.loc):
             typevars = typeinfer.typevars
             idx_ty = typevars[self.index.name].get()
             ty = typevars[self.value.name].get()
@@ -556,13 +562,13 @@ class CallConstraint(object):
         self.loc = loc
 
     def __call__(self, typeinfer):
-        msg = "typing of call at {0}\n".format(self.loc)
-        with new_error_context(msg):
+        with new_error_context("typing of call at {loc}", loc=self.loc):
             typevars = typeinfer.typevars
             with new_error_context(
-                    "resolving caller type: {}".format(self.func)):
+                    "resolving caller type: {func}", func=self.func):
                 fnty = typevars[self.func].getone()
-            with new_error_context("resolving callee type: {0}", fnty):
+            with new_error_context("resolving callee type: {fnty}",
+                                   fnty=fnty):
                 self.resolve(typeinfer, typevars, fnty)
 
     def resolve(self, typeinfer, typevars, fnty):
@@ -685,7 +691,8 @@ class CallConstraint(object):
 
 class IntrinsicCallConstraint(CallConstraint):
     def __call__(self, typeinfer):
-        with new_error_context("typing of intrinsic-call at {0}", self.loc):
+        with new_error_context("typing of intrinsic-call at {loc}",
+                               loc=self.loc):
             fnty = self.func
             if fnty in utils.OPERATORS_TO_BUILTINS:
                 fnty = typeinfer.resolve_value_type(None, fnty)
@@ -701,7 +708,8 @@ class GetAttrConstraint(object):
         self.inst = inst
 
     def __call__(self, typeinfer):
-        with new_error_context("typing of get attribute at {0}", self.loc):
+        with new_error_context("typing of get attribute at {loc}",
+                               loc=self.loc):
             typevars = typeinfer.typevars
             valtys = typevars[self.value.name].get()
             for ty in valtys:
@@ -762,7 +770,7 @@ class SetItemConstraint(SetItemRefinement):
         self.loc = loc
 
     def __call__(self, typeinfer):
-        with new_error_context("typing of setitem at {0}", self.loc):
+        with new_error_context("typing of setitem at {loc}", loc=self.loc):
             typevars = typeinfer.typevars
             if not all(typevars[var.name].defined
                        for var in (self.target, self.index, self.value)):
@@ -792,7 +800,8 @@ class StaticSetItemConstraint(SetItemRefinement):
         self.loc = loc
 
     def __call__(self, typeinfer):
-        with new_error_context("typing of staticsetitem at {0}", self.loc):
+        with new_error_context("typing of staticsetitem at {loc}",
+                               loc=self.loc):
             typevars = typeinfer.typevars
             if not all(typevars[var.name].defined
                        for var in (self.target, self.index_var, self.value)):
@@ -822,7 +831,7 @@ class DelItemConstraint(object):
         self.loc = loc
 
     def __call__(self, typeinfer):
-        with new_error_context("typing of delitem at {0}", self.loc):
+        with new_error_context("typing of delitem at {loc}", loc=self.loc):
             typevars = typeinfer.typevars
             if not all(typevars[var.name].defined
                        for var in (self.target, self.index)):
@@ -848,8 +857,8 @@ class SetAttrConstraint(object):
         self.loc = loc
 
     def __call__(self, typeinfer):
-        with new_error_context("typing of set attribute {0!r} at {1}",
-                               self.attr, self.loc):
+        with new_error_context("typing of set attribute {attr!r} at {loc}",
+                               attr=self.attr, loc=self.loc):
             typevars = typeinfer.typevars
             if not all(typevars[var.name].defined
                        for var in (self.target, self.value)):

--- a/numba/tests/test_errorhandling.py
+++ b/numba/tests/test_errorhandling.py
@@ -465,5 +465,22 @@ class TestCapturedErrorHandling(SerialMixin, TestCase):
             self.assertIn(expected, str(raises.exception))
 
 
+class TestCurlyBracesInPaths(unittest.TestCase):
+    """
+    Test that error messages handle file paths with curly braces (issue #10094)
+    """
+
+    def test_curly_braces_in_path_formatting(self):
+        # Issue #10094: paths with {uuid} caused KeyError in formatting
+        from numba.core.errors import _format_msg
+
+        problematic_path = r"C:\Users\{fa977bf3384160bce9243175b380be8}\file.py"
+        fmt = f"Error at {problematic_path}"
+
+        result = _format_msg(fmt, (), {})
+
+        expected = f"Error at {problematic_path}"
+        self.assertEqual(result, expected)
+
 if __name__ == '__main__':
     unittest.main()

--- a/numba/tests/test_errorhandling.py
+++ b/numba/tests/test_errorhandling.py
@@ -474,7 +474,11 @@ class TestCurlyBracesInPaths(unittest.TestCase):
         from numba.core.errors import _format_msg
 
         # used on typeinfer: placeholders with positional args
-        problematic_path = r"C:\\Users\\{fa977bf3384160bce9243175b380be8}\\file.py"
+        problematic_path = (
+            r"C:\\Users\\"
+            r"{fa977bf3384160bce9243175b380be8}"
+            r"\\file.py"
+        )
         fmt = "Error at {0}"
 
         result = _format_msg(fmt, (problematic_path,), {})
@@ -493,6 +497,7 @@ class TestCurlyBracesInPaths(unittest.TestCase):
 
         expected = f"Pass {name_with_braces}"
         self.assertEqual(result, expected)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/tests/test_errorhandling.py
+++ b/numba/tests/test_errorhandling.py
@@ -470,16 +470,28 @@ class TestCurlyBracesInPaths(unittest.TestCase):
     Test that error messages handle file paths with curly braces (issue #10094)
     """
 
-    def test_curly_braces_in_path_formatting(self):
-        # Issue #10094: paths with {uuid} caused KeyError in formatting
+    def test_placeholders_with_positional_args(self):
         from numba.core.errors import _format_msg
 
-        problematic_path = r"C:\Users\{fa977bf3384160bce9243175b380be8}\file.py"
-        fmt = f"Error at {problematic_path}"
+        # used on typeinfer: placeholders with positional args
+        problematic_path = r"C:\\Users\\{fa977bf3384160bce9243175b380be8}\\file.py"
+        fmt = "Error at {0}"
+
+        result = _format_msg(fmt, (problematic_path,), {})
+
+        expected = f"Error at {problematic_path}"
+        self.assertEqual(result, expected)
+
+    def test_preformatted_string_no_args(self):
+        from numba.core.errors import _format_msg
+
+        # used on compiler_machinery: preformatted string without args
+        name_with_braces = "{abc123}"
+        fmt = f"Pass {name_with_braces}"
 
         result = _format_msg(fmt, (), {})
 
-        expected = f"Error at {problematic_path}"
+        expected = f"Pass {name_with_braces}"
         self.assertEqual(result, expected)
 
 if __name__ == '__main__':

--- a/numba/tests/test_errorhandling.py
+++ b/numba/tests/test_errorhandling.py
@@ -471,7 +471,6 @@ class TestCurlyBracesInPaths(unittest.TestCase):
     """
 
     def test_placeholders_with_positional_args(self):
-        from numba.core.errors import _format_msg
 
         # used on typeinfer: placeholders with positional args
         problematic_path = (
@@ -481,19 +480,18 @@ class TestCurlyBracesInPaths(unittest.TestCase):
         )
         fmt = "Error at {0}"
 
-        result = _format_msg(fmt, (problematic_path,), {})
+        result = errors._format_msg(fmt, (problematic_path,), {})
 
         expected = f"Error at {problematic_path}"
         self.assertEqual(result, expected)
 
     def test_preformatted_string_no_args(self):
-        from numba.core.errors import _format_msg
 
         # used on compiler_machinery: preformatted string without args
         name_with_braces = "{abc123}"
         fmt = f"Pass {name_with_braces}"
 
-        result = _format_msg(fmt, (), {})
+        result = errors._format_msg(fmt, (), {})
 
         expected = f"Pass {name_with_braces}"
         self.assertEqual(result, expected)


### PR DESCRIPTION
This PR fixes a KeyError that occurs during error message formatting when Numba is installed in Windows paths containing curly braces, such as virtualized environments with UUIDs like C:\Users\{uuid}.
resolves: https://github.com/numba/numba/issues/10094

Changes-
- replace preformatted/f-strings with placeholder-based calls where appropriate
- condition on `_format_msg` used by errors context to return fmt unchanged when no args provided

Added tests to `numba/tests/test_errorhandling.py` to -
- test `_format_msg` when called with placeholder with brace-containing value
- test `_format_msg` when called with preformatted message with braces and no args