### PR TITLE
Add Support for s390x

### DIFF
--- a/numba/cext/listobject.c
+++ b/numba/cext/listobject.c
@@ -778,7 +778,12 @@ numba_test_list(void) {
             case 8:  CHECK(lp->allocated == 8); break;
             case 16: CHECK(lp->allocated == 16); break;
         }
-        status = numba_list_append(lp, (const char*)&i);
+
+        // Store as unsigned char to avoid endianness differences
+        // Only the first byte is used later, so using a single byte ensures 
+        // consistent behaviour across little and big-endian architectures
+        unsigned char j = (unsigned char)i;
+        status = numba_list_append(lp, (const char*)&j);
         CHECK(status == LIST_OK);
         switch(i) {
             // Check that the growth happened accordingly
@@ -833,7 +838,8 @@ numba_test_list(void) {
     CHECK(lp->size == 0);
     CHECK(lp->allocated == 0);
     for (i = 0; i < 17 ; i++) {
-        status = numba_list_append(lp, (const char*)&i);
+        unsigned char j = (unsigned char)i;
+        status = numba_list_append(lp, (const char*)&j);
         CHECK(status == LIST_OK);
     }
     CHECK(lp->size == 17);
@@ -892,7 +898,8 @@ numba_test_list(void) {
     CHECK(lp->size == 0);
     CHECK(lp->allocated == 0);
     for (i = 0; i < 17 ; i++) {
-        status = numba_list_append(lp, (const char*)&i);
+        unsigned char j = (unsigned char)i;
+        status = numba_list_append(lp, (const char*)&j);
         CHECK(status == LIST_OK);
     }
     CHECK(lp->size == 17);
@@ -942,7 +949,8 @@ numba_test_list(void) {
     CHECK(lp->size == 0);
     CHECK(lp->allocated == 0);
     for (i = 0; i < 17 ; i++) {
-        status = numba_list_append(lp, (const char*)&i);
+        unsigned char j = (unsigned char)i;
+        status = numba_list_append(lp, (const char*)&j);
         CHECK(status == LIST_OK);
     }
     CHECK(lp->size == 17);
@@ -954,7 +962,8 @@ numba_test_list(void) {
 
     // refill list
     for (i = 0; i < 17 ; i++) {
-        status = numba_list_append(lp, (const char*)&i);
+        unsigned char j = (unsigned char)i;
+        status = numba_list_append(lp, (const char*)&j);
         CHECK(status == LIST_OK);
     }
 

--- a/numba/core/runtime/nrt.cpp
+++ b/numba/core/runtime/nrt.cpp
@@ -1,6 +1,7 @@
 /* MSVC C99 doesn't have <stdatomic.h>, else this could be written in easily
  * in C */
 #include <atomic>
+#include <algorithm>
 
 #ifdef _MSC_VER
 #include <inttypes.h>
@@ -11,6 +12,11 @@
 #include "nrt.h"
 #include "assert.h"
 
+#if defined(__s390x__) || defined(__zarch__)
+    #define IS_S390X_ARCH 1
+#else
+    #define IS_S390X_ARCH 0
+#endif
 
 /* NOTE: if changing the layout, please update numba.core.runtime.atomicops */
 extern "C" {
@@ -301,6 +307,14 @@ void *nrt_allocate_meminfo_and_data_align(size_t size, unsigned align,
 {
     size_t offset = 0, intptr = 0, remainder = 0;
     NRT_Debug(nrt_debug_print("nrt_allocate_meminfo_and_data_align %p\n", allocator));
+    /*
+     * For s390x, all three SIMD backends have the same vector register size, 128 bits
+     * All three behave similarly but PPC and s390x gain more because they can load 128 bits of memory from quadword aligned memory
+     * https://pypy.org/posts/2016/11/vectorization-extended-powerpc-and-s390x-4042433015460084057.html
+     */
+    if (IS_S390X_ARCH) {
+        align = std::max({align, (unsigned)sizeof(void*), 16u});
+    }
     char *base = (char *)nrt_allocate_meminfo_and_data(size + 2 * align, mi, allocator);
     if (base == NULL) {
         return NULL; /* return early as allocation failed */

--- a/numba/cpython/hashing.py
+++ b/numba/cpython/hashing.py
@@ -7,6 +7,7 @@ import numpy as np
 import sys
 import ctypes
 import warnings
+from platform import machine as get_architecture
 from collections import namedtuple
 
 import llvmlite.binding as ll
@@ -448,9 +449,21 @@ def _build_hashsecret():
         ll.add_symbol(symbol_name, addr)
         info[name] = _hashsecret_entry(symbol=symbol_name, value=val)
 
-    inject('djbx33a_suffix', pyhashsecret.djbx33a.suffix)
-    inject('siphash_k0', pyhashsecret.siphash.k0)
-    inject('siphash_k1', pyhashsecret.siphash.k1)
+    # On s390x, the _Py_HashSecret struct is stored in big-endian
+    # order. Numba expects the values in little-endian format,
+    # so we must byte-swap manually
+    if get_architecture() == "s390x":
+        raw_bytes = bytes(pyhashsecret.uc)
+        inject('siphash_k0',
+               int.from_bytes(raw_bytes[0:8], byteorder='little'))
+        inject('siphash_k1',
+               int.from_bytes(raw_bytes[8:16], byteorder='little'))
+        inject('djbx33a_suffix',
+               int.from_bytes(raw_bytes[16:24], byteorder='little'))
+    else:
+        inject('djbx33a_suffix', pyhashsecret.djbx33a.suffix)
+        inject('siphash_k0', pyhashsecret.siphash.k0)
+        inject('siphash_k1', pyhashsecret.siphash.k1)
     return info
 
 

--- a/numba/cpython/mathimpl.py
+++ b/numba/cpython/mathimpl.py
@@ -6,6 +6,7 @@ import math
 import operator
 import sys
 import numpy as np
+from platform import machine as get_architecture
 
 import llvmlite.ir
 from llvmlite.ir import Constant
@@ -280,6 +281,10 @@ def frexp_impl(context, builder, sig, args):
 def ldexp_impl(context, builder, sig, args):
     val, exp = args
     fltty, intty = map(context.get_data_type, sig.args)
+
+    if get_architecture() == "s390x":
+        intty = ir.IntType(64)
+        exp = build.sext(exp, ir.IntType(64))
     fnty = llvmlite.ir.FunctionType(fltty, (fltty, intty))
     fname = {
         "float": "numba_ldexpf",

--- a/numba/np/ufunc/wrappers.py
+++ b/numba/np/ufunc/wrappers.py
@@ -1,6 +1,7 @@
 from collections import namedtuple
 
 import numpy as np
+from platform import machine as get_architecture
 
 from llvmlite.ir import Constant, IRBuilder
 from llvmlite import ir
@@ -518,7 +519,10 @@ def _prepare_call_to_object_mode(context, builder, pyapi, func,
     #       int type_num,
     #       int itemsize)
 
-    ll_int = context.get_value_type(types.int32)
+    if get_architecture() == "s390x":
+        ll_int = context.get_value_type(types.int64)
+    else:
+        ll_int = context.get_value_type(types.int32)
     ll_intp = context.get_value_type(types.intp)
     ll_intp_ptr = ir.PointerType(ll_intp)
     ll_voidptr = context.get_value_type(types.voidptr)

--- a/numba/tests/ctypes_usecases.py
+++ b/numba/tests/ctypes_usecases.py
@@ -1,5 +1,6 @@
 from ctypes import *
 import sys
+from platform import machine as get_architecture
 
 import numpy as np
 
@@ -32,11 +33,12 @@ def use_two_funcs(x):
 # Typed C functions accepting an array pointer
 # (either as a "void *" or as a typed pointer)
 
+intty = c_int64 if get_architecture() == "s390x" else c_int
 c_vsquare = libnumba._numba_test_vsquare
-c_vsquare.argtypes = [c_int, c_void_p, c_void_p]
+c_vsquare.argtypes = [intty, c_void_p, c_void_p]
 
 c_vcube = libnumba._numba_test_vsquare
-c_vcube.argtypes = [c_int, POINTER(c_double), POINTER(c_double)]
+c_vcube.argtypes = [intty, POINTER(c_double), POINTER(c_double)]
 
 def use_c_vsquare(x):
     out = np.empty_like(x)

--- a/numba/tests/test_gil.py
+++ b/numba/tests/test_gil.py
@@ -4,6 +4,7 @@ import os
 import sys
 import threading
 import warnings
+from platform import machine as get_architecture
 
 import numpy as np
 
@@ -26,8 +27,8 @@ if os.name == 'nt':
     sleep_factor = 1  # milliseconds
 else:
     sleep = ctypes.CDLL(ctypes.util.find_library("c")).usleep
-    sleep.argtypes = [ctypes.c_uint]
-    sleep.restype = ctypes.c_int
+    sleep.argtypes = [ctypes.c_uint64] if get_architecture() == "s390x" else [ctypes.c_uint]
+    sleep.restype = ctypes.c_int64 if get_architecture() == "s390x" else ctypes.c_int
     sleep_factor = 1000  # microseconds
 
 


### PR DESCRIPTION
This PR fixes segmentation faults/ general issues encountered on the s390x architecture due to little/big endian differences, ABI mismatches and memory alignment issues. These changes should not conflict with other architectures. The test suite now runs on s390x without segmentation faulting or hanging.