### PR TITLE
Fix `np.unique` not supporting non-numeric types

### DIFF
--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -2645,11 +2645,14 @@ def np_size(a):
 @overload(np.unique)
 def np_unique(ar):
     def np_unique_impl(ar):
+        def isnan(x):
+            # instead of np.isnan because it can't handle non-numeric type
+            return not (x == x)
         b = np.sort(ar.ravel())
         head = list(b[:1])
         tail = [
             x for i, x in enumerate(b[1:])
-            if b[i] != x and not (np.isnan(b[i]) and np.isnan(x))
+            if b[i] != x and not (isnan(b[i]) and isnan(x))
         ]
         return np.array(head + tail)
     return np_unique_impl

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -1805,6 +1805,11 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         check(np.array([[3.1, 3.1], [1.7, 2.29], [3.3, 1.7]]))
         check(np.array([]))
         check(np.array([np.nan, np.nan]))
+        check(np.array(['A', 'A', 'B'], dtype='<U16'))  # issue 10250
+        check(np.array([np.datetime64("2001-01-01"),
+                        np.datetime64("2001-01-01"),
+                        np.datetime64("2001-01-02"),
+                        np.datetime64("NAT")]))
 
     @needs_blas
     def test_array_dot(self):


### PR DESCRIPTION
Fix #10250.

Use `not (x == x)` instead of `np.isnan` so it works for non-numeric type. 