### PR TITLE
DO NOT MERGE: test if macos-14 image still works with Intel Mac platform

### DIFF
--- a/.github/workflows/numba_osx-64_conda_builder.yml
+++ b/.github/workflows/numba_osx-64_conda_builder.yml
@@ -42,7 +42,7 @@ jobs:
   osx-64-build-conda:
     name: osx-64-build-conda (py ${{ matrix.python-version }}, np ${{ matrix.numpy_build }})
     needs: load-matrix
-    runs-on: macos-13
+    runs-on: macos-14
     defaults:
       run:
         shell: bash -elx {0}
@@ -114,7 +114,7 @@ jobs:
   osx-64-test:
     name: osx-64-test-conda (py ${{ matrix.python-version }}, np ${{ matrix.numpy_test }})
     needs: [load-matrix, osx-64-build-conda]
-    runs-on: macos-13
+    runs-on: macos-14
     defaults:
       run:
         shell: bash -elx {0}

--- a/.github/workflows/numba_osx-64_conda_builder.yml
+++ b/.github/workflows/numba_osx-64_conda_builder.yml
@@ -42,7 +42,7 @@ jobs:
   osx-64-build-conda:
     name: osx-64-build-conda (py ${{ matrix.python-version }}, np ${{ matrix.numpy_build }})
     needs: load-matrix
-    runs-on: macos-14
+    runs-on: macos-14-large
     defaults:
       run:
         shell: bash -elx {0}
@@ -114,7 +114,7 @@ jobs:
   osx-64-test:
     name: osx-64-test-conda (py ${{ matrix.python-version }}, np ${{ matrix.numpy_test }})
     needs: [load-matrix, osx-64-build-conda]
-    runs-on: macos-14
+    runs-on: macos-14-large
     defaults:
       run:
         shell: bash -elx {0}


### PR DESCRIPTION
Some discussion online suggests that once the macos-13 image is removed from GHA, there won't be support for running on Intel Mac workers anymore.  That isn't how the docs look to me, so this PR is testing if the conda build workflow launches on an Intel Mac worker with the macos-14 image.