### PR TITLE
GHA/refactor `osx-arm64` and `win-64` wheel builder workflows to use setup-python for build job

### DIFF
--- a/.github/workflows/numba_osx-arm64_wheel_builder.yml
+++ b/.github/workflows/numba_osx-arm64_wheel_builder.yml
@@ -70,10 +70,14 @@ jobs:
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v3
         with:
-          python-version: ${{ matrix.python-version }}
           conda-remove-defaults: true
           auto-update-conda: true
           auto-activate-base: true
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Download llvmlite wheel
         if: inputs.llvmlite_wheel_runid != ''
@@ -92,7 +96,7 @@ jobs:
           else
               arch -arm64 python -m pip install -i ${{ env.WHEELS_INDEX_URL }} llvmlite
           fi
-          conda install -c defaults python-build numpy==${{ matrix.numpy_build }}
+          python -m pip install build numpy==${{ matrix.numpy_build }} setuptools wheel
           conda install --yes llvm-openmp
 
       - name: Build sdist [once - py3.10]
@@ -100,7 +104,7 @@ jobs:
         run: arch -arm64 python -m build --sdist
 
       - name: Build wheel
-        run: arch -arm64 python -m build
+        run: arch -arm64 python -m build --wheel --no-isolation
 
       - name: Fix macOS wheel library paths
         run: |

--- a/.github/workflows/numba_win-64_wheel_builder.yml
+++ b/.github/workflows/numba_win-64_wheel_builder.yml
@@ -67,13 +67,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v3
+      - name: Setup Python
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          conda-remove-defaults: true
-          auto-update-conda: true
-          auto-activate-base: true
 
       - name: Download llvmlite wheel
         if: inputs.llvmlite_wheel_runid != ''
@@ -92,11 +89,10 @@ jobs:
           else
               python -m pip install -i ${{ env.WHEELS_INDEX_URL }} llvmlite
           fi
-          conda install -c defaults python-build numpy==${{ matrix.numpy_build }} setuptools
-          python -m pip install tbb==2021.6 tbb-devel==2021.6
+          python -m pip install build numpy==${{ matrix.numpy_build }} setuptools wheel tbb==2021.6 tbb-devel==2021.6
 
       - name: Build wheel
-        run: python -m build
+        run: python -m build --wheel --no-isolation
 
       - name: Upload numba wheel
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Currently, the `osx-arm64` and `win-64` wheel builders use miniconda provided python on build environment, use conda to install build dependencies and osx compiler toolchain on `osx-arm64`.

This PR  replaces use of conda on wheel builder workflows to use `actions/setup-python` action to use system python. This would also allow getting pre-release versions of python for build and test using `allow-prereleases: true` param.

This PR also cleans up `Setup Miniconda` step from win-64 wheel builder which is now not needed, while still retaining miniconda on `osx-arm64` to provide `llvm-openmp` for linking.