### PR TITLE
Fix #10235 by adding bitwidth to bool type

### DIFF
--- a/numba/core/types/scalars.py
+++ b/numba/core/types/scalars.py
@@ -11,6 +11,10 @@ from numba.np import npdatetime_helpers
 
 class Boolean(Hashable):
 
+    def __init__(self, name):
+        super().__init__(name)
+        self.bitwidth = 8
+
     def cast_python_value(self, value):
         return bool(value)
 

--- a/numba/tests/test_record_dtype.py
+++ b/numba/tests/test_record_dtype.py
@@ -1786,6 +1786,15 @@ class TestNestedArrays(TestCase):
 
         self.assertEqual(expected, actual)
 
+    def test_issue_10235(self):
+        array = np.empty(1, dtype=[("mask", bool,2)])
+
+        @njit
+        def func(array):
+            return array[0]["mask"][0]
+
+        self.assertEqual(func(array), func.py_func(array))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Our bool type isn't an integer (previous discussions have concluded this is an oversight) so it has no bitwidth. Adding a bitwidth of 8 (the number of bits used to represent the bool in memory or in an array) resolves Issue #10235 by allowing the assertion in `NestedArray.__init__()` to pass.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
