### PR TITLE
minor docs fix: `omp` requirement on macOS updated to match the text above

### DIFF
--- a/docs/source/user/threading-layer.rst
+++ b/docs/source/user/threading-layer.rst
@@ -154,8 +154,6 @@ and requirements are as follows:
 |                      | Windows   | MS OpenMP libraries (very likely this will|
 |                      |           | already exist)                            |
 |                      |           |                                           |
-|                      | OSX       | Either the ``intel-openmp`` package or the|
-|                      |           | ``llvm-openmp`` package                   |
 |                      | OSX       | The ``llvm-openmp`` package (``$ conda    |
 |                      | (arm64)   | install llvm-openmp``)                    |
 +----------------------+-----------+-------------------------------------------+


### PR DESCRIPTION
https://github.com/numba/numba/blob/9424eeeecbce5de2e2763ea338a43ccc658606fb/docs/source/user/threading-layer.rst?plain=1#L157-L159