### PR TITLE
Update np.trapz to np.trapezoid

### DIFF
--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -2222,9 +2222,8 @@ def get_d_impl(x, dx):
     return impl
 
 
-@overload(np.trapezoid if numpy_version >= (2, 0) else np.trapz)
-def np_trapz(y, x=None, dx=1.0):
-
+def _trapz_impl(y, x=None, dx=1.0):
+    """Shared implementation for both np.trapz and np.trapezoid."""
     if isinstance(y, (types.Number, types.Boolean)):
         raise TypingError('y cannot be a scalar')
     elif isinstance(y, types.Array) and y.ndim == 0:
@@ -2244,9 +2243,18 @@ def np_trapz(y, x=None, dx=1.0):
     return impl
 
 
-# numpy 2.0 rename np.trapz to np.trapezoid
+# np.trapz exists in NumPy < 2.4 (deprecated in 2.0, removed in 2.4)
+if numpy_version < (2, 4):
+    @overload(np.trapz)
+    def np_trapz(y, x=None, dx=1.0):
+        return _trapz_impl(y, x, dx)
+
+
+# np.trapezoid introduced in NumPy 2.0 as replacement for np.trapz
 if numpy_version >= (2, 0):
-    overload(np.trapezoid)(np_trapz)
+    @overload(np.trapezoid)
+    def np_trapezoid(y, x=None, dx=1.0):
+        return _trapz_impl(y, x, dx)
 
 
 @register_jitable

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -347,19 +347,19 @@ def extract(condition, arr):
 
 
 def np_trapz(y):
-    return np.trapezoid(y)
+    return np.trapz(y)
 
 
 def np_trapz_x(y, x):
-    return np.trapezoid(y, x)
+    return np.trapz(y, x)
 
 
 def np_trapz_dx(y, dx):
-    return np.trapezoid(y, dx=dx)
+    return np.trapz(y, dx=dx)
 
 
 def np_trapz_x_dx(y, x, dx):
-    return np.trapezoid(y, x, dx)
+    return np.trapz(y, x, dx)
 
 
 def np_trapezoid(y):
@@ -4155,6 +4155,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
     def test_np_trapezoid_basic(self):
         self.test_np_trapz_basic(pyfunc=np_trapezoid)
 
+    @unittest.skipIf(numpy_version >= (2, 4), "np.trapz removed in NumPy 2.4+")
     def test_np_trapz_basic(self, pyfunc=np_trapz):
         cfunc = jit(nopython=True)(pyfunc)
         _check = partial(self._check_output, pyfunc, cfunc)
@@ -4193,6 +4194,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
     def test_np_trapezoid_x_basic(self):
         self.test_np_trapz_x_basic(pyfunc=np_trapezoid_x)
 
+    @unittest.skipIf(numpy_version >= (2, 4), "np.trapz removed in NumPy 2.4+")
     def test_np_trapz_x_basic(self, pyfunc=np_trapz_x):
         cfunc = jit(nopython=True)(pyfunc)
         _check = partial(self._check_output, pyfunc, cfunc)
@@ -4255,6 +4257,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
     def test_trapezoid_numpy_questionable(self):
         self.test_trapz_numpy_questionable(pyfunc=np_trapezoid)
 
+    @unittest.skipIf(numpy_version >= (2, 4), "np.trapz removed in NumPy 2.4+")
     @unittest.skip('NumPy behaviour questionable')
     def test_trapz_numpy_questionable(self, pyfunc=np_trapz):
         # https://github.com/numpy/numpy/issues/12858
@@ -4273,6 +4276,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
     def test_np_trapezoid_dx_basic(self):
         self.test_np_trapz_dx_basic(pyfunc=np_trapezoid_dx)
 
+    @unittest.skipIf(numpy_version >= (2, 4), "np.trapz removed in NumPy 2.4+")
     def test_np_trapz_dx_basic(self, pyfunc=np_trapz_dx):
         cfunc = jit(nopython=True)(pyfunc)
         _check = partial(self._check_output, pyfunc, cfunc)
@@ -4322,6 +4326,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
     def test_np_trapezoid_x_dx_basic(self):
         self.test_np_trapz_x_dx_basic(pyfunc=np_trapezoid_x_dx)
 
+    @unittest.skipIf(numpy_version >= (2, 4), "np.trapz removed in NumPy 2.4+")
     def test_np_trapz_x_dx_basic(self, pyfunc=np_trapz_x_dx):
         cfunc = jit(nopython=True)(pyfunc)
         _check = partial(self._check_output, pyfunc, cfunc)
@@ -4350,6 +4355,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
     def test_np_trapezoid_x_dx_exceptions(self):
         self.test_np_trapz_x_dx_exceptions(pyfunc=np_trapezoid_x_dx)
 
+    @unittest.skipIf(numpy_version >= (2, 4), "np.trapz removed in NumPy 2.4+")
     def test_np_trapz_x_dx_exceptions(self, pyfunc=np_trapz_x_dx):
         cfunc = jit(nopython=True)(pyfunc)
 


### PR DESCRIPTION
On our CI job running pre-release version of `numpy` and `numba` (installed from `main`):

```
✔︎ numba:                  0.63.0b1+96.ge18468b40
✔︎ numpy (<3,>=1.23):      2.4.0.dev0
```

We see: 

```
.venv/lib/python3.13/site-packages/numba/core/dispatcher.py:443: in _compile_for_args
    raise e
.venv/lib/python3.13/site-packages/numba/core/dispatcher.py:376: in _compile_for_args
    return_val = self.compile(tuple(argtypes))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.13/site-packages/numba/core/dispatcher.py:908: in compile
    cres = self._compiler.compile(args, return_type)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.13/site-packages/numba/core/dispatcher.py:80: in compile
    status, retval = self._compile_cached(args, return_type)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.13/site-packages/numba/core/dispatcher.py:94: in _compile_cached
    retval = self._compile_core(args, return_type)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.13/site-packages/numba/core/dispatcher.py:107: in _compile_core
    cres = compiler.compile_extra(self.targetdescr.typing_context,
.venv/lib/python3.13/site-packages/numba/core/compiler.py:737: in compile_extra
    pipeline = pipeline_class(typingctx, targetctx, library,
.venv/lib/python3.13/site-packages/numba/core/compiler.py:396: in __init__
    targetctx.refresh()
.venv/lib/python3.13/site-packages/numba/core/base.py:267: in refresh
    self.load_additional_registries()
.venv/lib/python3.13/site-packages/numba/core/cpu.py:76: in load_additional_registries
    from numba.np import linalg, arraymath, arrayobj # noqa F401
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.13/site-packages/numba/np/arraymath.py:2225: in <module>
    @overload(np.trapz)
              ^^^^^^^^
.venv/lib/python3.13/site-packages/numpy/__init__.py:792: in __getattr__
    raise AttributeError(f"module {__name__!r} has no attribute {attr!r}")
E   AttributeError: module 'numpy' has no attribute 'trapz'. Did you mean: 'trace'
```

The change line 2247-2249 in `arraymath.py` doesn't seem to be sufficient:

```
# numpy 2.0 rename np.trapz to np.trapezoid
if numpy_version >= (2, 0):
    overload(np.trapezoid)(np_trapz)
```