### PR TITLE
update version support table for `0.63.0rc1`

### DIFF
--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -16,7 +16,7 @@ Our supported platforms are:
 * Linux x86_64
 * Linux arm64/aarch-64
 * Windows 10 and later (64-bit)
-* OS X 10.9 and later (64-bit Intel and M1/Arm64)
+* OS X 11.0 and later (M1/Arm64)
 * NVIDIA GPUs of compute capability 5.0 and later
 
   * Compute capabilities 3.5 and 3.7 are supported, but deprecated.
@@ -107,8 +107,6 @@ Source archives of the latest release can also be found on
   * Linux ``x86_64``: ``gcc_linux-64`` and ``gxx_linux-64``
   * Linux ``POWER``: ``gcc_linux-ppc64le`` and ``gxx_linux-ppc64le``
   * Linux ``ARM``: no conda packages, use the system compiler
-  * Mac OSX: ``clang_osx-64`` and ``clangxx_osx-64`` or the system compiler at
-    ``/usr/bin/clang`` (Mojave onwards)
   * Mac OSX (M1): ``clang_osx-arm64`` and ``clangxx_osx-arm64``
   * Windows: a version of Visual Studio appropriate for the Python version in
     use
@@ -247,6 +245,9 @@ information.
 +----------++--------------+---------------------------+---------------------------------------------+------------------------------+-------------------+-----------------------------+
 | Numba     | Release date | Python                    | NumPy                                       | llvmlite                     | LLVM              | TBB                         |
 +===========+==============+===========================+=============================================+==============================+===================+=============================+
+| 0.63.0rc1 | 2025-11-18   | 3.10.x <= version < 3.15  | 1.22 <= version < 1.27 ;                    | 0.46.x                       | 20.x              | 2021.6 <= version           |
+|           |              |                           | 2.0 <= version < 2.4 ;                      |                              |                   |                             |
++-----------+--------------+---------------------------+---------------------------------------------+------------------------------+-------------------+-----------------------------+
 | 0.62.1    | 2025-09-26   | 3.10.x <= version < 3.14  | 1.22 <= version < 1.27 ;                    | 0.45.x                       | 20.x              | 2021.6 <= version           |
 |           |              |                           | 2.0 <= version < 2.4 ;                      |                              |                   |                             |
 +-----------+--------------+---------------------------+---------------------------------------------+------------------------------+-------------------+-----------------------------+


### PR DESCRIPTION
This updates the version support table as required by the release checklist.

- removes `osx-64` references from supported platform types and installation instructions. (conda support no longer available for `osx-64` packages)
- Updated version support table with entry for numba 0.63.0rc1.