### PR TITLE
gha/fix llvmlite channel path format on win artifact handling

### DIFF
--- a/.github/workflows/numba_win-64_conda_builder.yml
+++ b/.github/workflows/numba_win-64_conda_builder.yml
@@ -147,7 +147,7 @@ jobs:
         run: |
           # Set channel based on whether llvmlite artifact was downloaded
           if [ "${{ inputs.llvmlite_run_id }}" != "" ]; then
-            LLVMLITE_CHANNEL="file://${{ github.workspace }}/llvmlite_conda"
+            LLVMLITE_CHANNEL="${{ github.workspace }}/llvmlite_conda"
           else
             LLVMLITE_CHANNEL="${{ env.CONDA_CHANNEL_NUMBA }}"
           fi


### PR DESCRIPTION
This follows path format correction made to use `${{ github.workspace }}` on build and test steps. 

As this isn't caught by CI runs and only when user provided llvmlite workflow id is provided, I've tested this on my fork using llvmlite `win-64` conda package artifact from `numba/llvmlite` workflow id: `17215985531` using command -
```
gh workflow run numba_win-64_conda_builder.yml --repo swap357/numba --ref pr-10146 -f llvmlite_run_id=17215985531
```
run logs :
https://github.com/swap357/numba/actions/runs/17224176358/job/48865747092