### PR TITLE
GHA/ fix win-64 lib lookup paths

### DIFF
--- a/.github/workflows/numba_linux-64_wheel_builder.yml
+++ b/.github/workflows/numba_linux-64_wheel_builder.yml
@@ -7,6 +7,7 @@ on:
       - .github/workflows/wheel_workflow_matrix.json
       - buildscripts/github/build_wheel_linux.sh
       - buildscripts/github/repair_wheel_linux.sh
+      - setup.py
   workflow_dispatch:
     inputs:
       llvmlite_wheel_runid:

--- a/.github/workflows/numba_linux-aarch64_wheel_builder.yml
+++ b/.github/workflows/numba_linux-aarch64_wheel_builder.yml
@@ -7,6 +7,7 @@ on:
       - .github/workflows/wheel_workflow_matrix.json
       - buildscripts/github/build_wheel_linux.sh
       - buildscripts/github/repair_wheel_linux.sh
+      - setup.py
   workflow_dispatch:
     inputs:
       llvmlite_wheel_runid:

--- a/.github/workflows/numba_osx-arm64_wheel_builder.yml
+++ b/.github/workflows/numba_osx-arm64_wheel_builder.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - .github/workflows/numba_osx-arm64_wheel_builder.yml
       - .github/workflows/wheel_workflow_matrix.json
+      - setup.py
   workflow_dispatch:
     inputs:
       llvmlite_wheel_runid:

--- a/.github/workflows/numba_win-64_wheel_builder.yml
+++ b/.github/workflows/numba_win-64_wheel_builder.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - .github/workflows/numba_win-64_wheel_builder.yml
       - .github/workflows/wheel_workflow_matrix.json
+      - setup.py
   workflow_dispatch:
     inputs:
       llvmlite_wheel_runid:

--- a/setup.py
+++ b/setup.py
@@ -213,6 +213,7 @@ def get_ext_modules():
         """
         found = None
         path2check = [os.path.split(os.path.split(sys.executable)[0])[0]]
+        path2check += [os.path.dirname(sys.executable)]    # for GHA win toolcache: ...\Python\<ver>\x64
         path2check += [os.getenv(n, '') for n in ['CONDA_PREFIX', 'PREFIX']]
         if sys.platform.startswith('win'):
             path2check += [os.path.join(p, 'Library') for p in path2check]


### PR DESCRIPTION
on `win-64` GHA runners, 
Python is at - `...\Python\<ver>\x64\python.exe` 
and TBB headers at - `...\Python\<ver>\x64\Library\include\tbb\tbb.h`.

The `check_file_at_path()` on `setup.py` only seeded search roots with the parent of `sys.executable` 
(i.e., `...\Python\<ver>`), so it never looks under `...\x64\Library\....`
causing -
```
path2check - on windows ['C:\\hostedtoolcache\\windows\\Python\\3.10.11', '', '', 'C:\\hostedtoolcache\\windows\\Python\\3.10.11\\Library', 'Library', 'Library']
TBB not found
```


This PR appends base dir of python executable to paths to check-
`path2check += [os.path.dirname(sys.executable)]`, so `...\x64\Library` gets discovered.

I've verified that `3.10.11\x64\Library` is now searched and TBB is detected -
```
path2check - on windows ['C:\\hostedtoolcache\\windows\\Python\\3.10.11\\x64', 'C:\\hostedtoolcache\\windows\\Python\\3.10.11', '', '', 'C:\\hostedtoolcache\\windows\\Python\\3.10.11\\x64\\Library', 'C:\\hostedtoolcache\\windows\\Python\\3.10.11\\Library', 'Library', 'Library']
Using Intel TBB from: C:\hostedtoolcache\windows\Python\3.10.11\x64\Library
```

Also adds setup.py to the paths filters of all wheel-builder workflows, so any edits to setup.py automatically triggers wheel CI and validates logic.