### PR TITLE
update macos image version from `macos-13` to `macos-15` on azure ci

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ jobs:
 - template: buildscripts/azure/azure-linux-macos.yml
   parameters:
     name: macOS
-    vmImage: macos-13
+    vmImage: macos-15
     matrix:
       py310_np123:
         PYTHON: '3.10'


### PR DESCRIPTION
Azure is retiring `macos-13` image as per their policy to support n-1 version of OS images.
(https://devblogs.microsoft.com/devops/upcoming-updates-for-azure-pipelines-agents-images/#mac-os)
This PR updates azure ci to use newer `macos-15` for macos build and test.