### PR TITLE
skip test_prange_fastmath_check_works

### DIFF
--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -4227,6 +4227,7 @@ class TestPrangeSpecific(TestPrangeBase):
         msg = 'Only constant step size of 1 is supported for prange'
         self.assertIn(msg, str(raises.exception))
 
+    @unittest.skip("skip due to issue #10203: https://github.com/numba/numba/issues/10203")
     def test_prange_fastmath_check_works(self):
         # this function will benefit from `fastmath`, the div will
         # get optimised to a multiply by reciprocal and the accumulator


### PR DESCRIPTION
Temporarily skip `numba.tests.test_parfors.TestPrangeSpecific.test_prange_fastmath_check_works` due to intermittent failures detected during `0.62` testing. Tracking on issue https://github.com/numba/numba/issues/10203.