### PR TITLE
update deprecation notice for 0.63

### DIFF
--- a/docs/source/reference/deprecation.rst
+++ b/docs/source/reference/deprecation.rst
@@ -334,7 +334,7 @@ distribution support for Intel Mac (``osx-64``) has been discontinued.
 Impact
 ------
 
-* No CI testing or binary wheels for ``osx-64`` starting with Numba 0.63.0
+* No CI testing or binary artifacts will be released for ``osx-64`` starting with Numba 0.63.0
 * Platform code remains in source tree and may continue to work
 * Bug reports and PRs for Intel Macs will not block releases
 

--- a/docs/upcoming_changes/10187.deprecation.rst
+++ b/docs/upcoming_changes/10187.deprecation.rst
@@ -4,7 +4,7 @@ Deprecation of macOS x86-64 (Intel) support
 Official support for the Intel x86_64 macOS platform (also known as osx-64)
 has been deprecated and moved to Tier 2 under the :ref:`Support Tiers
 <support_tiers>` policy. Continuous integration will no longer test this
-platform and new releases will not include binary artifacts (wheels) for osx-64.
+platform and new releases will not include binary artifacts for osx-64.
 The platform remains in the source tree and may continue to work based on
 community reports.
 


### PR DESCRIPTION
This PR adds `osx-64` deprecation notices to `deprecation.rst` and towncrier fragments.