### PR TITLE
Fix median to support nan

### DIFF
--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -1577,6 +1577,8 @@ def _median_inner(temp_arry, n, supports_nans=False):
     high = n - 1
     half = n >> 1
     if supports_nans:
+        # Implementation based on NumPy
+        # https://github.com/numpy/numpy/blob/508943d1070d8f4e0712b98db2379d49304e4e38/numpy/_core/src/npysort/selection.cpp#L367-L376
         maxval = temp_arry[low]
         for k in range(low + 1, n):
             if not nan_aware_less_than(temp_arry[k], maxval):

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -355,6 +355,9 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
             yield a
             a[a % 4 >= 1] = 3.5
             yield a
+            a[0] = np.nan
+            yield a
+            a[0] = a[-1]
             a[-1] = np.nan
             yield a
 


### PR DESCRIPTION

## Title
Fix median operator NaN input support and add test. To fix the issue #10095
## Description
Fixed the issue where the `median` operator did not support inputs containing NaN values, and added relevant test cases to cover this scenario.

In terms of algorithm implementation, I referenced the approach used in NumPy, but with an optimized adjustment:
- For imprecise floating-point data types, I traverse the array to identify NaN values and return results immediately once NaNs are detected.
- Unlike NumPy (which handles this by adding a `k` value of `-1` in the `select` function), my implementation integrates this logic directly into the `median` function. This allows me to traverse the array early and return results upfront, eliminating the need for subsequent calls to the `select` function.

I would appreciate your feedback and review comments on whether this handling approach is appropriate.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Tests added/updated


