### PR TITLE
Make calls to type names create aliasing variables.

### DIFF
--- a/docs/upcoming_changes/10350.bug_fix.rst
+++ b/docs/upcoming_changes/10350.bug_fix.rst
@@ -1,0 +1,5 @@
+Fix aliasing issue with type calls.
+-----------------------------------
+
+If a variable is used in a call to a type (constructor) then consider
+that variable and the resulting object to alias.

--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -887,17 +887,22 @@ def find_potential_aliases(blocks, args, typemap, func_ir, alias_map=None,
                     if isinstance(fmod, ir.Var) and fname in np_alias_funcs:
                         _add_alias(lhs, fmod.name, alias_map, arg_aliases)
 
-                    # If we use an arg to create a type then they alias.
-                    fmod_mod = sys.modules[fmod]
-                    fmod_obj = getattr(fmod_mod, fname)
-                    if isinstance(fmod_obj, type):
-                        for earg in expr.args:
-                            if isinstance(earg, ir.Var):
-                                _add_alias(lhs, earg.name, alias_map, arg_aliases)
-                        for earg_tup in expr.kws:
-                            _, earg = earg_tup
-                            if isinstance(earg, ir.Var):
-                                _add_alias(lhs, earg.name, alias_map, arg_aliases)
+                    # fmod isn't necessarily a module so sys.modules below
+                    # may fail and that is okay.
+                    try:
+                        # If we use an arg to create a type then they alias.
+                        fmod_mod = sys.modules[fmod]
+                        fmod_obj = getattr(fmod_mod, fname)
+                        if isinstance(fmod_obj, type):
+                            for earg in expr.args:
+                                if isinstance(earg, ir.Var):
+                                    _add_alias(lhs, earg.name, alias_map, arg_aliases)
+                            for earg_tup in expr.kws:
+                                _, earg = earg_tup
+                                if isinstance(earg, ir.Var):
+                                    _add_alias(lhs, earg.name, alias_map, arg_aliases)
+                    except Exception:
+                        pass
                     # FIX ME: Technically this should be an denylist instead
                     # of a allowlist.  Any call to potentially create an alias
                     # and we should exclude calls known not to create aliases.

--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -887,24 +887,19 @@ def find_potential_aliases(blocks, args, typemap, func_ir, alias_map=None,
                     if isinstance(fmod, ir.Var) and fname in np_alias_funcs:
                         _add_alias(lhs, fmod.name, alias_map, arg_aliases)
 
-                    # fmod isn't necessarily a module so sys.modules below
-                    # may fail and that is okay.
-                    try:
-                        # If we use an arg to create a type then they alias.
-                        fmod_mod = sys.modules[fmod]
-                        fmod_obj = getattr(fmod_mod, fname)
-                        if isinstance(fmod_obj, type):
-                            for earg in expr.args:
-                                if isinstance(earg, ir.Var):
-                                    _add_alias(lhs, earg.name, alias_map, arg_aliases)
-                            for earg_tup in expr.kws:
-                                _, earg = earg_tup
-                                if isinstance(earg, ir.Var):
-                                    _add_alias(lhs, earg.name, alias_map, arg_aliases)
-                    except Exception:
-                        pass
+                    # We can put a var in a tuple and get it out again and
+                    # so the tuple and the field inside it should be said
+                    # to alias.
+                    if isinstance(typemap[lhs], types.containers.BaseTuple):
+                        for earg in expr.args:
+                            if isinstance(earg, ir.Var):
+                                _add_alias(lhs, earg.name, alias_map, arg_aliases)
+                        for earg_tup in expr.kws:
+                            _, earg = earg_tup
+                            if isinstance(earg, ir.Var):
+                                _add_alias(lhs, earg.name, alias_map, arg_aliases)
                     # FIX ME: Technically this should be an denylist instead
-                    # of a allowlist.  Any call to potentially create an alias
+                    # of a allowlist.  Any call could potentially create an alias
                     # and we should exclude calls known not to create aliases.
 
 

--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -890,7 +890,7 @@ def find_potential_aliases(blocks, args, typemap, func_ir, alias_map=None,
                     # We can put a var in a tuple and get it out again and
                     # so the tuple and the field inside it should be said
                     # to alias.
-                    if isinstance(typemap[lhs], types.containers.BaseTuple):
+                    if typemap and isinstance(typemap[lhs], types.containers.BaseTuple):
                         for earg in expr.args:
                             if isinstance(earg, ir.Var):
                                 _add_alias(lhs, earg.name, alias_map, arg_aliases)

--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -5,6 +5,7 @@
 
 import numpy
 import math
+import sys
 
 import types as pytypes
 import collections
@@ -885,6 +886,22 @@ def find_potential_aliases(blocks, args, typemap, func_ir, alias_map=None,
                         _add_alias(lhs, expr.args[0].name, alias_map, arg_aliases)
                     if isinstance(fmod, ir.Var) and fname in np_alias_funcs:
                         _add_alias(lhs, fmod.name, alias_map, arg_aliases)
+
+                    # If we use an arg to create a type then they alias.
+                    fmod_mod = sys.modules[fmod]
+                    fmod_obj = getattr(fmod_mod, fname)
+                    if isinstance(fmod_obj, type):
+                        for earg in expr.args:
+                            if isinstance(earg, ir.Var):
+                                _add_alias(lhs, earg.name, alias_map, arg_aliases)
+                        for earg_tup in expr.kws:
+                            _, earg = earg_tup
+                            if isinstance(earg, ir.Var):
+                                _add_alias(lhs, earg.name, alias_map, arg_aliases)
+                    # FIX ME: Technically this should be an denylist instead
+                    # of a allowlist.  Any call to potentially create an alias
+                    # and we should exclude calls known not to create aliases.
+
 
     # copy to avoid changing size during iteration
     old_alias_map = copy.deepcopy(alias_map)

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -52,9 +52,6 @@ from numba.core.extending import register_jitable
 from numba.core.bytecode import _fix_LOAD_GLOBAL_arg
 from numba.core import utils
 
-from typing import NamedTuple
-from numpy.typing import NDArray
-
 import cmath
 import unittest
 
@@ -135,7 +132,7 @@ _GLOBAL_INT_FOR_TESTING1 = 17
 _GLOBAL_INT_FOR_TESTING2 = 5
 
 TestNamedTuple = namedtuple('TestNamedTuple', ('part0', 'part1'))
-issue_10338_A = NamedTuple("issue_10338_A", [("age", NDArray[np.int64]),])
+issue_10338_A = namedtuple("issue_10338_A", ("age",))
 
 
 def null_comparer(a, b):

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -52,6 +52,9 @@ from numba.core.extending import register_jitable
 from numba.core.bytecode import _fix_LOAD_GLOBAL_arg
 from numba.core import utils
 
+from typing import NamedTuple
+from numpy.typing import NDArray
+
 import cmath
 import unittest
 
@@ -132,6 +135,7 @@ _GLOBAL_INT_FOR_TESTING1 = 17
 _GLOBAL_INT_FOR_TESTING2 = 5
 
 TestNamedTuple = namedtuple('TestNamedTuple', ('part0', 'part1'))
+issue_10338_A = NamedTuple("issue_10338_A", [("age", NDArray[np.int64]),])
 
 
 def null_comparer(a, b):
@@ -252,6 +256,9 @@ class TestParforsBase(TestCase):
         parfor_args = copy_args(*args)
         parfor_output = cpfunc.entry_point(*parfor_args)
 
+        print("py_expected", py_expected)
+        print("njit", njit_output)
+        print("parfor", parfor_output)
         if check_args_for_equality is None:
             np.testing.assert_almost_equal(njit_output, py_expected, **kwargs)
             np.testing.assert_almost_equal(parfor_output, py_expected, **kwargs)
@@ -4363,14 +4370,6 @@ class TestPrangeSpecific(TestPrangeBase):
         self.prange_tester(test_impl, 1.0)
 
     def test_issue_10338(self):
-        from numpy.typing import NDArray
-        issue_10338_A = NamedTuple(
-            "A",
-            [
-                ("age", NDArray[np.int64]),
-            ]
-        )
-
         def test_impl(x, y):
             for i in range(x.age.shape[0]):
                 y.age[i] = x.age[i]

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -4362,6 +4362,24 @@ class TestPrangeSpecific(TestPrangeBase):
             return B
         self.prange_tester(test_impl, 1.0)
 
+    def test_issue_10338(self):
+        from numpy.typing import NDArray
+        issue_10338_A = NamedTuple(
+            "A",
+            [
+                ("age", NDArray[np.int64]),
+            ]
+        )
+
+        def test_impl(x, y):
+            for i in range(x.age.shape[0]):
+                y.age[i] = x.age[i]
+            return x, y
+
+        a = issue_10338_A(age=np.array([1, 2, 3]))
+        b = issue_10338_A(age=np.array([0, 0, 0]))
+        self.prange_tester(test_impl, a, b)
+
     def test_argument_alias_recarray_field(self):
         # Test for issue4007.
         def test_impl(n):


### PR DESCRIPTION
Resolves #10338.

Make calls to type creates aliases.