### PR TITLE
Revert NumPy 1.23 support removal

### DIFF
--- a/.github/workflows/conda_workflow_matrix.json
+++ b/.github/workflows/conda_workflow_matrix.json
@@ -6,7 +6,6 @@
       { "python-version": "3.13", "numpy_build": "2.1" }
     ],
     "conda_test_matrix": [
-      { "python-version": "3.10", "numpy_test": "1.22" },
       { "python-version": "3.10", "numpy_test": "1.23" },
       { "python-version": "3.10", "numpy_test": "1.24" },
       { "python-version": "3.10", "numpy_test": "1.25" },

--- a/.github/workflows/conda_workflow_matrix.json
+++ b/.github/workflows/conda_workflow_matrix.json
@@ -6,6 +6,8 @@
       { "python-version": "3.13", "numpy_build": "2.1" }
     ],
     "conda_test_matrix": [
+      { "python-version": "3.10", "numpy_test": "1.22" },
+      { "python-version": "3.10", "numpy_test": "1.23" },
       { "python-version": "3.10", "numpy_test": "1.24" },
       { "python-version": "3.10", "numpy_test": "1.25" },
       { "python-version": "3.11", "numpy_test": "1.26" },

--- a/.github/workflows/wheel_workflow_matrix.json
+++ b/.github/workflows/wheel_workflow_matrix.json
@@ -6,6 +6,8 @@
         { "python-version": "3.13", "numpy_build": "2.1.3", "python_tag": "cp313" }
       ],
     "wheel_test_matrix": [
+        { "python-version": "3.10", "numpy_test": "1.22" },
+        { "python-version": "3.10", "numpy_test": "1.23" },
         { "python-version": "3.10", "numpy_test": "1.24" },
         { "python-version": "3.10", "numpy_test": "1.25" },
         { "python-version": "3.11", "numpy_test": "1.26" },

--- a/.github/workflows/wheel_workflow_matrix.json
+++ b/.github/workflows/wheel_workflow_matrix.json
@@ -6,7 +6,6 @@
         { "python-version": "3.13", "numpy_build": "2.1.3", "python_tag": "cp313" }
       ],
     "wheel_test_matrix": [
-        { "python-version": "3.10", "numpy_test": "1.22" },
         { "python-version": "3.10", "numpy_test": "1.23" },
         { "python-version": "3.10", "numpy_test": "1.24" },
         { "python-version": "3.10", "numpy_test": "1.25" },

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,9 +12,9 @@ jobs:
     name: macOS
     vmImage: macos-13
     matrix:
-      py310_np124:
+      py310_np122:
         PYTHON: '3.10'
-        NUMPY: '1.24'
+        NUMPY: '1.22'
         CONDA_ENV: 'azure_ci'
         TEST_THREADING: 'tbb'
         TEST_START_INDEX: 0
@@ -36,7 +36,7 @@ jobs:
     matrix:
       py310_np123:
         PYTHON: '3.10'
-        NUMPY: '1.23'
+        NUMPY: '1.22'
         CONDA_ENV: azure_ci
         TEST_START_INDEX: 3
       py310_np124_cov_doc:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ trigger:
 
 variables:
   # Change the following along with adding new TEST_START_INDEX.
-  TEST_COUNT: 21
+  TEST_COUNT: 22
 
 jobs:
 # Mac and Linux use the same template with different matrixes
@@ -34,6 +34,11 @@ jobs:
     name: Linux
     vmImage: ubuntu-24.04
     matrix:
+      py310_np123:
+        PYTHON: '3.10'
+        NUMPY: '1.23'
+        CONDA_ENV: azure_ci
+        TEST_START_INDEX: 3
       py310_np124_cov_doc:
         PYTHON: '3.10'
         NUMPY: '1.24'
@@ -42,82 +47,82 @@ jobs:
         RUN_MYPY: yes
         BUILD_DOC: yes
         CONDA_ENV: azure_ci
-        TEST_START_INDEX: 3
+        TEST_START_INDEX: 4
       py310_np125_typeguard:
         PYTHON: '3.10'
         NUMPY: '1.25'
         CONDA_ENV: azure_ci
         RUN_TYPEGUARD: no
-        TEST_START_INDEX: 4
+        TEST_START_INDEX: 5
       py310_np126:
         PYTHON: '3.10'
         NUMPY: '1.26'
         CONDA_ENV: azure_ci
-        TEST_START_INDEX: 5
+        TEST_START_INDEX: 6
       py310_np22:
         PYTHON: '3.10'
         NUMPY: '2.2'
         CONDA_ENV: azure_ci
-        TEST_START_INDEX: 6
+        TEST_START_INDEX: 7
 
       py311_np124:
         PYTHON: '3.11'
         NUMPY: '1.24'
         CONDA_ENV: azure_ci
-        TEST_START_INDEX: 7
+        TEST_START_INDEX: 8
       py311_np125:
         PYTHON: '3.11'
         NUMPY: '1.25'
         CONDA_ENV: azure_ci
-        TEST_START_INDEX: 8
+        TEST_START_INDEX: 9
       py311_np126:
         PYTHON: '3.11'
         NUMPY: '1.26'
         CONDA_ENV: azure_ci
-        TEST_START_INDEX: 9
+        TEST_START_INDEX: 10
       py311_np21:
         PYTHON: '3.11'
         NUMPY: '2.1'
         CONDA_ENV: azure_ci
-        TEST_START_INDEX: 10
+        TEST_START_INDEX: 11
       py311_np22:
         PYTHON: '3.11'
         NUMPY: '2.2'
         CONDA_ENV: azure_ci
-        TEST_START_INDEX: 11
+        TEST_START_INDEX: 12
       py311_np126_2:
         PYTHON: '3.11'
         NUMPY: '1.26'
         CONDA_ENV: azure_ci
-        TEST_START_INDEX: 12
+        TEST_START_INDEX: 13
       py311_np125_svml:
         PYTHON: '3.11'
         NUMPY: '1.25'
         CONDA_ENV: azure_ci
         TEST_SVML: yes
-        TEST_START_INDEX: 13
+        TEST_START_INDEX: 14
 
       py312_np126:
         PYTHON: '3.12'
         NUMPY: '1.26'
         CONDA_ENV: azure_ci
-        TEST_START_INDEX: 14
+        TEST_START_INDEX: 15
       py312_np20:
         PYTHON: '3.12'
         NUMPY: '2.0'
         CONDA_ENV: azure_ci
-        TEST_START_INDEX: 15
+        TEST_START_INDEX: 16
       py312_np22:
         PYTHON: '3.12'
         NUMPY: '2.2'
         CONDA_ENV: azure_ci
-        TEST_START_INDEX: 16
+        TEST_START_INDEX: 17
 
       py313_np23:
         PYTHON: '3.13'
         NUMPY: '2.3'
         CONDA_ENV: azure_ci
-        TEST_START_INDEX: 17
+        TEST_START_INDEX: 18
 
 - template: buildscripts/azure/azure-windows.yml
   parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,9 +12,9 @@ jobs:
     name: macOS
     vmImage: macos-13
     matrix:
-      py310_np122:
+      py310_np123:
         PYTHON: '3.10'
-        NUMPY: '1.22'
+        NUMPY: '1.23'
         CONDA_ENV: 'azure_ci'
         TEST_THREADING: 'tbb'
         TEST_START_INDEX: 0
@@ -36,7 +36,7 @@ jobs:
     matrix:
       py310_np123:
         PYTHON: '3.10'
-        NUMPY: '1.22'
+        NUMPY: '1.23'
         CONDA_ENV: azure_ci
         TEST_START_INDEX: 3
       py310_np124_cov_doc:

--- a/buildscripts/azure/azure-windows.yml
+++ b/buildscripts/azure/azure-windows.yml
@@ -12,17 +12,17 @@ jobs:
         PYTHON: '3.10'
         NUMPY: '1.24'
         CONDA_ENV: 'testenv'
-        TEST_START_INDEX: 18
+        TEST_START_INDEX: 19
       py312_np20:
         PYTHON: '3.12'
         NUMPY: '2.0'
         CONDA_ENV: 'testenv'
-        TEST_START_INDEX: 19
+        TEST_START_INDEX: 20
       py313_np23:
         PYTHON: '3.13'
         NUMPY: '2.3'
         CONDA_ENV: 'testenv'
-        TEST_START_INDEX: 20
+        TEST_START_INDEX: 21
 
   steps:
     - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"

--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -39,7 +39,7 @@ requirements:
     - tbb-devel >=2021.6       # [not (aarch64 or ppc64le)]
   run:
     - python >=3.10
-    - numpy >=1.24
+    - numpy >=1.23
     # On channel https://anaconda.org/numba/
     - llvmlite >=0.45.0dev0,<0.45
   run_constrained:

--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -39,7 +39,7 @@ requirements:
     - tbb-devel >=2021.6       # [not (aarch64 or ppc64le)]
   run:
     - python >=3.10
-    - numpy >=1.23
+    - numpy >=1.22.3
     # On channel https://anaconda.org/numba/
     - llvmlite >=0.45.0dev0,<0.45
   run_constrained:

--- a/docs/source/user/5minguide.rst
+++ b/docs/source/user/5minguide.rst
@@ -17,7 +17,7 @@ Out of the box Numba works with the following:
 * Architecture: x86, x86_64, ppc64le, armv8l (aarch64), M1/Arm64.
 * GPUs: Nvidia CUDA.
 * CPython
-* NumPy 1.23 - 1.26
+* NumPy 1.22 - 1.26
 
 How do I get it?
 ----------------

--- a/docs/source/user/5minguide.rst
+++ b/docs/source/user/5minguide.rst
@@ -17,7 +17,7 @@ Out of the box Numba works with the following:
 * Architecture: x86, x86_64, ppc64le, armv8l (aarch64), M1/Arm64.
 * GPUs: Nvidia CUDA.
 * CPython
-* NumPy 1.24 - 1.26
+* NumPy 1.23 - 1.26
 
 How do I get it?
 ----------------

--- a/docs/upcoming_changes/10183.highlight.rst
+++ b/docs/upcoming_changes/10183.highlight.rst
@@ -1,0 +1,4 @@
+Revert the minimum supported NumPy version to 1.22
+--------------------------------------------------
+
+This release updates the minimum supported version of NumPy to 1.22.

--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -34,8 +34,8 @@ def _ensure_critical_deps():
     import numpy as np
     numpy_version = extract_version(np)
 
-    if numpy_version < (1, 23):
-        msg = (f"Numba needs NumPy 1.23 or greater. Got NumPy "
+    if numpy_version < (1, 22):
+        msg = (f"Numba needs NumPy 1.22 or greater. Got NumPy "
                f"{numpy_version[0]}.{numpy_version[1]}.")
         raise ImportError(msg)
 

--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -34,8 +34,8 @@ def _ensure_critical_deps():
     import numpy as np
     numpy_version = extract_version(np)
 
-    if numpy_version < (1, 24):
-        msg = (f"Numba needs NumPy 1.24 or greater. Got NumPy "
+    if numpy_version < (1, 23):
+        msg = (f"Numba needs NumPy 1.23 or greater. Got NumPy "
                f"{numpy_version[0]}.{numpy_version[1]}.")
         raise ImportError(msg)
 

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -3816,8 +3816,15 @@ def make_searchsorted_implementation(np_dtype, side):
         _impl = _searchsorted(lt)
         _cmp = lt
     else:
-        _impl = _searchsorted(le)
-        _cmp = le
+        if np.issubdtype(np_dtype, np.inexact) and numpy_version < (1, 23):
+            # change in behaviour for inexact types
+            # introduced by:
+            # https://github.com/numpy/numpy/pull/21867
+            _impl = _searchsorted(le)
+            _cmp = lt
+        else:
+            _impl = _searchsorted(le)
+            _cmp = le
 
     return register_jitable(_impl), register_jitable(_cmp)
 
@@ -4050,7 +4057,6 @@ finfo = namedtuple('finfo', _finfo_supported)
 _iinfo_supported = ('min', 'max', 'bits',)
 
 iinfo = namedtuple('iinfo', _iinfo_supported)
-
 
 
 # This module is imported under the compiler lock which should deal with the

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -2803,11 +2803,17 @@ def array_view(context, builder, sig, args):
         else:
             setattr(ret, k, val)
 
-    tyctx = context.typing_context
-    fnty = tyctx.resolve_value_type(_compatible_view)
-    _compatible_view_sig = fnty.get_call_type(tyctx, (*sig.args,), {})
-    impl = context.get_function(fnty, _compatible_view_sig)
-    impl(builder, args)
+    if numpy_version >= (1, 23):
+        # NumPy 1.23+ bans views using a dtype that is a different size to that
+        # of the array when the last axis is not contiguous. For example, this
+        # manifests at runtime when a dtype size altering view is requested
+        # on a Fortran ordered array.
+
+        tyctx = context.typing_context
+        fnty = tyctx.resolve_value_type(_compatible_view)
+        _compatible_view_sig = fnty.get_call_type(tyctx, (*sig.args,), {})
+        impl = context.get_function(fnty, _compatible_view_sig)
+        impl(builder, args)
 
     ok = _change_dtype(context, builder, aryty, retty, ret)
     fail = builder.icmp_unsigned('==', ok, Constant(ok.type, 0))

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -460,10 +460,19 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         dt2 = np.dtype([('u', np.int16), ('v', np.int8)])
         dt3 = np.dtype([('x', np.int16), ('y', np.int16)])
 
-        check_error_larger_dt = check_err_larger_dtype
-        check_error_smaller_dt = check_err_smaller_dtype
-        check_error_noncontig = check_err_noncontig_last_axis
-        check_error_0d = check_err_0d
+        # The checking routines are much more specific from NumPy 1.23 onwards
+        # as the granularity of error reporing is improved in Numba to match
+        # that of NumPy.
+        if numpy_version >= (1, 23):
+            check_error_larger_dt = check_err_larger_dtype
+            check_error_smaller_dt = check_err_smaller_dtype
+            check_error_noncontig = check_err_noncontig_last_axis
+            check_error_0d = check_err_0d
+        else:
+            check_error_larger_dt = check_err
+            check_error_smaller_dt = check_err
+            check_error_noncontig = check_err
+            check_error_0d = check_err
 
         # C-contiguous
         arr = np.arange(24, dtype=np.int8)
@@ -490,7 +499,12 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         # neither F or C contiguous
         not_f_or_c_arr = np.zeros((4, 4)).T[::2, ::2]
 
-        check_maybe_error = check_err_noncontig_last_axis
+        # NumPy 1.23 does not allow views with different size dtype for
+        # non-contiguous last axis.
+        if numpy_version >= (1, 23):
+            check_maybe_error = check_err_noncontig_last_axis
+        else:
+            check_maybe_error = check
 
         check(f_arr, np.int8)
         check(not_f_or_c_arr, np.uint64)

--- a/numba/tests/test_comprehension.py
+++ b/numba/tests/test_comprehension.py
@@ -359,6 +359,19 @@ class TestArrayComprehension(unittest.TestCase):
         self.check(comp_nest_with_array_conditional, 5,
                    assert_allocate_list=True)
 
+    @unittest.skipUnless(numpy_version < (1, 24),
+                         'Setting an array element with a sequence is removed '
+                         'in NumPy 1.24')
+    def test_comp_nest_with_dependency(self):
+        def comp_nest_with_dependency(n):
+            l = np.array([[i * j for j in range(i+1)] for i in range(n)])
+            return l
+        # test is expected to fail
+        with self.assertRaises(TypingError) as raises:
+            self.check(comp_nest_with_dependency, 5)
+        self.assertIn(_header_lead, str(raises.exception))
+        self.assertIn('array(undefined,', str(raises.exception))
+
     def test_comp_unsupported_iter(self):
         def comp_unsupported_iter():
             val = zip([1, 2, 3], [4, 5, 6])

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -3,6 +3,7 @@
 import itertools
 import math
 import platform
+import warnings
 from functools import partial
 from itertools import product
 from textwrap import dedent
@@ -13,7 +14,7 @@ from numba import jit, njit, typeof
 from numba.core import types
 from numba.typed import List, Dict
 from numba.np.numpy_support import numpy_version
-from numba.core.errors import TypingError
+from numba.core.errors import (TypingError, NumbaDeprecationWarning)
 from numba.core.config import IS_32BITS
 from numba.core.utils import pysignature
 from numba.np.extensions import cross2d
@@ -7022,6 +7023,13 @@ def foo():
         exec(compile(funcstr, '<string>', 'exec'), globals(), dct)
         return dct['foo']
 
+    @unittest.skipIf(numpy_version >= (1, 24), "NumPy < 1.24 required")
+    def test_MachAr(self):
+        attrs = ('ibeta', 'it', 'machep', 'eps', 'negep', 'epsneg', 'iexp',
+                 'minexp', 'xmin', 'maxexp', 'xmax', 'irnd', 'ngrd',
+                 'epsilon', 'tiny', 'huge', 'precision', 'resolution',)
+        self.check(machar, attrs)
+
     def test_finfo(self):
         types = [np.float32, np.float64, np.complex64, np.complex128]
         attrs = ('eps', 'epsneg', 'iexp', 'machep', 'max', 'maxexp', 'negep',
@@ -7057,6 +7065,26 @@ def foo():
         with self.assertTypingError():
             cfunc = jit(nopython=True)(iinfo)
             cfunc(np.float64(7))
+
+    @unittest.skipUnless(numpy_version < (1, 24), "Needs NumPy < 1.24")
+    @TestCase.run_test_in_subprocess
+    def test_np_MachAr_deprecation_np122(self):
+        # Tests that Numba is replaying the NumPy 1.22 deprecation warning
+        # raised on the getattr of 'MachAr' on the NumPy module.
+        # Needs to be run in a subprocess as the warning is generated from the
+        # typing part of the `np.MachAr` overload, which may already have been
+        # executed for the given types and so an empty in memory cache is
+        # needed.
+        msg = r'.*`np.MachAr` is deprecated \(NumPy 1.22\)'
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('ignore')  # override warning behavior
+            warnings.filterwarnings("always", message=msg,
+                                    category=NumbaDeprecationWarning,)
+            f = njit(lambda : np.MachAr().eps)
+            f()
+
+        self.assertEqual(len(w), 1)
+        self.assertIn('`np.MachAr` is deprecated', str(w[0]))
 
 
 class TestRegistryImports(TestCase):

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ except ImportError:
 min_python_version = "3.10"
 max_python_version = "3.14"  # exclusive
 min_numpy_build_version = "1.11"
-min_numpy_run_version = "1.24"
+min_numpy_run_version = "1.23"
 min_llvmlite_version = "0.45.0dev0"
 max_llvmlite_version = "0.46"
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ except ImportError:
 min_python_version = "3.10"
 max_python_version = "3.14"  # exclusive
 min_numpy_build_version = "1.11"
-min_numpy_run_version = "1.23"
+min_numpy_run_version = "1.22"
 min_llvmlite_version = "0.45.0dev0"
 max_llvmlite_version = "0.46"
 


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

As titled, 

This PR intends to re-add NumPy 1.23 support which was removed in https://github.com/numba/numba/pull/9739