### PR TITLE
GHA/ Fix for linux wheel builds

### DIFF
--- a/.github/workflows/numba_linux-64_wheel_builder.yml
+++ b/.github/workflows/numba_linux-64_wheel_builder.yml
@@ -93,14 +93,12 @@ jobs:
 
           # Prepare build environment
           mkdir -p dist wheelhouse
-          chmod +x buildscripts/github/build_wheel_linux.sh
-          chmod +x buildscripts/github/repair_wheel_linux.sh
 
           # Run the build script inside Docker container
           docker run --rm \
             -v ${{ github.workspace }}:/io \
             quay.io/pypa/manylinux2014_x86_64 \
-            /io/buildscripts/github/build_wheel_linux.sh \
+            bash /io/buildscripts/github/build_wheel_linux.sh \
             "${PYTHON_EXECUTABLE}" \
             "${USE_TBB}" \
             "${{ matrix.numpy_build }}" \
@@ -120,7 +118,7 @@ jobs:
           docker run --rm \
             -v ${{ github.workspace }}:/io \
             quay.io/pypa/manylinux2014_x86_64 \
-            /io/buildscripts/github/repair_wheel_linux.sh \
+            bash /io/buildscripts/github/repair_wheel_linux.sh \
             "$PYTHON_EXECUTABLE" \
             "$USE_TBB" \
             "/io/wheelhouse"

--- a/.github/workflows/numba_linux-aarch64_wheel_builder.yml
+++ b/.github/workflows/numba_linux-aarch64_wheel_builder.yml
@@ -87,14 +87,12 @@ jobs:
 
           # Prepare build environment
           mkdir -p dist wheelhouse
-          chmod +x buildscripts/github/build_wheel_linux.sh
-          chmod +x buildscripts/github/repair_wheel_linux.sh
 
           # Run the build script inside Docker container
           docker run --rm \
             -v ${{ github.workspace }}:/io \
             quay.io/pypa/${{ env.MANYLINUX_IMAGE }} \
-            /io/buildscripts/github/build_wheel_linux.sh \
+            bash /io/buildscripts/github/build_wheel_linux.sh \
             "${PYTHON_EXECUTABLE}" \
             "false" \
             "${{ matrix.numpy_build }}" \
@@ -114,7 +112,7 @@ jobs:
           docker run --rm \
             -v ${{ github.workspace }}:/io \
             quay.io/pypa/${{ env.MANYLINUX_IMAGE }} \
-            /io/buildscripts/github/repair_wheel_linux.sh \
+            bash /io/buildscripts/github/repair_wheel_linux.sh \
             "${PYTHON_EXECUTABLE}" \
             "false" \
             "/io/wheelhouse"


### PR DESCRIPTION
This PR is to address linux wheel build bug on GHA, where it builds with `.dirty`.

https://github.com/numba/numba/issues/10204

This was caused by update of permissions on build and repair scripts. This resolves it by removing `chmod +x` and using `bash` to run the scripts on manylinux container.