### PR TITLE
gha/add env variables for reduced testing on win-64 wheel builder

### DIFF
--- a/.github/workflows/numba_win-64_wheel_builder.yml
+++ b/.github/workflows/numba_win-64_wheel_builder.yml
@@ -142,6 +142,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Validate and test wheel
+        env:
+          NUMBA_CPU_NAME: generic
+          _NUMBA_REDUCED_TESTING: 1
         run: |
           python -m pip install --upgrade pip twine
           python -m pip install numpy==${{ matrix.numpy_test }} tbb==2021.6 tbb-devel==2021.6


### PR DESCRIPTION
This PR aligns `win-64` wheel workflow with reduced-testing config to avoid memory pressure on Windows runners. This follows same practice as - https://github.com/numba/numba/pull/10176 for conda package testing.

To validate working with llvm20 migration, ran this patch applied to `pr-10146` and ran workflow on my fork -
https://github.com/swap357/numba/actions/runs/17228383745