### PR TITLE
GHA/ fix numba `osx-arm64` wheel tag regression 

### DIFF
--- a/.github/workflows/numba_osx-arm64_wheel_builder.yml
+++ b/.github/workflows/numba_osx-arm64_wheel_builder.yml
@@ -101,6 +101,8 @@ jobs:
         run: arch -arm64 python -m build --sdist
 
       - name: Build wheel
+        env:
+          MACOSX_DEPLOYMENT_TARGET: "11.0"
         run: arch -arm64 python -m build --wheel --no-isolation
 
       - name: Fix macOS wheel library paths


### PR DESCRIPTION
resolves: https://github.com/numba/numba/issues/10264

previous PR merge - https://github.com/numba/numba/pull/10230 changed `osx-arm64` build job to use `actions/setup-python` action to use system python. This change lead to `osx-arm64` wheel builder producing `macosx_10_9_universal2` tagged wheels, which meant they were built with 2 slices (to work on both `x86_64` and `arm64`) which was unintentional.

The root cause of this was found to be GHA systems' interpreter, which was built using deployment target 10.9 and universal2 tagged. This in turn affects wheel built using the interpreter. It also does not obey `MACOSX_DEPLOYMENT_TARGET=11.0` specification from environment.

To correct this, this PR reverts to using conda based python to build `osx-arm64` wheels. It also adds explicit `MACOSX_DEPLOYMENT_TARGET=11.0` specification to build env. 