### PR TITLE
Enh: refactor array reshaping in tests to use reshape method

### DIFF
--- a/numba/cuda/tests/cudapy/test_atomics.py
+++ b/numba/cuda/tests/cudapy/test_atomics.py
@@ -1272,7 +1272,7 @@ class TestCudaAtomics(CUDATestCase):
         np.random.shuffle(res)
         res = np.asarray(res, dtype=dtype)
         if ndim == 2:
-            res.shape = (10, -1)
+            res = res.reshape((10, -1))
         out = np.zeros_like(res)
         ary = np.random.randint(1, 10, size=res.shape).astype(res.dtype)
 

--- a/numba/tests/npyufunc/test_dufunc.py
+++ b/numba/tests/npyufunc/test_dufunc.py
@@ -661,7 +661,7 @@ class TestDUFuncReduceNumPyTests(TestCase):
     def test_numpy_identityless_reduction_noncontig_unaligned(self):
         a = np.empty((3 * 4 * 5 * 8 + 1,), dtype='i1')
         a = a[1:].view(dtype='f8')
-        a.shape = (3, 4, 5)
+        a = a.reshape((3, 4, 5))
         a = a[1:, 1:, 1:]
         self.check_identityless_reduction(a)
 

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -2630,7 +2630,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
 
         # check axis handling for multidimensional empty arrays
         a = np.array([])
-        a.shape = (3, 2, 1, 0)
+        a = a.reshape((3, 2, 1, 0))
 
         # include this with some other empty data structures
         for arr in a, (), np.array([]):
@@ -2649,7 +2649,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
 
         # check axis handling for multidimensional empty arrays
         a = np.array([])
-        a.shape = (3, 2, 1, 0)
+        a = a.reshape((3, 2, 1, 0))
 
         # include this with some other empty data structures
         for arr in a, (), np.array([]):


### PR DESCRIPTION
NumPy2.4 will be deprecating in-place modification of ndarray shape.
https://numpy.org/doc/stable/release/2.4.0-notes.html#in-place-modification-of-ndarray-shape-is-pending-deprecation

This PR updates tests that uses deprecating pattern with `arr.reshape()`.