### PR TITLE
pin osx compiler versions to 19 on wheel builder workflows

### DIFF
--- a/.github/workflows/numba_osx-64_wheel_builder.yml
+++ b/.github/workflows/numba_osx-64_wheel_builder.yml
@@ -96,7 +96,7 @@ jobs:
           else
               python -m pip install -i ${{ env.WHEELS_INDEX_URL }} llvmlite
           fi
-          conda install -c defaults python-build numpy==${{ matrix.numpy_build }} clang_osx-64 clangxx_osx-64
+          conda install -c defaults python-build numpy==${{ matrix.numpy_build }} clang_osx-64=19 clangxx_osx-64=19
           conda install --yes llvm-openmp
 
       - name: Build wheel

--- a/.github/workflows/numba_osx-arm64_wheel_builder.yml
+++ b/.github/workflows/numba_osx-arm64_wheel_builder.yml
@@ -92,7 +92,7 @@ jobs:
           else
               arch -arm64 python -m pip install -i ${{ env.WHEELS_INDEX_URL }} llvmlite
           fi
-          conda install -c defaults python-build numpy==${{ matrix.numpy_build }} clang_osx-arm64 clangxx_osx-arm64
+          conda install -c defaults python-build numpy==${{ matrix.numpy_build }} clang_osx-arm64=19 clangxx_osx-arm64=19
           conda install --yes llvm-openmp
 
       - name: Build sdist [once - py3.10]


### PR DESCRIPTION
Without explicit pins on compilers on build step, it uses `clang=20.*` on conda env, which has ABI break.