### PR TITLE
GHA/ update artifact names in wheel builder workflows

### DIFF
--- a/.github/workflows/numba_linux-64_wheel_builder.yml
+++ b/.github/workflows/numba_linux-64_wheel_builder.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Upload numba wheel
         uses: actions/upload-artifact@v4
         with:
-          name: numba-linux-64-py${{ matrix.python_canonical }}
+          name: numba_linux-64_wheel_py${{ matrix.python_canonical }}
           path: wheelhouse/*.whl
           compression-level: 0
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
@@ -170,7 +170,7 @@ jobs:
       - name: Download Numba wheel artifact
         uses: actions/download-artifact@v4
         with:
-          name: numba-linux-64-py${{ matrix.python_canonical }}
+          name: numba_linux-64_wheel_py${{ matrix.python_canonical }}
           path: dist
 
       - name: Download llvmlite wheel

--- a/.github/workflows/numba_linux-aarch64_wheel_builder.yml
+++ b/.github/workflows/numba_linux-aarch64_wheel_builder.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Upload numba wheel
         uses: actions/upload-artifact@v4
         with:
-          name: numba-linux-aarch64-py${{ matrix.python_canonical }}
+          name: numba_linux-aarch64_wheel_py${{ matrix.python_canonical }}
           path: wheelhouse/*.whl
           compression-level: 0
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
@@ -162,7 +162,7 @@ jobs:
       - name: Download Numba wheel artifact
         uses: actions/download-artifact@v4
         with:
-          name: numba-linux-aarch64-py${{ matrix.python_canonical }}
+          name: numba_linux-aarch64_wheel_py${{ matrix.python_canonical }}
           path: dist
 
       - name: Download llvmlite wheel

--- a/.github/workflows/numba_osx-64_wheel_builder.yml
+++ b/.github/workflows/numba_osx-64_wheel_builder.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Upload numba wheel
         uses: actions/upload-artifact@v4
         with:
-          name: numba-osx-64-py${{ matrix.python_canonical }}
+          name: numba_osx-64_wheel_py${{ matrix.python_canonical }}
           path: dist/*.whl
           compression-level: 0
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
@@ -157,7 +157,7 @@ jobs:
       - name: Download Numba wheel artifact
         uses: actions/download-artifact@v4
         with:
-          name: numba-osx-64-py${{ matrix.python_canonical }}
+          name: numba_osx-64_wheel_py${{ matrix.python_canonical }}
           path: dist
 
       - name: Download llvmlite wheel

--- a/.github/workflows/numba_osx-arm64_wheel_builder.yml
+++ b/.github/workflows/numba_osx-arm64_wheel_builder.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Upload numba wheel
         uses: actions/upload-artifact@v4
         with:
-          name: numba-osx-arm64-py${{ matrix.python_canonical }}
+          name: numba_osx-arm64_wheel_py${{ matrix.python_canonical }}
           path: dist/*.whl
           compression-level: 0
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
@@ -162,7 +162,7 @@ jobs:
       - name: Download Numba wheel artifact
         uses: actions/download-artifact@v4
         with:
-          name: numba-osx-arm64-py${{ matrix.python_canonical }}
+          name: numba_osx-arm64_wheel_py${{ matrix.python_canonical }}
           path: dist
 
       - name: Download llvmlite wheel

--- a/.github/workflows/numba_win-64_wheel_builder.yml
+++ b/.github/workflows/numba_win-64_wheel_builder.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Upload numba wheel
         uses: actions/upload-artifact@v4
         with:
-          name: numba-win-64-py${{ matrix.python_canonical }}
+          name: numba_win-64_wheel_py${{ matrix.python_canonical }}
           path: dist/*.whl
           compression-level: 0
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
@@ -128,7 +128,7 @@ jobs:
       - name: Download Numba wheel artifact
         uses: actions/download-artifact@v4
         with:
-          name: numba-win-64-py${{ matrix.python_canonical }}
+          name: numba_win-64_wheel_py${{ matrix.python_canonical }}
           path: dist
 
       - name: Download llvmlite wheel


### PR DESCRIPTION
This PR addresses - https://github.com/numba/numba/issues/10204#issuecomment-3234709820
- change artifact dir names to use format- `numba_<platform>_wheel_<python-version>`

