### PR TITLE
Implementing Python 3.14 complex number NaN recovery

### DIFF
--- a/numba/core/utils.py
+++ b/numba/core/utils.py
@@ -32,6 +32,20 @@ from numba.core import types
 from collections.abc import Mapping, Sequence, MutableSet, MutableMapping
 
 
+def _detect_complex_div_nan_recovery():
+    """
+    Detect whether the host interpreter applies the CPython 3.14 complex
+    division NaN-recovery semantics. The probe divides a finite complex by
+    an infinite complex; pre-3.14 yields NaNs, 3.14+ returns signed zeros.
+    """
+    test = (1.0 + 0.0j) / complex(math.inf, math.inf)
+    return not (math.isnan(test.real) or math.isnan(test.imag))
+
+
+HAS_COMPLEX_DIV_NAN_RECOVERY = _detect_complex_div_nan_recovery()
+del _detect_complex_div_nan_recovery
+
+
 def erase_traceback(exc_value):
     """
     Erase the traceback and hanging locals from the given exception instance.

--- a/numba/np/math/numbers.py
+++ b/numba/np/math/numbers.py
@@ -7,7 +7,7 @@ from llvmlite import ir
 from llvmlite.ir import Constant
 
 from numba.core.imputils import impl_ret_untracked
-from numba.core import typing, types, errors, cgutils
+from numba.core import typing, types, errors, cgutils, utils
 from numba.cpython.unsafe.numbers import viewer
 
 def _int_arith_flags(rettype):
@@ -1096,26 +1096,49 @@ def complex_div_impl(context, builder, sig, args):
         aimag = a.imag
         breal = b.real
         bimag = b.imag
+        abs_breal = abs(breal)
+        abs_bimag = abs(bimag)
         if not breal and not bimag:
             raise ZeroDivisionError("complex division by zero")
-        if abs(breal) >= abs(bimag):
+        if abs_breal >= abs_bimag:
             # Divide tops and bottom by b.real
             if not breal:
-                return complex(NAN, NAN)
-            ratio = bimag / breal
-            denom = breal + bimag * ratio
-            return complex(
-                (areal + aimag * ratio) / denom,
-                (aimag - areal * ratio) / denom)
+                res = complex(NAN, NAN)
+            else:
+                ratio = bimag / breal
+                denom = breal + bimag * ratio
+                res = complex(
+                    (areal + aimag * ratio) / denom,
+                    (aimag - areal * ratio) / denom)
         else:
             # Divide tops and bottom by b.imag
             if not bimag:
-                return complex(NAN, NAN)
-            ratio = breal / bimag
-            denom = breal * ratio + bimag
-            return complex(
-                (a.real * ratio + a.imag) / denom,
-                (a.imag * ratio - a.real) / denom)
+                res = complex(NAN, NAN)
+            else:
+                ratio = breal / bimag
+                denom = breal * ratio + bimag
+                res = complex(
+                    (areal * ratio + aimag) / denom,
+                    (aimag * ratio - areal) / denom)
+
+        if (utils.HAS_COMPLEX_DIV_NAN_RECOVERY
+                and math.isnan(res.real) and math.isnan(res.imag)):
+            if ((math.isinf(areal) or math.isinf(aimag))
+                    and math.isfinite(breal) and math.isfinite(bimag)):
+                x = math.copysign(1.0 if math.isinf(areal) else 0.0, areal)
+                y = math.copysign(1.0 if math.isinf(aimag) else 0.0, aimag)
+                res = complex(
+                    math.inf * (x * breal + y * bimag),
+                    math.inf * (y * breal - x * bimag))
+            elif ((math.isinf(abs_breal) or math.isinf(abs_bimag))
+                  and math.isfinite(areal) and math.isfinite(aimag)):
+                x = math.copysign(1.0 if math.isinf(breal) else 0.0, breal)
+                y = math.copysign(1.0 if math.isinf(bimag) else 0.0, bimag)
+                res = complex(
+                    0.0 * (areal * x + aimag * y),
+                    0.0 * (aimag * x - areal * y))
+
+        return res
 
     res = context.compile_internal(builder, complex_div, sig, args)
     return impl_ret_untracked(context, builder, sig.return_type, res)

--- a/numba/tests/test_complex.py
+++ b/numba/tests/test_complex.py
@@ -114,7 +114,6 @@ class TestComplex(BaseComplexTest, TestCase):
                        (types.complex64, types.complex64)]
         self.run_binary(div_usecase, value_types, values, flags=flags)
 
-    @skip_if_py314
     def test_div_npm(self):
         self.test_div(flags=no_pyobj_flags)
 
@@ -208,7 +207,6 @@ class TestCMath(BaseComplexTest, TestCase):
         self.run_binary(log_base_usecase, value_types, values, flags=flags,
                         ulps=3)
 
-    @skip_if_py314
     def test_log_base_npm(self):
         self.test_log_base(flags=no_pyobj_flags)
 


### PR DESCRIPTION
Fixes #10257 by implementing Python 3.14's new "NaN recovery" for complex numbers.

I've gated this so that for 3.13 and below the original behaviour is still retained. I've done this via runtime feature detection - if a direct version number gate is preferred, then it can be easily changed.