### PR TITLE
Improve gitlog2changelog.py

### DIFF
--- a/maint/gitlog2changelog.py
+++ b/maint/gitlog2changelog.py
@@ -104,7 +104,7 @@ if __name__ == '__main__':
                       else repo.commit(str(c.sha)).author.name)
             assert author is not None and author != ""
             pr_authors.add(author)
-            committer = (c.committer 
+            committer = (c.committer
                          if (c.committer is not None
                              and c.committer.login != "web-flow")
                          else repo.commit(str(c.sha)).committer.name)

--- a/maint/gitlog2changelog.py
+++ b/maint/gitlog2changelog.py
@@ -3,8 +3,7 @@
 Usage:
   gitlog2changelog.py (-h | --help)
   gitlog2changelog.py --version
-  gitlog2changelog.py --token=<token> --beginning=<tag> --repo=<repo> \
-          --digits=<digits> [--summary]
+  gitlog2changelog.py --token=<token> --beginning=<tag> --repo=<repo>
 
 Options:
   -h --help          Show this screen.
@@ -12,8 +11,11 @@ Options:
   --beginning=<tag>  Where in the History to begin
   --repo=<repo>      Which repository to look at on GitHub
   --token=<token>    The GitHub token to talk to the API
-  --digits=<digits>  The number of digits to use in the issue finding regex
-  --summary          Show total count for each section
+
+Dependencies:
+  * docopt
+  * pygithub
+  * gitpython
 
 """
 
@@ -21,75 +23,102 @@ import re
 
 from git import Repo
 from docopt import docopt
-from github import Github
-
-
-ghrepo = None
-
-
-def get_pr(pr_number):
-    return ghrepo.get_pull(pr_number)
+from github import Github, Auth
 
 
 def hyperlink_user(user_obj):
-    return "`%s <%s>`_" % (user_obj.login, user_obj.html_url)
+    try:
+        return "`%s <%s>`_" % (user_obj.login, user_obj.html_url)
+    except AttributeError:
+        return user_obj
+
+
+def author_key(x):
+    return x.login.lower() if not isinstance(x, str) else x.lower()
 
 
 if __name__ == '__main__':
+
+    # Process command line arguments.
     arguments = docopt(__doc__, version='1.0')
     beginning = arguments['--beginning']
     target_ghrepo = arguments['--repo']
     github_token = arguments['--token']
-    regex_digits = arguments['--digits']
-    summary = arguments["--summary"]
-    ghrepo = Github(github_token).get_repo(target_ghrepo)
+
+    # this is an object representation of the repo on github using pygithub
+    ghrepo = Github(auth=Auth.Token(github_token)).get_repo(target_ghrepo)
+    # this is an object representation of the local git repo using gitpython
     repo = Repo('.')
-    all_commits = [x for x in repo.iter_commits(f'{beginning}..HEAD')]
-    merge_commits = [x for x in all_commits
-                     if 'Merge pull request' in x.message]
+
+    # # We obtain the merge commits for the given range by looking at the
+    # commit message. If it begins with the string "Merge pull request" it is
+    # either a true merge commit (with two parents) that originats from merging
+    # a pull-requets OR it is a cherry-picked merge-commit. Both are fine and
+    # should be included.
+    merge_commits = [x for x in repo.iter_commits(f'{beginning}..HEAD')
+                   if x.message.startswith('Merge pull request')]
+    # We use the following regular expression to extract the GitHub ID of the
+    # pull-request from the message.
     prmatch = re.compile(
-        f'^Merge pull request #([0-9]{{{regex_digits}}}) from.*')
-    ordered = {}
+        f'^Merge pull request #(\\d+) from.*')
+
+    # Then, using the list, we use the GitHub API via pygithub to obtain the
+    # corresponding `github.PullRequest` objects.
+    # `pull_requests` is a dictionary mapping pull-request ID to description:
+    # int -> string.
+    pull_requests = {}
+    for m in merge_commits:
+        match = prmatch.match(m.message)
+        if not match:
+            breakpoint()
+        number = int(match.group(1))
+        # There are very rare cases where the commit message of the merge
+        # commit created when merging a pull-request on GitHub does not include
+        # the description. In that case, we use the GitHub API to obtain that
+        # description.
+        try:
+            description = m.message.splitlines()[2]
+        except IndexError:
+            p = ghrepo.get_pull(number)
+            description = p.title
+        # Lastly, add the pull-request to the dictionary.
+        pull_requests[number] = str(description)
+
+    # Now that we have the pull-requests, we iterate through them to determine
+    # the authors involved.
     authors = set()
-    for x in merge_commits:
-        match = prmatch.match(x.message)
-        if match:
-            issue_id = match.groups()[0]
-            ordered[issue_id] = "%s" % (x.message.splitlines()[2])
     print("Pull-Requests:\n")
-    missing_authors = set()
-    for k in sorted(ordered.keys()):
-        pull = get_pr(int(k))
-        hyperlink = "`#%s <%s>`_" % (k, pull.html_url)
+    for k in sorted(pull_requests.keys()):
+        pr = ghrepo.get_pull(k)
+        hyperlink = "`#%s <%s>`_" % (k, pr.html_url)
         # get all users for all commits
         pr_authors = set()
-        for c in pull.get_commits():
-            author = c.author
-            if author:
-                pr_authors.add(c.author)
-            else:
-                missing_authors.add((pull, c))
-            if c.committer and c.committer.login != "web-flow":
-                pr_authors.add(c.committer)
-            elif not author:
-                missing_authors.add((pull, c))
-        print("* PR %s: %s (%s)" % (hyperlink, ordered[k],
+        for c in pr.get_commits():
+            # Here we need to try to get some kind of an "author" string for
+            # the given commit. The first thing we try is to get the GitHub
+            # username associated with the email address in the commit
+            # metadata. If this fails, when someone has used a 'user.email'
+            # setting that does not correspond to a known account on GitHub, we
+            # attempt to get the `user.name` setting from the commit directly.
+            # We need to convert the commit from its pygithub style object to
+            # its gitpython style object in order to access that information.
+            # We do the same for the committer.
+            author = (c.author if c.author is not None
+                      else repo.commit(str(c.sha)).author.name)
+            assert author is not None and author != ""
+            pr_authors.add(author)
+            committer = (c.committer 
+                         if (c.committer is not None
+                             and c.committer.login != "web-flow")
+                         else repo.commit(str(c.sha)).committer.name)
+            if committer != "GitHub":
+                pr_authors.add(committer)
+        print("* PR %s: %s (%s)" % (hyperlink, pull_requests[k],
                                     " ".join([hyperlink_user(u) for u in
-                                              pr_authors])))
+                                              sorted(pr_authors, key=author_key)])))
         for a in pr_authors:
             authors.add(a)
-    if missing_authors:
-        print("\n===========================WARNING=================================\n")
-        print("Following PR commits are missing authors and may need manual changes:\n")
-        for pull, commit in missing_authors:
-            print(f"* {commit} in PR #{pull.number}: {pull.title}")
-        print("\n===================================================================\n")
-    if summary:
-        print("\nTotal PRs: %s\n" % len(ordered))
-    else:
-        print()
+
+    print("")
     print("Authors:\n")
-    [print('* %s' % hyperlink_user(x)) for x in sorted(authors, key=lambda x:
-                                                       x.login.lower())]
-    if summary:
-        print("\nTotal authors: %s" % len(authors))
+    [print('* %s' % hyperlink_user(x)) for x in sorted(authors, key=author_key)]

--- a/maint/gitlog2changelog.py
+++ b/maint/gitlog2changelog.py
@@ -62,10 +62,9 @@ if __name__ == '__main__':
     prmatch = re.compile(
         f'^Merge pull request #(\\d+) from.*')
 
-    # Then, using the list, we use the GitHub API via pygithub to obtain the
-    # corresponding `github.PullRequest` objects.
-    # `pull_requests` is a dictionary mapping pull-request ID to description:
-    # int -> string.
+    # Then, using the list, we use the regular expression above to extract the
+    # ID of the pull-requests and build a dictionary mapping the Pull-Request
+    # ID to it's description.
     pull_requests = {}
     for m in merge_commits:
         match = prmatch.match(m.message)

--- a/maint/gitlog2changelog.py
+++ b/maint/gitlog2changelog.py
@@ -69,8 +69,6 @@ if __name__ == '__main__':
     pull_requests = {}
     for m in merge_commits:
         match = prmatch.match(m.message)
-        if not match:
-            breakpoint()
         number = int(match.group(1))
         # There are very rare cases where the commit message of the merge
         # commit created when merging a pull-request on GitHub does not include


### PR DESCRIPTION
The script `gitlog2changelog.py` is improved in multiple ways.

The argument `--digits` is no longer needed. A better, more general regular expression is being used.

The method to determine the "author" of a commit is improved. There is now a fallback mechanism that uses the metadata from the commit object itself if the commit can not be associated with a GitHub user.

The `--summary` argument was unused and has now been removed.

The dependencies of the script are listed in the help text for the command-line interface.

The script should now be runnable with much less human post-processing.
