### PR TITLE
Fix swapped shapes in slice assignment error message

### DIFF
--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1710,8 +1710,8 @@ def ol_raise_with_shape_context_cpu(src_shapes, index_shape):
                 index_str = f"({index_shape[0]},)"
             else:
                 index_str = f"({', '.join([str(x) for x in index_shape])})"
-            msg = (f"cannot assign slice of shape {shape_str} from input of "
-                   f"shape {index_str}")
+            msg = (f"cannot assign slice of shape {index_str} from input of "
+                   f"shape {shape_str}")
             raise ValueError(msg)
         return impl
 

--- a/numba/tests/test_indexing.py
+++ b/numba/tests/test_indexing.py
@@ -812,8 +812,8 @@ class TestSetItem(TestCase):
         if flags.get('nopython', False):
             # if in nopython mode, check the error message from Numba
             slice_size = len(arg[slice(1, -N + k, 1)])
-            msg = (f"cannot assign slice of shape ({k},) from input of shape "
-                   f"({slice_size},)")
+            msg = (f"cannot assign slice of shape ({slice_size},) from input of shape "
+                   f"({k},)")
             self.assertIn(msg, str(raises.exception))
 
     def test_1d_slicing_set_tuple(self, flags=enable_pyobj_flags):
@@ -996,8 +996,8 @@ class TestSetItem(TestCase):
         with self.assertRaises(ValueError) as raises:
             setitem_broadcast_usecase(dst, src)
         errmsg = str(raises.exception)
-        self.assertEqual(('cannot assign slice of shape (2, 5) from input of' +
-                         ' shape (1, 5)'),
+        self.assertEqual(('cannot assign slice of shape (1, 5) from input of' +
+                         ' shape (2, 5)'),
                          errmsg)
         # lower to higher
         # 1D -> 2D
@@ -1006,8 +1006,8 @@ class TestSetItem(TestCase):
         with self.assertRaises(ValueError) as raises:
             setitem_broadcast_usecase(dst, src)
         errmsg = str(raises.exception)
-        self.assertEqual(('cannot assign slice of shape (2, 4) from input of' +
-                        ' shape (2, 5)'),
+        self.assertEqual(('cannot assign slice of shape (2, 5) from input of' +
+                        ' shape (2, 4)'),
                         errmsg)
 
     def test_slicing_1d_broadcast(self):

--- a/numba/tests/test_pycc.py
+++ b/numba/tests/test_pycc.py
@@ -290,8 +290,8 @@ class TestCC(BasePYCCTest):
                 lib.do_setitem1(a, b)
 
             self.assertIn(
-                f"cannot assign slice of shape {b.shape} from "
-                f"input of shape {a.shape}",
+                f"cannot assign slice of shape {a.shape} from "
+                f"input of shape {b.shape}",
                 str(raises.exception))
 
             a = np.zeros((4, 6), dtype=np.float64)
@@ -300,8 +300,8 @@ class TestCC(BasePYCCTest):
                 lib.do_setitem2(a, b)
 
             self.assertIn(
-                f"cannot assign slice of shape {b.shape} from "
-                f"input of shape {a.shape}",
+                f"cannot assign slice of shape {a.shape} from "
+                f"input of shape {b.shape}",
                 str(raises.exception))
 
 


### PR DESCRIPTION
## Summary
- Fixes the error message in `raise_with_shape_context` where the shape values were swapped
- The message was incorrectly reporting "cannot assign slice of shape <source> from input of shape <destination>"
- Now correctly reports "cannot assign slice of shape <destination> from input of shape <source>"
- Updated corresponding tests in `test_indexing.py` and `test_pycc.py`

## Test plan
- [ ] Run `numba.tests.test_indexing.TestSetItem.test_setitem_broadcast_error`
- [ ] Run `numba.tests.test_indexing.TestSetItem.check_1d_slicing_set_sequence`
- [ ] Run `numba.tests.test_pycc.TestCC` (requires external compiler)
- [ ] Verify error message matches NumPy semantics: "slice" = destination, "input" = source

Fixes #10402

---
> [!NOTE]
> This PR was created with AI assistance using Claude (claude-opus-4-5).

Generated with [Claude Code](https://claude.ai/claude-code)