### PR TITLE
CI/ move `sphinx_rtd_theme` dependency

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - numpy
   - numpydoc
   - setuptools
+  - sphinx_rtd_theme>=0.5.1
   # https://stackoverflow.com/questions/67542699/readthedocs-sphinx-not-rendering-bullet-list-from-rst-fileA
   - docutils==0.16
   # The following is needed to fix RTD.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,16 +31,6 @@ except ImportError:
     sys.path.insert(0, os.path.abspath('../..'))
     import numba
 
-
-on_rtd = os.environ.get('READTHEDOCS') == 'True'
-
-if on_rtd:
-    # The following is needed to fix RTD issue with numpydoc
-    # https://github.com/readthedocs/sphinx_rtd_theme/issues/766
-    from conda.cli.python_api import run_command as conda_cmd
-
-    conda_cmd("install", "-c", "conda-forge", "sphinx_rtd_theme>=0.5.1", "-y")
-
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.


### PR DESCRIPTION
`conda.cli.python_api` was deprecated and removed from new conda release `25.9.0`. This is being used on - [docs/source/conf.py#L40](https://github.com/numba/numba/blob/ee698b59b1142d7d334b8dd678bda2f63b7e6e7b/docs/source/conf.py#L40) to install `sphinx_rtd_theme>=0.5.1`

This PR removes the usage of deprecated module and moves dependency installation to `environment.yml`.