### PR TITLE
[CI TEST] Is collections' operator.contains typing used?

### DIFF
--- a/numba/core/typing/collections.py
+++ b/numba/core/typing/collections.py
@@ -6,15 +6,6 @@ from .templates import (AttributeTemplate, ConcreteTemplate, AbstractTemplate,
 from .builtins import normalize_1d_index
 
 
-@infer_global(operator.contains)
-class InContainer(AbstractTemplate):
-    key = operator.contains
-
-    def generic(self, args, kws):
-        cont, item = args
-        if isinstance(cont, types.Container):
-            return signature(types.boolean, cont, cont.dtype)
-
 @infer_global(len)
 class ContainerLen(AbstractTemplate):
 


### PR DESCRIPTION
It may be buggy as it returns the container type forcing a cast. If this were used for e.g. `1.5 in (1, 2)` then the signature would likely be along the lines of `bool(UniTuple(int64, 2), int64)`, so I am wondering if it is used at all.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
