### PR TITLE
Fix median to support nan

### DIFF
--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -347,13 +347,15 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
         pyfunc = array_median_global
 
         def variations(a):
-            # Sorted, reversed, random, many duplicates
+            # Sorted, reversed, random, many duplicates, nan
             yield a
             a = a[::-1].copy()
             yield a
             np.random.shuffle(a)
             yield a
             a[a % 4 >= 1] = 3.5
+            yield a
+            a[-1] = np.nan
             yield a
 
         self.check_median_basic(pyfunc, variations)


### PR DESCRIPTION
<!--

## Title
Fix median operator NaN input support and add test [cases](https://github.com/numba/numba/issues/10095)

## Description
Fixed the issue where the `median` operator did not support inputs containing NaN values, and added relevant test cases to cover this scenario.

In terms of algorithm implementation, I referenced the approach used in NumPy, but with an optimized adjustment:
- For imprecise floating-point data types, I traverse the array to identify NaN values and return results immediately once NaNs are detected.
- Unlike NumPy (which handles this by adding a `k` value of `-1` in the `select` function), my implementation integrates this logic directly into the `median` function. This allows me to traverse the array early and return results upfront, eliminating the need for subsequent calls to the `select` function.

I would appreciate your feedback and review comments on whether this handling approach is appropriate.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Tests added/updated
-->
