### PR TITLE
gha/ add version constraint for conda-libmamba-solver `<25.11`

### DIFF
--- a/.github/workflows/numba_linux-64_conda_builder.yml
+++ b/.github/workflows/numba_linux-64_conda_builder.yml
@@ -78,7 +78,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install conda-build
-        run: conda install conda-build
+        run: conda install conda-build "conda-libmamba-solver<25.11"
 
       - name: Build Numba conda package
         run: |
@@ -159,7 +159,7 @@ jobs:
 
       - name: Install conda-build
         run: |
-          conda install conda-build
+          conda install conda-build "conda-libmamba-solver<25.11"
 
       - name: Install catchsegv
         run: |

--- a/.github/workflows/numba_linux-aarch64_conda_builder.yml
+++ b/.github/workflows/numba_linux-aarch64_conda_builder.yml
@@ -78,7 +78,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install conda-build
-        run: conda install conda-build
+        run: conda install conda-build "conda-libmamba-solver<25.11"
 
       - name: Build Numba conda package
         run: |
@@ -159,7 +159,7 @@ jobs:
 
       - name: Install conda-build
         run: |
-          conda install conda-build
+          conda install conda-build "conda-libmamba-solver<25.11"
 
       - name: Install catchsegv
         run: |

--- a/.github/workflows/numba_osx-arm64_conda_builder.yml
+++ b/.github/workflows/numba_osx-arm64_conda_builder.yml
@@ -78,7 +78,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install conda-build
-        run: conda install conda-build
+        run: conda install conda-build "conda-libmamba-solver<25.11"
 
       - name: Build Numba conda package
         run: |
@@ -159,7 +159,7 @@ jobs:
 
       - name: Install conda-build
         run: |
-          conda install conda-build
+          conda install conda-build "conda-libmamba-solver<25.11"
 
       - name: Run tests
         env:


### PR DESCRIPTION
Pin `conda-libmamba-solver<25.11` in conda builder workflows to work around an issue ( https://github.com/conda/conda-libmamba-solver/issues/800) on version `25.11.0`. 
This affects conda workflows for numba, which depend on llvmlite `>=0.47.0dev0,<0.47`.