### PR TITLE
Enable further signature compilation

### DIFF
--- a/numba/core/decorators.py
+++ b/numba/core/decorators.py
@@ -1,6 +1,7 @@
 """
 Define @jit and related decorators.
 """
+from functools import wraps
 
 import sys
 import warnings
@@ -244,12 +245,14 @@ def _jit(sigs, locals, target, cache, targetoptions, **dispatcher_args):
             with typeinfer.register_dispatcher(disp):
                 for sig in sigs:
                     disp.compile(sig)
-                disp.disable_compile()
+                if not allow_further_signature_compilation:
+                    disp.disable_compile()
         return disp
 
     return wrapper
 
 
+@wraps(jit)
 def njit(*args, **kws):
     """
     Equivalent to jit(nopython=True)

--- a/numba/core/decorators.py
+++ b/numba/core/decorators.py
@@ -2,7 +2,6 @@
 Define @jit and related decorators.
 """
 
-
 import sys
 import warnings
 import inspect
@@ -19,13 +18,21 @@ _logger = logging.getLogger(__name__)
 # -----------------------------------------------------------------------------
 # Decorators
 
-_msg_deprecated_signature_arg = ("Deprecated keyword argument `{0}`. "
-                                 "Signatures should be passed as the first "
-                                 "positional argument.")
+_msg_deprecated_signature_arg = (
+    "Deprecated keyword argument `{0}`. "
+    "Signatures should be passed as the first "
+    "positional argument."
+)
 
 
-def jit(signature_or_function=None, locals=MappingProxyType({}), cache=False,
-        pipeline_class=None, boundscheck=None, **options):
+def jit(
+    signature_or_function=None,
+    locals=MappingProxyType({}),
+    cache=False,
+    pipeline_class=None,
+    boundscheck=None,
+    **options,
+):
     """
     This decorator is used to compile a Python function into native code.
 
@@ -42,8 +49,26 @@ def jit(signature_or_function=None, locals=MappingProxyType({}), cache=False,
         Mapping of local variable names to Numba types. Used to override the
         types deduced by Numba's type inference engine.
 
+    cache: bool
+        Set to True to enable caching of the compiled function to disk.  The
+        default is False.  Note that caching requires the presence of a
+        working LLVM setup.
+
     pipeline_class: type numba.compiler.CompilerBase
             The compiler pipeline type for customizing the compilation stages.
+
+    boundscheck: bool or None
+        Set to True to enable bounds checking for array indices. Out
+        of bounds accesses will raise IndexError. The default is to
+        not do bounds checking. If False, bounds checking is disabled,
+        out of bounds accesses can produce garbage results or segfaults.
+        However, enabling bounds checking will slow down typical
+        functions, so it is recommended to only use this flag for
+        debugging. You can also set the NUMBA_BOUNDSCHECK environment
+        variable to 0 or 1 to globally override this flag. The default
+        value is None, which under normal execution equates to False,
+        but if debug is set to True then bounds checking will be
+        enabled. Note that bounds checking is only supported in nopython mode.
 
     options:
         For a cpu target, valid options are:
@@ -80,19 +105,6 @@ def jit(signature_or_function=None, locals=MappingProxyType({}), cache=False,
                 return Truthy as to whether to inline.
                 NOTE: This inlining is performed at the Numba IR level and is in
                 no way related to LLVM inlining.
-
-            boundscheck: bool or None
-                Set to True to enable bounds checking for array indices. Out
-                of bounds accesses will raise IndexError. The default is to
-                not do bounds checking. If False, bounds checking is disabled,
-                out of bounds accesses can produce garbage results or segfaults.
-                However, enabling bounds checking will slow down typical
-                functions, so it is recommended to only use this flag for
-                debugging. You can also set the NUMBA_BOUNDSCHECK environment
-                variable to 0 or 1 to globally override this flag. The default
-                value is None, which under normal execution equates to False,
-                but if debug is set to True then bounds checking will be
-                enabled.
 
     Returns
     --------

--- a/numba/tests/test_api.py
+++ b/numba/tests/test_api.py
@@ -1,5 +1,6 @@
 import warnings
 
+import numpy as np
 import numba
 from numba import jit, njit
 
@@ -85,6 +86,35 @@ class TestJitDecorator(TestCase):
         jit_func(1)
         # Since forceobj is ignored this has to compile in nopython mode
         self.assertEqual(len(jit_func.nopython_signatures), 1)
+
+    def test_enable_further_signatures_false(self):
+        def py_func(x):
+            return x
+
+        jit_func = jit("float64(float64)", allow_further_signature_compilation=False)(
+            py_func
+        )
+        self.assertEqual(len(jit_func.nopython_signatures), 1)
+        assert not jit_func._can_compile
+
+        with self.assertRaises(TypeError):
+            jit_func(np.array([1, 2, 3]))
+
+    def test_enable_further_signatures_true(self):
+        def py_func(x):
+            return x
+
+        jit_func = jit("float64(float64)", allow_further_signature_compilation=True)(
+            py_func
+        )
+        self.assertEqual(len(jit_func.nopython_signatures), 1)
+        assert jit_func._can_compile
+
+        x = np.array([1, 2, 3])
+        out = jit_func(x)
+        assert (out == x).all()
+        assert out.dtype == x.dtype
+        self.assertEqual(len(jit_func.nopython_signatures), 2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Currently, when signatures are passed to the `jit` decorator, dispatcher compilation is disabled, meaning unseen signatures cannot be compiled when encountered for the first time (the behaviour that we get when no signature is supplied). 
I think it is useful to be able to mix these behaviours: define some known signatures such that they can be compiled at import (and cached) but also avoid failures when unexpected signatures are encountered. 

This change adds an optional flag to the jit decorator to enable this behaviour. I wasn't sure whether to add a new argument of fold it into the variable kwargs named `options`. I noticed that the `disable_compile` method is public on the dispatcher and the code simply sets `_can_cache` to `False`. However, there is no public `enable_compile` and so there was no way for my application to unlock this behaviour without accessing private variables. Open to suggestions here. 

I did a small amount of clean up on the documentation as well. 