### PR TITLE
Fix target extension issues

### DIFF
--- a/docs/upcoming_changes/10185.bug_fix.rst
+++ b/docs/upcoming_changes/10185.bug_fix.rst
@@ -1,0 +1,6 @@
+Fix target-specific function resolution
+---------------------------------------
+
+Fix target-specific function resolution. This resolves errors when
+target-specific extensions are run before any compilation for CPU targets.
+Also fixes parfors' function resolution to be target-aware.

--- a/numba/core/inline_closurecall.py
+++ b/numba/core/inline_closurecall.py
@@ -1533,7 +1533,7 @@ def _inline_const_arraycall(block, func_ir, context, typemap, calltypes):
 
         # Create a variable to hold the numpy empty function.
         empty_func = scope.redefine("empty_func", loc)
-        fnty = get_np_ufunc_typ(np.empty)
+        fnty = get_np_ufunc_typ(np.empty, context)
         context.resolve_function_type(fnty, (size_typ,), {'dtype': nptype})
 
         typemap[empty_func.name] = fnty

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -4321,7 +4321,7 @@ def _empty_nd_impl(context, builder, arrtype, shapes):
     return ary
 
 
-@overload_classmethod(types.Array, "_allocate")
+@overload_classmethod(types.Array, "_allocate", target="CPU")
 def _ol_array_allocate(cls, allocsize, align):
     """Implements a Numba-only default target (cpu) classmethod on the array
     type.

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -3236,7 +3236,7 @@ def _arrayexpr_tree_to_ir(
                 ir_expr = ir.Expr.binop(op, arg_vars[0], arg_vars[1], loc)
                 if op == operator.truediv:
                     func_typ, ir_expr = _gen_np_divide(
-                        arg_vars[0], arg_vars[1], out_ir, typemap)
+                        arg_vars[0], arg_vars[1], out_ir, typemap, typingctx)
             else:
                 func_typ = typingctx.resolve_function_type(op, (el_typ1,), {})
                 ir_expr = ir.Expr.unary(op, arg_vars[0], loc)
@@ -3302,7 +3302,7 @@ def _arrayexpr_tree_to_ir(
     return out_ir
 
 
-def _gen_np_divide(arg1, arg2, out_ir, typemap):
+def _gen_np_divide(arg1, arg2, out_ir, typemap, typingctx):
     """generate np.divide() instead of / for array_expr to get numpy error model
     like inf for division by zero (test_division_by_zero).
     """
@@ -3316,13 +3316,13 @@ def _gen_np_divide(arg1, arg2, out_ir, typemap):
     # attr call: div_attr = getattr(g_np_var, divide)
     div_attr_call = ir.Expr.getattr(g_np_var, "divide", loc)
     attr_var = ir.Var(scope, mk_unique_var("$div_attr"), loc)
-    func_var_typ = get_np_ufunc_typ(numpy.divide)
+    func_var_typ = get_np_ufunc_typ(numpy.divide, typingctx)
     typemap[attr_var.name] = func_var_typ
     attr_assign = ir.Assign(div_attr_call, attr_var, loc)
     # divide call:  div_attr(arg1, arg2)
     div_call = ir.Expr.call(attr_var, [arg1, arg2], (), loc)
     func_typ = func_var_typ.get_call_type(
-        typing.Context(), [typemap[arg1.name], typemap[arg2.name]], {})
+        typingctx, [typemap[arg1.name], typemap[arg2.name]], {})
     out_ir.extend([g_np_assign, attr_assign])
     return func_typ, div_call
 

--- a/numba/parfors/parfor_lowering.py
+++ b/numba/parfors/parfor_lowering.py
@@ -197,7 +197,7 @@ def _lower_parfor_parallel_std(lowerer, parfor):
             # First create a var for the numpy empty ufunc.
             glbl_np_empty = pfbdr.bind_global_function(
                 fobj=np.empty,
-                ftype=get_np_ufunc_typ(np.empty),
+                ftype=get_np_ufunc_typ(np.empty, pfbdr._typingctx),
                 args=(
                     types.UniTuple(types.intp, redarrdim),
                 ),
@@ -251,7 +251,7 @@ def _lower_parfor_parallel_std(lowerer, parfor):
                     # First, create a variable for np.full.
                     full_func_node = pfbdr.bind_global_function(
                         fobj=np.full,
-                        ftype=get_np_ufunc_typ(np.full),
+                        ftype=get_np_ufunc_typ(np.full, pfbdr._typingctx),
                         args=(
                             types.UniTuple(types.intp, redvar_typ.ndim),
                             reddtype,


### PR DESCRIPTION
- b4a9656f9adb462270f44f7f6963229c09c817fb fix #9956 
- 0d7523088c3ea8086a3b69dba5545128fe06cd7c fix parfors function resolution to be target aware
    ```
    NUMBA_DEVELOPER_MODE=1 python -m unittest numba.tests.test_target_extension.TestTargetHierarchySelection.test_overload_allocation numba.tests.test_parfors_caching.TestParforsCache.test_prange numba.tests.test_np_functions.TestNPFunctions.test_partition_empty_array numba.tests.test_parfors_caching.TestParforsCache.test_prange numba.tests.test_parfors_passes.TestConvertLoopPass.test_prange_map_nested_prange numba.tests.test_parfors_passes.TestConvertLoopPass.test_prange_map_simple
    ```