### PR TITLE
Make `types.ListType` evaluable

### DIFF
--- a/docs/upcoming_changes/10195.bug_fix.rst
+++ b/docs/upcoming_changes/10195.bug_fix.rst
@@ -1,0 +1,6 @@
+Make ``types.ListType`` string representation evaluable
+-------------------------------------------------------
+
+Fix ``types.ListType`` canonical string representation by making it evaluable.
+This changes ``str()`` to ``repr()`` call for obtaining string representation of
+the list's element.

--- a/numba/core/types/containers.py
+++ b/numba/core/types/containers.py
@@ -620,7 +620,8 @@ class SetEntry(Type):
 
 
 class ListType(IterableType):
-    """List type
+    """
+    List type
     """
 
     mutable = True
@@ -666,11 +667,12 @@ class ListType(IterableType):
                 return self
 
     def __repr__(self):
-        return f"ListType({self.item_type})"
+        return f"ListType({repr(self.item_type)})"
 
 
 class ListTypeIterableType(SimpleIterableType):
-    """List iterable type
+    """
+    List iterable type
     """
 
     def __init__(self, parent):
@@ -738,7 +740,8 @@ class DictType(IterableType, InitialValue):
 
     @classmethod
     def refine(cls, keyty, valty):
-        """Refine to a precise dictionary type
+        """
+        Refine to a precise dictionary type
         """
         res = cls(keyty, valty)
         assert res.is_precise()


### PR DESCRIPTION
This PR fixes `repr` for `ListType` making it evaluable in repl. 