### PR TITLE
Fix CI: skip test if LLVM reports host CPU as 'generic'

### DIFF
--- a/numba/tests/test_caching.py
+++ b/numba/tests/test_caching.py
@@ -842,6 +842,8 @@ class TestCacheWithCpuSetting(DispatcherCacheUsecasesTest):
         self.assertGreater(match_count, 0,
                            msg='nothing to compare')
 
+    @unittest.skipIf(ll.get_host_cpu_name() == "generic",
+                     "LLVM detected 'generic' CPU")
     def test_user_set_cpu_name(self):
         self.check_pycache(0)
 


### PR DESCRIPTION
The test requires comparing against a generic CPU so it cannot work if LLVM detects host CPU as generic already