### PR TITLE
Update conda_build_config.yaml to pin osx compiler version to 19

### DIFF
--- a/buildscripts/condarecipe.local/conda_build_config.yaml
+++ b/buildscripts/condarecipe.local/conda_build_config.yaml
@@ -1,11 +1,13 @@
 # Numba/llvmlite stack needs an older compiler for backwards compatibility.
-c_compiler_version:         # [linux]
+c_compiler_version:         # [linux or osx]
   - 7                       # [linux and (x86_64 or ppc64le)]
   - 11                      # [linux and aarch64]
+  - 19                      # [osx]
 
-cxx_compiler_version:       # [linux]
+cxx_compiler_version:       # [linux or osx]
   - 7                       # [linux and (x86_64 or ppc64le)]
   - 11                      # [linux and aarch64]
+  - 19                      # [osx]
 
 fortran_compiler_version:   # [linux]
   - 7                       # [linux and (x86_64 or ppc64le)]

--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     # OpenMP headers from llvm needed for OSX.
-    - llvm-openmp              # [osx]
+    - llvm-openmp={{ c_compiler_version }}              # [osx]
   host:
     - python
     - numpy


### PR DESCRIPTION
The conda recipe on numba did not pin compiler versions for osx. That causes builds to use
- clang 19 on `osx-64` (defaults/osx-64::clang-19-19.1.7) and 
- clang 20 on `osx-arm64` (defaults/osx-arm64::clang-20.1.8)
since, there's an ABI break in LLVM libc++ between llvm 19 and 20, this PR aims to pin version on both osx platforms to 19.