### PR TITLE
Fix #10281: generator expression used as args

### DIFF
--- a/numba/core/interpreter.py
+++ b/numba/core/interpreter.py
@@ -374,11 +374,15 @@ def _call_function_ex_replace_args_large(
     # tuple.
     search_start = 0
     total_args = []
-    if (
-        isinstance(vararg_stmt, ir.Assign)
-        and isinstance(vararg_stmt.value, ir.Var)
-    ):
-        target_name = vararg_stmt.value.name
+    if isinstance(vararg_stmt, ir.Assign):
+        value = vararg_stmt.value
+
+        if isinstance(value, ir.Var):
+            target_name = value.name
+        elif isinstance(value, ir.Expr):
+            msg = "Generator expression for arguments is unsupported"
+            raise UnsupportedBytecodeError(msg, loc=vararg_stmt.loc)
+
         # If there is an initial assignment, delete it
         new_body[search_end] = None
         # Remove the definition.

--- a/numba/tests/test_interpreter.py
+++ b/numba/tests/test_interpreter.py
@@ -626,6 +626,20 @@ class TestCallFunctionExPeepHole(MemoryLeakMixin, TestCase):
         b = cfunc(False)
         self.assertEqual(a, b)
 
+    def test_generator_expression_args(self):
+        # See Issue #10281:
+        # https://github.com/numba/numba/issues/10281
+
+        @njit
+        def f(a, b, sep=2):
+            pass
+
+        msg = "Generator expression for arguments is unsupported"
+        with self.assertRaisesRegex(UnsupportedBytecodeError, msg):
+            @njit('void()')
+            def genexp_args():
+                x(*(s for s in ["a", "b"]), sep=2)
+
 
 class TestLargeConstDict(TestCase, MemoryLeakMixin):
     """


### PR DESCRIPTION
`_call_function_ex_replace_args_large()` expects that the `vararg_stmt` is an `ir.Assign` whose value is an `ir.Var`. This is not the case when the arguments come from a generator expression, and it is an `ir.Expr` instead. Since this is unsupported anyway (and will report an error later in the pipeline) it seems that a pragmatic fix is to inform the user at this point that using a generator expression as arguments is unsupported; fixing up the function to correctly handle assigning an `ir.Expr` seems like more work that will not add value to users, as it will only result in a less-clear error message ("The use of yield in a closure is unsupported") being given to the user anyway.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
