### PR TITLE
Fix: NumPy2.4 CI test error

### DIFF
--- a/.github/workflows/numba_linux-64_wheel_builder.yml
+++ b/.github/workflows/numba_linux-64_wheel_builder.yml
@@ -198,17 +198,15 @@ jobs:
             NUMBA_THREADING_LAYER=tbb $PYTHON_PATH -c "import numba; numba.get_num_threads(); print(numba.threading_layer())"
           fi
 
-          # Disable NumPy dispatching to AVX512_SKX feature extensions if the chip is
-          # reported to support the feature and NumPy >= 1.22 as this results in the use
-          # of low accuracy SVML libm replacements in ufunc loops.
-          _NPY_CMD='from numba.misc import numba_sysinfo;\
-                    sysinfo=numba_sysinfo.get_sysinfo();\
-                    print(sysinfo["NumPy AVX512_SKX detected"] and
-                          sysinfo["NumPy Version"]>="1.22")'
-          NUMPY_DETECTS_AVX512_SKX_NP_GT_122=$($PYTHON_PATH -c "$_NPY_CMD")
-          echo "NumPy >= 1.22 with AVX512_SKX detected: $NUMPY_DETECTS_AVX512_SKX_NP_GT_122"
+          # Disable NumPy dispatching to AVX512_SKX if the CPU supports it AND it's
+          # in NumPy's dispatch list. This avoids low accuracy SVML libm replacements.
+          # This is needed because only dispatched features can be disabled via NPY_DISABLE_CPU_FEATURES.
+          _NPY_CMD='from numba.misc import numba_sysinfo; si=numba_sysinfo.get_sysinfo();\
+                    print(si["NumPy AVX512_SKX detected"] and "AVX512_SKX" in si.get("NumPy Supported SIMD dispatch", ()))'
+          DISABLE_AVX512_SKX=$($PYTHON_PATH -c "$_NPY_CMD")
+          echo "Disable AVX512_SKX: $DISABLE_AVX512_SKX"
 
-          if [[ "$NUMPY_DETECTS_AVX512_SKX_NP_GT_122" == "True" ]]; then
+          if [[ "$DISABLE_AVX512_SKX" == "True" ]]; then
               export NPY_DISABLE_CPU_FEATURES="AVX512_SKX"
           fi
 

--- a/.github/workflows/numba_win-64_wheel_builder.yml
+++ b/.github/workflows/numba_win-64_wheel_builder.yml
@@ -157,17 +157,15 @@ jobs:
           python -m twine check dist/*.whl
           python -m pip install dist/*.whl
 
-          # Disable NumPy dispatching to AVX512_SKX feature extensions if the chip is
-          # reported to support the feature and NumPy >= 1.22 as this results in the use
-          # of low accuracy SVML libm replacements in ufunc loops.
-          _NPY_CMD='from numba.misc import numba_sysinfo;\
-                    sysinfo=numba_sysinfo.get_sysinfo();\
-                    print(sysinfo["NumPy AVX512_SKX detected"] and
-                          sysinfo["NumPy Version"]>="1.22")'
-          NUMPY_DETECTS_AVX512_SKX_NP_GT_122=$(python -c "$_NPY_CMD")
-          echo "NumPy >= 1.22 with AVX512_SKX detected: $NUMPY_DETECTS_AVX512_SKX_NP_GT_122"
+          # Disable NumPy dispatching to AVX512_SKX if the CPU supports it AND it's
+          # in NumPy's dispatch list. This avoids low accuracy SVML libm replacements.
+          # This is needed because only dispatched features can be disabled via NPY_DISABLE_CPU_FEATURES.
+          _NPY_CMD='from numba.misc import numba_sysinfo; si=numba_sysinfo.get_sysinfo();\
+                    print(si["NumPy AVX512_SKX detected"] and "AVX512_SKX" in si.get("NumPy Supported SIMD dispatch", ()))'
+          DISABLE_AVX512_SKX=$(python -c "$_NPY_CMD")
+          echo "Disable AVX512_SKX: $DISABLE_AVX512_SKX"
 
-          if [[ "$NUMPY_DETECTS_AVX512_SKX_NP_GT_122" == "True" ]]; then
+          if [[ "$DISABLE_AVX512_SKX" == "True" ]]; then
               export NPY_DISABLE_CPU_FEATURES="AVX512_SKX"
           fi
 


### PR DESCRIPTION
This PR is to resolve errors seen on CI runs with NumPy2.4 like one here -
https://github.com/numba/numba/actions/runs/21257425799/job/61176362734

The condition to disable using `AVX512_SKX` was put in place while testing because of accuracy issues. Numpy2.4 updated the SIMD dispatch support, it no longer has `AVX512_SKX` -
```
NumPy Supported SIMD dispatch                 : ('X86_V3', 'X86_V4', 'AVX512_ICL', 'AVX512_SPR')
NumPy Supported SIMD baseline                 : ('X86_V2',)
```
and `test_no_accidental_warnings` test errors as it encounters unintended warning -
```
ImportWarning: During parsing environment variable: 'NPY_DISABLE_CPU_FEATURES':
You cannot disable CPU features (AVX512_SKX), since they are not part of the dispatched optimizations
(X86_V3 X86_V4 AVX512_ICL AVX512_SPR).
```

The fix here is to update conditional logic to disable `AVX512_SKX` based on cpu support and _**only**_ if present on numpy dispatch support list.
