### PR TITLE
update wheel builder workflows to install pre-release llvmlite versions

### DIFF
--- a/.github/workflows/numba_linux-64_wheel_builder.yml
+++ b/.github/workflows/numba_linux-64_wheel_builder.yml
@@ -184,7 +184,7 @@ jobs:
           if [ "${{ inputs.llvmlite_wheel_runid }}" != "" ]; then
               $PYTHON_PATH -m pip install --no-cache-dir llvmlite_wheels/*.whl
           else
-              $PYTHON_PATH -m pip install --no-cache-dir -i $WHEELS_INDEX_URL llvmlite
+              $PYTHON_PATH -m pip install --no-cache-dir --pre -i $WHEELS_INDEX_URL llvmlite
           fi
           $PYTHON_PATH -m twine check dist/*.whl
 

--- a/.github/workflows/numba_linux-aarch64_wheel_builder.yml
+++ b/.github/workflows/numba_linux-aarch64_wheel_builder.yml
@@ -176,7 +176,7 @@ jobs:
           if [ "${{ inputs.llvmlite_wheel_runid }}" != "" ]; then
               $PYTHON_PATH -m pip install --no-cache-dir llvmlite_wheels/*.whl
           else
-              $PYTHON_PATH -m pip install --no-cache-dir -i $WHEELS_INDEX_URL llvmlite
+              $PYTHON_PATH -m pip install --no-cache-dir --pre -i $WHEELS_INDEX_URL llvmlite
           fi
           $PYTHON_PATH -m twine check dist/*.whl
           $PYTHON_PATH -m pip install dist/numba*.whl numpy==${{ matrix.numpy_test }} setuptools

--- a/.github/workflows/numba_osx-arm64_wheel_builder.yml
+++ b/.github/workflows/numba_osx-arm64_wheel_builder.yml
@@ -207,7 +207,7 @@ jobs:
           if [ "${{ inputs.llvmlite_wheel_runid }}" != "" ]; then
               arch -arm64 python -m pip install llvmlite_wheels/*.whl
           else
-              arch -arm64 python -m pip install -i ${{ env.WHEELS_INDEX_URL }} llvmlite
+              arch -arm64 python -m pip install --pre -i ${{ env.WHEELS_INDEX_URL }} llvmlite
           fi
           arch -arm64 python -m twine check dist/*.whl
           arch -arm64 python -m pip install dist/numba*.whl numpy==${{ matrix.numpy_test }}

--- a/.github/workflows/numba_win-64_wheel_builder.yml
+++ b/.github/workflows/numba_win-64_wheel_builder.yml
@@ -150,7 +150,7 @@ jobs:
           if [ "${{ inputs.llvmlite_wheel_runid }}" != "" ]; then
               python -m pip install llvmlite_wheels/*.whl
           else
-              python -m pip install -i ${{ env.WHEELS_INDEX_URL }} llvmlite
+              python -m pip install --pre -i ${{ env.WHEELS_INDEX_URL }} llvmlite
           fi
           python -m twine check dist/*.whl
           python -m pip install dist/*.whl


### PR DESCRIPTION
unblocks https://github.com/numba/numba/pull/10382
Test steps in wheel builder workflows fail because pip installs stable llvmlite (`0.46.0`) instead of the required pre-release version (`>=0.47.0dev0`) when installing from the index URL.

This PR adds `--pre` flag to llvmlite pip install commands in test steps across all four wheel builder workflows to allow pip to consider pre-release versions.
