### PR TITLE
remove conditional logic for using ad-testing channel for py314

### DIFF
--- a/.github/workflows/numba_linux-64_conda_builder.yml
+++ b/.github/workflows/numba_linux-64_conda_builder.yml
@@ -44,7 +44,7 @@ jobs:
     needs: load-matrix
     runs-on: ubuntu-latest
     env:
-      EXTRA_CHANNELS: ${{ matrix.python-version == '3.14' && '-c ad-testing/label/py314' || '' }}
+      EXTRA_CHANNELS: ''
     defaults:
       run:
         shell: bash -elx {0}
@@ -119,7 +119,7 @@ jobs:
     needs: [load-matrix, linux-64-build-conda]
     runs-on: ubuntu-latest
     env:
-      EXTRA_CHANNELS: ${{ matrix.python-version == '3.14' && '-c ad-testing/label/py314' || '' }}
+      EXTRA_CHANNELS: ''
     defaults:
       run:
         shell: bash -elx {0}

--- a/.github/workflows/numba_linux-aarch64_conda_builder.yml
+++ b/.github/workflows/numba_linux-aarch64_conda_builder.yml
@@ -44,7 +44,7 @@ jobs:
     needs: load-matrix
     runs-on: ubuntu-24.04-arm
     env:
-      EXTRA_CHANNELS: ${{ matrix.python-version == '3.14' && '-c ad-testing/label/py314' || '' }}
+      EXTRA_CHANNELS: ''
     defaults:
       run:
         shell: bash -elx {0}
@@ -119,7 +119,7 @@ jobs:
     needs: [load-matrix, linux-aarch64-build-conda]
     runs-on: ubuntu-24.04-arm
     env:
-      EXTRA_CHANNELS: ${{ matrix.python-version == '3.14' && '-c ad-testing/label/py314' || '' }}
+      EXTRA_CHANNELS: ''
     defaults:
       run:
         shell: bash -elx {0}

--- a/.github/workflows/numba_osx-arm64_conda_builder.yml
+++ b/.github/workflows/numba_osx-arm64_conda_builder.yml
@@ -44,7 +44,7 @@ jobs:
     needs: load-matrix
     runs-on: macos-14
     env:
-      EXTRA_CHANNELS: ${{ matrix.python-version == '3.14' && '-c ad-testing/label/py314' || '' }}
+      EXTRA_CHANNELS: ''
     defaults:
       run:
         shell: bash -elx {0}
@@ -119,7 +119,7 @@ jobs:
     needs: [load-matrix, osx-arm64-build-conda]
     runs-on: macos-14
     env:
-      EXTRA_CHANNELS: ${{ matrix.python-version == '3.14' && '-c ad-testing/label/py314' || '' }}
+      EXTRA_CHANNELS: ''
     defaults:
       run:
         shell: bash -elx {0}

--- a/.github/workflows/numba_win-64_conda_builder.yml
+++ b/.github/workflows/numba_win-64_conda_builder.yml
@@ -44,7 +44,7 @@ jobs:
     needs: load-matrix
     runs-on: windows-2025
     env:
-      EXTRA_CHANNELS: ${{ matrix.python-version == '3.14' && '-c ad-testing/label/py314' || '' }}
+      EXTRA_CHANNELS: ''
     defaults:
       run:
         shell: bash -elx {0}
@@ -118,7 +118,7 @@ jobs:
     needs: [load-matrix, win-64-build-conda]
     runs-on: windows-2025
     env:
-      EXTRA_CHANNELS: ${{ matrix.python-version == '3.14' && '-c ad-testing/label/py314' || '' }}
+      EXTRA_CHANNELS: ''
     defaults:
       run:
         shell: bash -elx {0}


### PR DESCRIPTION
Cleanup GHA workflows after official release of python 3.14 :
- remove extra channel (`ad-testing/label/py314`) used on conda builder workflow.
