### PR TITLE
Add support for Fancy Indexing in Numba

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -162,7 +162,7 @@ or layout.
    are not supported.
 
 
-.. _.. _structured-array-access::
+.. _array-access:
 
 Array access
 ------------

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -162,6 +162,8 @@ or layout.
    are not supported.
 
 
+.. _.. _structured-array-access::
+
 Array access
 ------------
 
@@ -206,7 +208,7 @@ exceed the number of dimensions in the array being indexed as well as the indice
 to a common shape.
 
 .. seealso::
-   `NumPy indexing <http://docs.scipy.org/doc/numpy/reference/arrays.indexing.html>`_
+   `NumPy indexing <https://numpy.org/doc/stable/user/basics.indexing.html>`_
    reference.
 
 .. note::

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -213,6 +213,8 @@ to a common shape.
   Because of the way Numba logic is implemented, fancy indexing with multiple array indices
   and/or multidimensional array indices can be slower than expected. This is currently being
   investigated and optimized, but users should be aware of this when using these features.
+  
+.. _structured-array-access:
 
 Structured array access
 -----------------------

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -167,17 +167,52 @@ Array access
 
 Arrays support normal iteration.  Full basic indexing and slicing is
 supported along with passing ``None`` / ``np.newaxis`` as indices for
-additional resulting dimensions. A subset of advanced indexing is also
-supported: only one advanced index is allowed, and it has to be a
-one-dimensional array (it can be combined with an arbitrary number
-of basic indices as well).
+additional resulting dimensions.
+
+Fancy indexing with multiple array indices and/or multidimensional 
+array indices is also supported in accordance with NumPy semantics.
+An example of this is as follows:
+
+.. code:: python
+
+    import numba
+    import numpy as np
+
+    @numba.njit
+    def non_shifted_subspace(x, idx, idx2):
+        return x[:, idx, idx2, :] # Consecutive fancy indices (idx, idx2) are adjacent.
+
+    @numba.njit
+    def shifted_subspace(x, idx, idx2):
+        return x[:, idx, :, idx2] # Non-consecutive fancy indices (idx, idx2) are separated by a slice.
+
+    a = np.random.randint(0, 100, (10, 11, 12, 13, 14))
+    b = np.random.randint(0, 4, (4, 5))  # Now supports multidimensional indices
+    c = np.random.randint(0, 4, (4, 5))  # Now supports multiple array indices
+
+    print(non_shifted_subspace(a, b, c).shape) 
+    # Output: (10, 4, 5, 13, 14) - Notice subspace (4, 5) is correctly indexed at position 1
+    print(np.allclose(non_shifted_subspace(a, b, c), non_shifted_subspace.py_func(a, b, c)))
+    # Output: True
+
+    print(shifted_subspace(a, b, c).shape) 
+    # Output: (4, 5, 10, 13, 14) - Notice subspace (4, 5) is correctly indexed at position 0
+    print(np.allclose(shifted_subspace(a, b, c), shifted_subspace.py_func(a, b, c)))
+    # Output: True
+
+Resrictions on the indices are the same as in NumPy, meaning that the indices must be within bounds of
+the array dimensions and must be of integer type. Additionally, the number of fancy indices must not
+exceed the number of dimensions in the array being indexed as well as the indices must be broadcastable
+to a common shape.
 
 .. seealso::
    `NumPy indexing <http://docs.scipy.org/doc/numpy/reference/arrays.indexing.html>`_
    reference.
 
-
-.. _structured-array-access:
+.. note::
+  Because of the way Numba logic is implemented, fancy indexing with multiple array indices
+  and/or multidimensional array indices can be slower than expected. This is currently being
+  investigated and optimized, but users should be aware of this when using these features.
 
 Structured array access
 -----------------------

--- a/docs/upcoming_changes/10432.highlight.rst
+++ b/docs/upcoming_changes/10432.highlight.rst
@@ -1,0 +1,4 @@
+Add support for Fancy Indexing in Numba
+---------------------------------------
+
+Support ``a[(idx_a, idx_b)]`` type fancy indexing, including for multidimensional arrays.

--- a/docs/upcoming_changes/10432.highlight.rst
+++ b/docs/upcoming_changes/10432.highlight.rst
@@ -7,36 +7,5 @@ such as using multiple fancy indices simultaneously or using multidimensional fa
 arrays, are now fully supported along with inclusion of ``None`` / ``np.newaxis`` for
 additional resulting dimensions.
 
-Example usage is as follows:
+For more details, and example usage see the ::ref::`Numba documentation <https://numba.readthedocs.io/en/stable/reference/numpysupported.html#array-access>`.
 
-.. code-block:: python
-
-    import numba
-    import numpy as np
-
-    @numba.njit
-    def non_shifted_subspace(x, idx, idx2):
-        return x[:, idx, idx2, :] # Consecutive fancy indices (idx, idx2) are adjacent.
-
-    @numba.njit
-    def shifted_subspace(x, idx, idx2):
-        return x[:, idx, :, idx2] # Non-consecutive fancy indices (idx, idx2) are separated by a slice.
-
-    a = np.random.randint(0, 100, (10, 11, 12, 13, 14))
-    b = np.random.randint(0, 4, (4, 5))  # Now supports multidimensional indices
-    c = np.random.randint(0, 4, (4, 5))  # Now supports multiple array indices
-
-    print(non_shifted_subspace(a, b, c).shape) 
-    # Output: (10, 4, 5, 13, 14) - Notice subspace (4, 5) is correctly indexed at position 1
-    print(np.allclose(non_shifted_subspace(a, b, c), non_shifted_subspace.py_func(a, b, c)))
-    # Output: True
-
-    print(shifted_subspace(a, b, c).shape) 
-    # Output: (4, 5, 10, 13, 14) - Notice subspace (4, 5) is correctly indexed at position 0
-    print(np.allclose(shifted_subspace(a, b, c), shifted_subspace.py_func(a, b, c)))
-    # Output: True
-
-Resrictions on the indices are the same as in NumPy, meaning that the indices must be within bounds of
-the array dimensions and must be of integer type. Additionally, the number of fancy indices must not
-exceed the number of dimensions in the array being indexed as well as the indices must be broadcastable
-to a common shape.

--- a/docs/upcoming_changes/10432.highlight.rst
+++ b/docs/upcoming_changes/10432.highlight.rst
@@ -1,4 +1,42 @@
-Add support for Fancy Indexing in Numba
----------------------------------------
+Add support for Fancy Indexing with Multiple Multi-Dimensional Array Indices in Numba
+-------------------------------------------------------------------------------------
 
-Support ``a[(idx_a, idx_b)]`` type fancy indexing, including for multidimensional arrays.
+This PR adds complete support for fancy indexing with multiple array indices and/or multidimensional
+array indices, in accordance with NumPy semantics. Cases that were previously unsupported,
+such as using multiple fancy indices simultaneously or using multidimensional fancy index
+arrays, are now fully supported along with inclusion of ``None`` / ``np.newaxis`` for
+additional resulting dimensions.
+
+Example usage is as follows:
+
+.. code-block:: python
+
+    import numba
+    import numpy as np
+
+    @numba.njit
+    def non_shifted_subspace(x, idx, idx2):
+        return x[:, idx, idx2, :] # Consecutive fancy indices (idx, idx2) are adjacent.
+
+    @numba.njit
+    def shifted_subspace(x, idx, idx2):
+        return x[:, idx, :, idx2] # Non-consecutive fancy indices (idx, idx2) are separated by a slice.
+
+    a = np.random.randint(0, 100, (10, 11, 12, 13, 14))
+    b = np.random.randint(0, 4, (4, 5))  # Now supports multidimensional indices
+    c = np.random.randint(0, 4, (4, 5))  # Now supports multiple array indices
+
+    print(non_shifted_subspace(a, b, c).shape) 
+    # Output: (10, 4, 5, 13, 14) - Notice subspace (4, 5) is correctly indexed at position 1
+    print(np.allclose(non_shifted_subspace(a, b, c), non_shifted_subspace.py_func(a, b, c)))
+    # Output: True
+
+    print(shifted_subspace(a, b, c).shape) 
+    # Output: (4, 5, 10, 13, 14) - Notice subspace (4, 5) is correctly indexed at position 0
+    print(np.allclose(shifted_subspace(a, b, c), shifted_subspace.py_func(a, b, c)))
+    # Output: True
+
+Resrictions on the indices are the same as in NumPy, meaning that the indices must be within bounds of
+the array dimensions and must be of integer type. Additionally, the number of fancy indices must not
+exceed the number of dimensions in the array being indexed as well as the indices must be broadcastable
+to a common shape.

--- a/numba/core/typing/arraydecl.py
+++ b/numba/core/typing/arraydecl.py
@@ -87,9 +87,7 @@ def get_array_index_type(ary, idx):
         elif (isinstance(ty, types.Array)
               and isinstance(ty.dtype, (types.Integer, types.Boolean))):
             if ty.ndim > 1:
-                # Advanced indexing limitation # 1
-                raise NumbaTypeError(
-                    "Multi-dimensional indices are not supported.")
+                ndim += ty.ndim - 1
             array_indices += 1
             # The condition for activating advanced indexing is simply
             # having at least one array with size > 1.

--- a/numba/core/typing/arraydecl.py
+++ b/numba/core/typing/arraydecl.py
@@ -46,7 +46,7 @@ def get_array_index_type(ary, idx):
     # contiguous groups.
     in_subspace = False
     num_subspaces = 0
-    array_indices = 0
+    array_indices = []
 
     # Walk indices
     for ty in idx:
@@ -86,12 +86,9 @@ def get_array_index_type(ary, idx):
                 in_subspace = True
         elif (isinstance(ty, types.Array)
               and isinstance(ty.dtype, (types.Integer, types.Boolean))):
-            if ty.ndim > 1:
-                ndim += ty.ndim - 1
-            array_indices += 1
-            # The condition for activating advanced indexing is simply
-            # having at least one array with size > 1.
+            array_indices.append(ty.ndim)
             advanced = True
+            ndim -= 1
             if not in_subspace:
                 num_subspaces += 1
                 in_subspace = True
@@ -104,11 +101,7 @@ def get_array_index_type(ary, idx):
         (right_indices if ellipsis_met else left_indices).append(ty)
 
     if advanced:
-        if array_indices > 1:
-            # Advanced indexing limitation # 2
-            msg = "Using more than one non-scalar array index is unsupported."
-            raise NumbaTypeError(msg)
-
+        ndim += max(array_indices)
         if num_subspaces > 1:
             # Advanced indexing limitation # 3
             msg = ("Using more than one indexing subspace is unsupported."

--- a/numba/core/typing/arraydecl.py
+++ b/numba/core/typing/arraydecl.py
@@ -102,12 +102,6 @@ def get_array_index_type(ary, idx):
 
     if advanced:
         ndim += max(array_indices)
-        if num_subspaces > 1:
-            # Advanced indexing limitation # 3
-            msg = ("Using more than one indexing subspace is unsupported."
-                   " An indexing subspace is a group of one or more"
-                   " consecutive indices comprising integer or array types.")
-            raise NumbaTypeError(msg)
 
     # Only Numpy arrays support advanced indexing
     if advanced and not isinstance(ary, types.Array):

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1138,22 +1138,23 @@ class FancyIndexer(object):
         num_subspaces = 0
         in_subspace = False
         subspace_index = None
-        for idx, i in enumerate(indexers):
-            if isinstance(i, (IntegerArrayIndexer, IntegerIndexer)):
-                if in_subspace == False:
-                    in_subspace = True
-                    num_subspaces += 1
-                if subspace_index is None:
-                    subspace_index = idx
-            else:
-                if in_subspace == True:
-                    in_subspace = False
-        
-        if num_subspaces:
-            if num_subspaces > 1:
-                subspace_index = 0
+        if any([isinstance(i, IntegerArrayIndexer) for i in indexers]):
+            for idx, i in enumerate(indexers):
+                if isinstance(i, (IntegerArrayIndexer, IntegerIndexer)):
+                    if in_subspace == False:
+                        in_subspace = True
+                        num_subspaces += 1
+                    if subspace_index is None:
+                        subspace_index = idx
+                else:
+                    if in_subspace == True:
+                        in_subspace = False
+            
+            if num_subspaces:
+                if num_subspaces > 1:
+                    subspace_index = 0
 
-            indexers.insert(subspace_index, self.subspace_indexer)
+                indexers.insert(subspace_index, self.subspace_indexer)
 
         self.subspace_index = subspace_index
         self.indexers = indexers

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -799,9 +799,11 @@ class IntegerArrayIndexer(Indexer):
     Compute indices from an array of integer indices.
     """
 
-    def __init__(self, context, builder, idxty, idxary, size):
+    def __init__(self, context, builder, idxty, idxary, size, subspace_allocated, global_ary_idx):
         self.context = context
         self.builder = builder
+        self.subspace_allocated = subspace_allocated
+        self.global_ary_idx = global_ary_idx
 
         self.idx_shape = cgutils.unpack_tuple(builder, idxary.shape)
         self.size = size
@@ -839,7 +841,6 @@ class IntegerArrayIndexer(Indexer):
         self.idx_size = self.ll_intp(1)
         for _shape in self.idx_shape:
             self.idx_size = self.builder.mul(self.idx_size, _shape)
-        self.idx_index = cgutils.alloca_once(builder, self.ll_intp)
         self.bb_start = builder.append_basic_block()
         self.bb_end = builder.append_basic_block()
 
@@ -856,15 +857,15 @@ class IntegerArrayIndexer(Indexer):
     def loop_head(self):
         builder = self.builder
         # Initialize loop variable
-        self.builder.store(Constant(self.ll_intp, 0), self.idx_index)
         builder.branch(self.bb_start)
         builder.position_at_end(self.bb_start)
-        cur_index = builder.load(self.idx_index)
-        with builder.if_then(
-            builder.icmp_signed('>=', cur_index, self.idx_size),
-            likely=False
-        ):
-            builder.branch(self.bb_end)
+        cur_index = builder.load(self.global_ary_idx)
+        if not self.subspace_allocated:
+            with builder.if_then(
+                builder.icmp_signed('>=', cur_index, self.idx_size),
+                likely=False
+            ):
+                builder.branch(self.bb_end)
         # Load the actual index from the array of indices
         index = _getitem_array_single_int(
             self.context, builder, self.idxty.dtype, self.idxty, self.idxary,
@@ -876,10 +877,13 @@ class IntegerArrayIndexer(Indexer):
 
     def loop_tail(self):
         builder = self.builder
-        next_index = cgutils.increment_index(builder,
-                                             builder.load(self.idx_index))
-        builder.store(next_index, self.idx_index)
-        builder.branch(self.bb_start)
+        if not self.subspace_allocated:
+            next_index = cgutils.increment_index(builder,
+                                                builder.load(self.global_ary_idx))
+            builder.store(next_index, self.global_ary_idx)
+            builder.branch(self.bb_start)
+        else:
+            builder.branch(self.bb_end)
         builder.position_at_end(self.bb_end)
 
 
@@ -1027,20 +1031,21 @@ class FancyIndexer(object):
     Perform fancy indexing on the given array.
     """
 
-    def __init__(self, context, builder, aryty, ary, index_types, indices):
+    def __init__(self, context, builder, aryty, ary, index_types, indices, subspace_shape_tuple):
         self.context = context
         self.builder = builder
         self.aryty = aryty
         self.shapes = cgutils.unpack_tuple(builder, ary.shape, aryty.ndim)
         self.strides = cgutils.unpack_tuple(builder, ary.strides, aryty.ndim)
         self.ll_intp = self.context.get_value_type(types.intp)
-        self.newaxes = []
-
+        self.subspace_shape = subspace_shape_tuple
+        self.global_ary_idx = cgutils.alloca_once(builder, self.ll_intp)
+        self.builder.store(Constant(self.ll_intp, 0), self.global_ary_idx)
         indexers = []
         num_newaxes = len([idx for idx in index_types if is_nonelike(idx)])
 
-        ax = 0 # keeps track of position of original axes
-        new_ax = 0 # keeps track of position for inserting new axes
+        ax = 0
+        subspace_allocated=False
         for indexval, idxty in zip(indices, index_types):
             if idxty is types.ellipsis:
                 # Fill up missing dimensions at the middle
@@ -1068,7 +1073,10 @@ class FancyIndexer(object):
                 if isinstance(idxty.dtype, types.Integer):
                     indexer = IntegerArrayIndexer(context, builder,
                                                   idxty, idxary,
-                                                  self.shapes[ax])
+                                                  self.shapes[ax],
+                                                  subspace_allocated,
+                                                  self.global_ary_idx)
+                    subspace_allocated = True
                 elif isinstance(idxty.dtype, types.Boolean):
                     indexer = BooleanArrayIndexer(context, builder,
                                                   idxty, idxary)
@@ -1096,20 +1104,18 @@ class FancyIndexer(object):
     def prepare(self):
         for i in self.indexers:
             i.prepare()
-
-        one = self.context.get_constant(types.intp, 1)
-
-        # Compute the resulting shape given by the indices
-        res_shape = [i.get_shape() for i in self.indexers]
-
-        # At every position where newaxis/None is present insert
-        # one as a constant shape in the resulting list of shapes.
-        for i in self.newaxes:
-            res_shape.insert(i, (one,))
-
-        # Store the shape as a tuple, we can't do a simple
-        # tuple(res_shape) here since res_shape is a list
-        # of tuples which may be differently sized.
+        # Compute the resulting shape
+        res_shape = []
+        subspace_added=False
+        for i in self.indexers:
+            # Shape of subspace i.e. cumulative shape of indexing
+            # arrays only needs to be considered once
+            if isinstance(i, IntegerArrayIndexer):
+                if not subspace_added:
+                    res_shape.append(self.subspace_shape)
+                    subspace_added = True
+            else:
+                res_shape.append(i.get_shape())
         self.indexers_shape = sum(res_shape, ())
 
     def get_shape(self):
@@ -1165,6 +1171,32 @@ class FancyIndexer(object):
             i.loop_tail()
 
 
+def get_bdcast_idx(context, builder, array_indices):
+    max_dims = max([ary[2].ndim for ary in array_indices])
+
+    def bdcast_idx_shapes(*args):
+        return np.broadcast_shapes(*args)
+    
+    inpty = types.StarArgTuple(tuple(types.UniTuple(types.intp, count=ary_idx[2].ndim) for ary_idx in array_indices))
+    retty = types.UniTuple(types.intp, count=max_dims)
+    subspace_shape = context.compile_internal(builder, bdcast_idx_shapes, signature(retty, inpty),
+                                                (cgutils.pack_struct(builder, tuple([ary_idx[3].shape for ary_idx in array_indices])),))
+
+    bdcast_indices = []
+    
+    def bdcast_array(ary, shape):
+        return np.broadcast_to(ary, shape)
+    
+    for i, idx, idxty, _ in array_indices:
+        inpty = (idxty, types.UniTuple(types.intp, count=max_dims))
+        retty = types.Array(idxty.dtype, max_dims, 'A', readonly=True)
+        bdcast_idx = context.compile_internal(builder, bdcast_array, signature(retty, *inpty),
+                                                (idx, subspace_shape))
+        bdcast_indices.append((i, bdcast_idx, retty))
+    subspace_shape = tuple(cgutils.unpack_tuple(builder, subspace_shape))
+    return bdcast_indices, subspace_shape
+
+
 def fancy_getitem(context, builder, sig, args,
                   aryty, ary, index_types, indices):
 
@@ -1172,8 +1204,24 @@ def fancy_getitem(context, builder, sig, args,
     strides = cgutils.unpack_tuple(builder, ary.strides)
     data = ary.data
 
+    array_indices = []
+    for i, idxty in enumerate(index_types):
+        idx = indices[i]
+        if isinstance(idxty, types.Array):
+            idx_make = make_array(idxty)(context, builder, idx)
+            array_indices.append((i, idx, idxty, idx_make))
+
+    bdcast_indices, subspace_shape_tuple = \
+        get_bdcast_idx(context, builder, array_indices)
+
+    indices = list(indices)
+    index_types = list(index_types)
+    for i, bdcast_idx, bdcast_idxty in bdcast_indices:
+        indices[i] = bdcast_idx
+        index_types[i] = bdcast_idxty
+
     indexer = FancyIndexer(context, builder, aryty, ary,
-                           index_types, indices)
+                           index_types, indices, subspace_shape_tuple)
     indexer.prepare()
 
     # Construct output array

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1045,7 +1045,9 @@ class FancyIndexer(object):
         indexers = []
         num_newaxes = len([idx for idx in index_types if is_nonelike(idx)])
 
-        ax = 0
+        ax = 0 # keeps track of position of original axes
+        new_ax = 0 # keeps track of position for inserting new axes
+
         subspace_allocated=False
         for indexval, idxty in zip(indices, index_types):
             if idxty is types.ellipsis:

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -805,15 +805,33 @@ class IntegerArrayIndexer(Indexer):
     def __init__(self, context, builder, idxty, idxary, size):
         self.context = context
         self.builder = builder
-        self.idxty = idxty
-        self.idxary = idxary
+
+        self.idx_shape = cgutils.unpack_tuple(builder, idxary.shape)
         self.size = size
-        assert idxty.ndim == 1
         self.ll_intp = self.context.get_value_type(types.intp)
+
+        if idxty.ndim > 1:
+            def flat_imp(ary):
+                # TODO: Make sure this operation is being done in-place
+                return ary.reshape(ary.size)
+
+            retty = types.Array(idxty.dtype, 1, idxty.layout, readonly=True)
+            sig = signature(retty, idxty)
+            res = context.compile_internal(builder, flat_imp, sig,
+                                           (idxary._getvalue(),))
+            self.idxty = retty
+            self.idxary = make_array(retty)(context, builder, res)
+        else:
+            self.idxty = idxty
+            self.idxary = idxary
+
+        assert self.idxty.ndim == 1
 
     def prepare(self):
         builder = self.builder
-        self.idx_size = cgutils.unpack_tuple(builder, self.idxary.shape)[0]
+        self.idx_size = self.ll_intp(1)
+        for _shape in self.idx_shape:
+            self.idx_size = self.builder.mul(self.idx_size, _shape)
         self.idx_index = cgutils.alloca_once(builder, self.ll_intp)
         self.bb_start = builder.append_basic_block()
         self.bb_end = builder.append_basic_block()
@@ -822,7 +840,7 @@ class IntegerArrayIndexer(Indexer):
         return self.idx_size
 
     def get_shape(self):
-        return (self.idx_size,)
+        return tuple(self.idx_shape)
 
     def get_index_bounds(self):
         # Pessimal heuristic, as we don't want to scan for the min and max

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -700,12 +700,9 @@ class Indexer(object):
 
     def loop_head(self):
         """
-        Start indexation loop.  Return a (index, count) tuple.
+        Start indexation loop.  Returns a index.
         *index* is an integer LLVM value representing the index over this
         dimension.
-        *count* is either an integer LLVM value representing the current
-        iteration count, or None if this dimension should be omitted from
-        the indexation result.
         """
         raise NotImplementedError
 
@@ -756,7 +753,7 @@ class EntireIndexer(Indexer):
         with builder.if_then(builder.icmp_signed('>=', cur_index, self.size),
                              likely=False):
             builder.branch(self.bb_end)
-        return cur_index, cur_index
+        return cur_index
 
     def loop_tail(self):
         builder = self.builder
@@ -791,7 +788,7 @@ class IntegerIndexer(Indexer):
         return (self.idx, self.builder.add(self.idx, self.get_size()))
 
     def loop_head(self):
-        return self.idx, None
+        return self.idx
 
     def loop_tail(self):
         pass
@@ -811,9 +808,19 @@ class IntegerArrayIndexer(Indexer):
         self.ll_intp = self.context.get_value_type(types.intp)
 
         if idxty.ndim > 1:
-            def flat_imp(ary):
-                # TODO: Make sure this operation is being done in-place
+            def flat_imp_nocopy(ary):
                 return ary.reshape(ary.size)
+
+            def flat_imp_copy(ary):
+                return ary.copy().reshape(ary.size)
+
+            # If the index array is contigous, use the nocopy version
+            if idxty.is_contig:
+                flat_imp = flat_imp_nocopy
+            # otherwise, use copy version since we don't support
+            # reshaping non-contigous arrays
+            else:
+                flat_imp = flat_imp_copy
 
             retty = types.Array(idxty.dtype, 1, idxty.layout, readonly=True)
             sig = signature(retty, idxty)
@@ -865,7 +872,7 @@ class IntegerArrayIndexer(Indexer):
         )
         index = fix_integer_index(self.context, builder,
                                   self.idxty.dtype, index, self.size)
-        return index, cur_index
+        return index
 
     def loop_tail(self):
         builder = self.builder
@@ -894,7 +901,6 @@ class BooleanArrayIndexer(Indexer):
         builder = self.builder
         self.size = cgutils.unpack_tuple(builder, self.idxary.shape)[0]
         self.idx_index = cgutils.alloca_once(builder, self.ll_intp)
-        self.count = cgutils.alloca_once(builder, self.ll_intp)
         self.bb_start = builder.append_basic_block()
         self.bb_tail = builder.append_basic_block()
         self.bb_end = builder.append_basic_block()
@@ -926,11 +932,9 @@ class BooleanArrayIndexer(Indexer):
         builder = self.builder
         # Initialize loop variable
         self.builder.store(self.zero, self.idx_index)
-        self.builder.store(self.zero, self.count)
         builder.branch(self.bb_start)
         builder.position_at_end(self.bb_start)
         cur_index = builder.load(self.idx_index)
-        cur_count = builder.load(self.count)
         with builder.if_then(builder.icmp_signed('>=', cur_index, self.size),
                              likely=False):
             builder.branch(self.bb_end)
@@ -941,10 +945,7 @@ class BooleanArrayIndexer(Indexer):
         )
         with builder.if_then(builder.not_(pred)):
             builder.branch(self.bb_tail)
-        # Increment the count for next iteration
-        next_count = cgutils.increment_index(builder, cur_count)
-        builder.store(next_count, self.count)
-        return cur_index, cur_count
+        return cur_index
 
     def loop_tail(self):
         builder = self.builder
@@ -983,7 +984,6 @@ class SliceIndexer(Indexer):
         self.is_step_negative = cgutils.is_neg_int(builder, self.slice.step)
         # Create loop entities
         self.index = cgutils.alloca_once(builder, self.ll_intp)
-        self.count = cgutils.alloca_once(builder, self.ll_intp)
         self.bb_start = builder.append_basic_block()
         self.bb_end = builder.append_basic_block()
 
@@ -1001,11 +1001,9 @@ class SliceIndexer(Indexer):
         builder = self.builder
         # Initialize loop variable
         self.builder.store(self.slice.start, self.index)
-        self.builder.store(self.zero, self.count)
         builder.branch(self.bb_start)
         builder.position_at_end(self.bb_start)
         cur_index = builder.load(self.index)
-        cur_count = builder.load(self.count)
         is_finished = builder.select(self.is_step_negative,
                                      builder.icmp_signed('<=', cur_index,
                                                          self.slice.stop),
@@ -1013,15 +1011,13 @@ class SliceIndexer(Indexer):
                                                          self.slice.stop))
         with builder.if_then(is_finished, likely=False):
             builder.branch(self.bb_end)
-        return cur_index, cur_count
+        return cur_index
 
     def loop_tail(self):
         builder = self.builder
         next_index = builder.add(builder.load(self.index), self.slice.step,
                                  flags=['nsw'])
         builder.store(next_index, self.index)
-        next_count = cgutils.increment_index(builder, builder.load(self.count))
-        builder.store(next_count, self.count)
         builder.branch(self.bb_start)
         builder.position_at_end(self.bb_end)
 
@@ -1161,8 +1157,8 @@ class FancyIndexer(object):
         return lower, upper
 
     def begin_loops(self):
-        indices, counts = zip(*(i.loop_head() for i in self.indexers))
-        return indices, counts
+        indices = tuple(i.loop_head() for i in self.indexers)
+        return indices
 
     def end_loops(self):
         for i in reversed(self.indexers):
@@ -1190,7 +1186,7 @@ def fancy_getitem(context, builder, sig, args,
                                         context.get_constant(types.intp, 0))
 
     # Loop on source and copy to destination
-    indices, _ = indexer.begin_loops()
+    indices = indexer.begin_loops()
 
     # No need to check for wraparound, as the indexers all ensure
     # a positive index is returned.
@@ -1779,7 +1775,6 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
         srcty, src = _broadcast_to_shape(context, builder, srcty, src,
                                          index_shape)
         src_shapes = cgutils.unpack_tuple(builder, src.shape)
-        src_strides = cgutils.unpack_tuple(builder, src.strides)
         src_data = src.data
 
         # Check shapes are equal
@@ -1794,24 +1789,6 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
             raise_shape_mismatch_error(context, builder, src_shapes,
                                        index_shape)
 
-        # Check for array overlap
-        src_start, src_end = get_array_memory_extents(context, builder, srcty,
-                                                      src, src_shapes,
-                                                      src_strides, src_data)
-
-        dest_lower, dest_upper = indexer.get_offset_bounds(dest_strides,
-                                                           ary.itemsize)
-        dest_start, dest_end = compute_memory_extents(context, builder,
-                                                      dest_lower, dest_upper,
-                                                      dest_data)
-
-        use_copy = extents_may_overlap(context, builder, src_start, src_end,
-                                       dest_start, dest_end)
-
-        src_getitem, src_cleanup = maybe_copy_source(context, builder, use_copy,
-                                                     srcty, src, src_shapes,
-                                                     src_strides, src_data)
-
     elif isinstance(srcty, types.Sequence):
         src_dtype = srcty.dtype
 
@@ -1824,67 +1801,56 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
         shape_error = builder.icmp_signed('!=', index_shape[0], seq_len)
 
         with builder.if_then(shape_error, likely=False):
-            raise_shape_mismatch_error(context, builder, (seq_len,),
-                                       (index_shape[0],))
-
-        def src_getitem(source_indices):
-            idx, = source_indices
-            getitem_impl = context.get_function(
-                operator.getitem,
-                signature(src_dtype, srcty, types.intp),
-            )
-            return getitem_impl(builder, (src, idx))
-
-        def src_cleanup():
-            pass
-
+            msg = "cannot assign slice from input of different size"
+            context.call_conv.return_user_exc(builder, ValueError, (msg,))
     else:
         # Source is a scalar (broadcast or not, depending on destination
         # shape).
         src_dtype = srcty
 
-        def src_getitem(source_indices):
-            return src
+    def flat_imp_nocopy(ary):
+        return ary.reshape(ary.size)
 
-        def src_cleanup():
-            pass
+    def flat_imp_copy(ary):
+        return ary.copy().reshape(ary.size)
 
-    zero = context.get_constant(types.uintp, 0)
+    # If the source array is contigous, use the nocopy version
+    if srcty.is_contig:
+        flat_imp = flat_imp_nocopy
+    # otherwise, use copy version since we don't support
+    # reshaping non-contigous arrays
+    else:
+        flat_imp = flat_imp_copy
+
+    retty = types.Array(srcty.dtype, 1, srcty.layout, readonly=True)
+    sig = signature(retty, srcty)
+    src_flat_instr = context.compile_internal(builder, flat_imp, sig,
+                                              (src._getvalue(),))
+    src_flat = make_array(retty)(context, builder, src_flat_instr)
+    src_data = src_flat.data
+    src_idx = cgutils.alloca_once_value(builder,
+                                        context.get_constant(types.intp, 0))
     # Loop on destination and copy from source to destination
-    dest_indices, counts = indexer.begin_loops()
-
-    # Source is iterated in natural order
-
-    # Counts represent a counter for the number of times a specified axis
-    # is being accessed, during setitem they are used as source
-    # indices
-    counts = list(counts)
-
-    # We need to artifically introduce the index zero wherever a
-    # newaxis is present within the indexer. These always remain
-    # zero.
-    for i in indexer.newaxes:
-        counts.insert(i, zero)
-
-    source_indices = [c for c in counts if c is not None]
-
-    val = src_getitem(source_indices)
-
-    # Cast to the destination dtype (cross-dtype slice assignment is allowed)
-    val = context.cast(builder, val, src_dtype, aryty.dtype)
+    dest_indices = indexer.begin_loops()
 
     # No need to check for wraparound, as the indexers all ensure
     # a positive index is returned.
     dest_ptr = cgutils.get_item_pointer2(context, builder, dest_data,
                                          dest_shapes, dest_strides,
                                          aryty.layout, dest_indices,
-                                         wraparound=False,
-                                         boundscheck=context.enable_boundscheck)
+                                         wraparound=False)
+
+    cur = builder.load(src_idx)
+    ptr = builder.gep(src_data, [cur])
+    val = builder.load(ptr)
+    val = context.cast(builder, val, src_dtype, aryty.dtype)
     store_item(context, builder, aryty, val, dest_ptr)
+    next_idx = cgutils.increment_index(builder, cur)
+    builder.store(next_idx, src_idx)
 
     indexer.end_loops()
 
-    src_cleanup()
+    context.nrt.decref(builder, retty, src_flat_instr)
 
     return context.get_dummy_value()
 

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1139,7 +1139,7 @@ class FancyIndexer(object):
         in_subspace = False
         subspace_index = None
         for idx, i in enumerate(indexers):
-            if isinstance(i, IntegerArrayIndexer):
+            if isinstance(i, (IntegerArrayIndexer, IntegerIndexer)):
                 if in_subspace == False:
                     in_subspace = True
                     num_subspaces += 1
@@ -1165,18 +1165,18 @@ class FancyIndexer(object):
         # Compute the resulting shape
         res_shape = []
         for i in self.indexers:
-            res_shape.append(i.get_shape())
-
-        # At every position where newaxis/None is present insert
-        # one as a constant shape in the resulting list of shapes.
-        for i in self.newaxes:
-            res_shape.insert(i, (one,))
+            res_shape.append(list(i.get_shape()))
 
         # Store the shape as a tuple, we can't do a simple
         # tuple(res_shape) here since res_shape is a list
         # of tuples which may be differently sized.
-        self.indexers_shape = sum(res_shape, ())
+        self.indexers_shape = sum(res_shape, [])
 
+        # At every position where newaxis/None is present insert
+        # one as a constant shape in the resulting list of shapes.
+        for i in self.newaxes:
+            self.indexers_shape.insert(i, one)
+        
     def get_shape(self):
         """
         Get the resulting data shape as Python tuple.

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -865,6 +865,7 @@ class IntegerArrayIndexer(Indexer):
                 builder.icmp_signed('>=', cur_index, self.idx_size),
                 likely=False
             ):
+                self.builder.store(Constant(self.ll_intp, 0), self.global_ary_idx)
                 builder.branch(self.bb_end)
         # Load the actual index from the array of indices
         index = _getitem_array_single_int(

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1315,6 +1315,10 @@ def fancy_getitem(context, builder, sig, args,
 
     indexer.end_loops()
 
+    for indexer in indexer.indexers:
+        if isinstance(indexer, (IntegerArrayIndexer, BooleanArrayIndexer)):
+            context.nrt.decref(builder, indexer.idxty, indexer.idxary._getvalue())
+
     return impl_ret_new_ref(context, builder, out_ty, out._getvalue())
 
 
@@ -1980,6 +1984,13 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
     indexer.end_loops()
 
     context.nrt.decref(builder, retty, src_flat_instr)
+    for indexer in indexer.indexers:
+        if isinstance(indexer, (IntegerArrayIndexer, BooleanArrayIndexer)):
+            context.nrt.decref(builder, indexer.idxty, indexer.idxary._getvalue())
+
+    for i, idx, idxty, idx_make in array_indices:
+        if idxty.ndim > 1:
+            context.nrt.decref(builder, idxty, idx_make._getvalue())
 
     return context.get_dummy_value()
 

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -712,6 +712,12 @@ class Indexer(object):
         """
         raise NotImplementedError
 
+    def cleanup(self, context, builder):
+        """
+        Perform any cleanup required after the loop.
+        """
+        pass
+
 
 class EntireIndexer(Indexer):
     """
@@ -807,6 +813,7 @@ class IntegerArrayIndexer(Indexer):
         self.idx_shape = cgutils.unpack_tuple(builder, idxary.shape)
         self.size = size
         self.ll_intp = self.context.get_value_type(types.intp)
+        self._cleanup_items = []
 
         if idxty.ndim > 1:
             def flat_imp_nocopy(ary):
@@ -827,15 +834,16 @@ class IntegerArrayIndexer(Indexer):
             sig = signature(retty, idxty)
             res = context.compile_internal(builder, flat_imp, sig,
                                            (idxary._getvalue(),))
+            self._cleanup_items.append((idxty, idxary._getvalue()))
+
             self.idxty = retty
             self.idxary = make_array(retty)(context, builder, res)
-            context.nrt.decref(builder, idxty,
-                    idxary._getvalue())
         else:
             self.idxty = idxty
             self.idxary = idxary
 
         assert self.idxty.ndim == 1
+        self._cleanup_items.append((self.idxty, self.idxary._getvalue()))
 
     def prepare(self):
         builder = self.builder
@@ -875,6 +883,10 @@ class IntegerArrayIndexer(Indexer):
         builder.branch(self.bb_end)
         builder.position_at_end(self.bb_end)
 
+    def cleanup(self, context, builder):
+        for cleanup_type, value in self._cleanup_items:
+            context.nrt.decref(builder, cleanup_type, value)
+
 
 class BooleanArrayIndexer(Indexer):
     """
@@ -886,9 +898,11 @@ class BooleanArrayIndexer(Indexer):
         self.builder = builder
         self.idxty = idxty
         self.idxary = idxary
+        self._cleanup_items = []
         assert idxty.ndim == 1
         self.ll_intp = self.context.get_value_type(types.intp)
         self.zero = Constant(self.ll_intp, 0)
+        self._cleanup_items.append((idxty, self.idxary._getvalue()))
 
     def prepare(self):
         builder = self.builder
@@ -949,6 +963,10 @@ class BooleanArrayIndexer(Indexer):
         builder.store(next_index, self.idx_index)
         builder.branch(self.bb_start)
         builder.position_at_end(self.bb_end)
+
+    def cleanup(self, context, builder):
+        for cleanup_type, value in self._cleanup_items:
+            context.nrt.decref(builder, cleanup_type, value)
 
 
 class SliceIndexer(Indexer):
@@ -1063,6 +1081,9 @@ class SubspaceIndexer(object):
         builder.branch(self.bb_start)
         builder.position_at_end(self.bb_end)
 
+    def cleanup(self, context, builder):
+        pass
+
 
 class FancyIndexer(object):
     """
@@ -1166,9 +1187,6 @@ class FancyIndexer(object):
 
         self.subspace_index = subspace_index
         self.indexers = indexers
-        print(aryty)
-        print(indexers)
-        print(self.subspace_index)
 
     def prepare(self):
         one = self.context.get_constant(types.intp, 1)
@@ -1243,9 +1261,14 @@ class FancyIndexer(object):
         for i in reversed(self.indexers):
             i.loop_tail()
 
+    def cleanup(self, context, builder):
+        for i in self.indexers:
+            i.cleanup(context, builder)
+
 
 def get_bdcast_idx(context, builder, array_indices):
     max_dims = max([ary[2].ndim for ary in array_indices])
+    cleanup_items = []
 
     def bdcast_idx_shapes(*args):
         return np.broadcast_shapes(*args)
@@ -1276,8 +1299,15 @@ def get_bdcast_idx(context, builder, array_indices):
             (idx, subspace_shape)
         )
         bdcast_indices.append((i, bdcast_idx, retty))
+
+        # cleanup_items.append((idxty, idx))
     subspace_shape = tuple(cgutils.unpack_tuple(builder, subspace_shape))
-    return bdcast_indices, subspace_shape
+
+    def bdcast_cleanup(context, builder):
+        for bdcast_idx_ty, bdcast_idx in cleanup_items:
+            context.nrt.decref(builder, bdcast_idx_ty, bdcast_idx)
+
+    return bdcast_indices, subspace_shape, bdcast_cleanup
 
 
 def fancy_getitem(context, builder, sig, args,
@@ -1294,7 +1324,7 @@ def fancy_getitem(context, builder, sig, args,
             idx_make = make_array(idxty)(context, builder, idx)
             array_indices.append((i, idx, idxty, idx_make))
 
-    bdcast_indices, subspace_shape_tuple = \
+    bdcast_indices, subspace_shape_tuple, bdcast_cleanup = \
         get_bdcast_idx(context, builder, array_indices)
 
     indices = list(indices)
@@ -1336,14 +1366,8 @@ def fancy_getitem(context, builder, sig, args,
 
     indexer.end_loops()
 
-    for indexer in indexer.indexers:
-        if isinstance(indexer, (IntegerArrayIndexer, BooleanArrayIndexer)):
-            context.nrt.decref(builder, indexer.idxty,
-                               indexer.idxary._getvalue())
-
-    for i, idx, idxty, idx_make in array_indices:
-        if idxty.ndim > 1:
-            context.nrt.decref(builder, idxty, idx_make._getvalue())
+    indexer.cleanup(context, builder)
+    bdcast_cleanup(context, builder)
 
     return impl_ret_new_ref(context, builder, out_ty, out._getvalue())
 
@@ -1895,7 +1919,7 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
             array_indices.append((i, idx, idxty, idx_make))
 
     if len(array_indices):
-        bdcast_indices, subspace_shape_tuple = \
+        bdcast_indices, subspace_shape_tuple, bdcast_cleanup = \
             get_bdcast_idx(context, builder, array_indices)
 
         indices = list(indices)
@@ -1905,6 +1929,7 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
             index_types[i] = bdcast_idxty
     else:
         subspace_shape_tuple = ()
+        bdcast_cleanup = lambda context, builder: None
 
     indexer = FancyIndexer(context, builder, aryty, ary,
                            index_types, indices, subspace_shape_tuple)
@@ -2045,14 +2070,8 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
         if is_flattened:
             context.nrt.decref(builder, retty, src_flat_instr)
 
-    for indexer in indexer.indexers:
-        if isinstance(indexer, (IntegerArrayIndexer, BooleanArrayIndexer)):
-            context.nrt.decref(builder, indexer.idxty,
-                               indexer.idxary._getvalue())
-
-    for i, idx, idxty, idx_make in array_indices:
-        if idxty.ndim > 1:
-            context.nrt.decref(builder, idxty, idx_make._getvalue())
+    indexer.cleanup(context, builder)
+    bdcast_cleanup(context, builder)
 
     return context.get_dummy_value()
 

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1170,13 +1170,13 @@ class FancyIndexer(object):
         if any([isinstance(i, IntegerArrayIndexer) for i in indexers]):
             for idx, i in enumerate(indexers):
                 if isinstance(i, (IntegerArrayIndexer, IntegerIndexer)):
-                    if in_subspace is False:
+                    if not in_subspace:
                         in_subspace = True
                         num_subspaces += 1
                     if subspace_index is None:
                         subspace_index = idx
                 else:
-                    if in_subspace is True:
+                    if in_subspace:
                         in_subspace = False
 
             if num_subspaces:

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1898,7 +1898,7 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
                                           src_shapes),
                        context.make_tuple(builder, raise_sig.args[1],
                                           index_shape)))
-
+    src_is_scalar = False
     if isinstance(srcty, types.Buffer):
         # Source is an array
         src_dtype = srcty.dtype
@@ -1940,50 +1940,63 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
         # Source is a scalar (broadcast or not, depending on destination
         # shape).
         src_dtype = srcty
-
-    def flat_imp_nocopy(ary):
-        return ary.reshape(ary.size)
-
-    def flat_imp_copy(ary):
-        return ary.copy().reshape(ary.size)
-
-    # If the source array is contigous, use the nocopy version
-    if srcty.is_contig:
-        flat_imp = flat_imp_nocopy
-    # otherwise, use copy version since we don't support
-    # reshaping non-contigous arrays
+        src_is_scalar = True
+    
+    if src_is_scalar:
+        dest_indices = indexer.begin_loops()
+        # No need to check for wraparound, as the indexers all ensure
+        # a positive index is returned.
+        dest_ptr = cgutils.get_item_pointer2(context, builder, dest_data,
+                                            dest_shapes, dest_strides,
+                                            aryty.layout, dest_indices,
+                                            wraparound=False)
+        store_item(context, builder, aryty, src, dest_ptr)
+        indexer.end_loops()
     else:
-        flat_imp = flat_imp_copy
+        def flat_imp_nocopy(ary):
+            return ary.reshape(ary.size)
 
-    retty = types.Array(srcty.dtype, 1, srcty.layout, readonly=True)
-    sig = signature(retty, srcty)
-    src_flat_instr = context.compile_internal(builder, flat_imp, sig,
-                                              (src._getvalue(),))
-    src_flat = make_array(retty)(context, builder, src_flat_instr)
-    src_data = src_flat.data
-    src_idx = cgutils.alloca_once_value(builder,
-                                        context.get_constant(types.intp, 0))
-    # Loop on destination and copy from source to destination
-    dest_indices = indexer.begin_loops()
+        def flat_imp_copy(ary):
+            return ary.copy().reshape(ary.size)
 
-    # No need to check for wraparound, as the indexers all ensure
-    # a positive index is returned.
-    dest_ptr = cgutils.get_item_pointer2(context, builder, dest_data,
-                                         dest_shapes, dest_strides,
-                                         aryty.layout, dest_indices,
-                                         wraparound=False)
+        # If the source array is contigous, use the nocopy version
+        if srcty.is_contig:
+            flat_imp = flat_imp_nocopy
+        # otherwise, use copy version since we don't support
+        # reshaping non-contigous arrays
+        else:
+            flat_imp = flat_imp_copy
 
-    cur = builder.load(src_idx)
-    ptr = builder.gep(src_data, [cur])
-    val = builder.load(ptr)
-    val = context.cast(builder, val, src_dtype, aryty.dtype)
-    store_item(context, builder, aryty, val, dest_ptr)
-    next_idx = cgutils.increment_index(builder, cur)
-    builder.store(next_idx, src_idx)
+        retty = types.Array(srcty.dtype, 1, srcty.layout, readonly=True)
+        sig = signature(retty, srcty)
+        src_flat_instr = context.compile_internal(builder, flat_imp, sig,
+                                                (src._getvalue(),))
+        src_flat = make_array(retty)(context, builder, src_flat_instr)
+        src_data = src_flat.data
+        src_idx = cgutils.alloca_once_value(builder,
+                                            context.get_constant(types.intp, 0))
+        # Loop on destination and copy from source to destination
+        dest_indices = indexer.begin_loops()
 
-    indexer.end_loops()
+        # No need to check for wraparound, as the indexers all ensure
+        # a positive index is returned.
+        dest_ptr = cgutils.get_item_pointer2(context, builder, dest_data,
+                                            dest_shapes, dest_strides,
+                                            aryty.layout, dest_indices,
+                                            wraparound=False)
 
-    context.nrt.decref(builder, retty, src_flat_instr)
+        cur = builder.load(src_idx)
+        ptr = builder.gep(src_data, [cur])
+        val = builder.load(ptr)
+        val = context.cast(builder, val, src_dtype, aryty.dtype)
+        store_item(context, builder, aryty, val, dest_ptr)
+        next_idx = cgutils.increment_index(builder, cur)
+        builder.store(next_idx, src_idx)
+
+        indexer.end_loops()
+
+        context.nrt.decref(builder, retty, src_flat_instr)
+
     for indexer in indexer.indexers:
         if isinstance(indexer, (IntegerArrayIndexer, BooleanArrayIndexer)):
             context.nrt.decref(builder, indexer.idxty, indexer.idxary._getvalue())

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1268,7 +1268,6 @@ class FancyIndexer(object):
 
 def get_bdcast_idx(context, builder, array_indices):
     max_dims = max([ary[2].ndim for ary in array_indices])
-    cleanup_items = []
 
     def bdcast_idx_shapes(*args):
         return np.broadcast_shapes(*args)
@@ -1300,14 +1299,9 @@ def get_bdcast_idx(context, builder, array_indices):
         )
         bdcast_indices.append((i, bdcast_idx, retty))
 
-        # cleanup_items.append((idxty, idx))
     subspace_shape = tuple(cgutils.unpack_tuple(builder, subspace_shape))
 
-    def bdcast_cleanup(context, builder):
-        for bdcast_idx_ty, bdcast_idx in cleanup_items:
-            context.nrt.decref(builder, bdcast_idx_ty, bdcast_idx)
-
-    return bdcast_indices, subspace_shape, bdcast_cleanup
+    return bdcast_indices, subspace_shape
 
 
 def fancy_getitem(context, builder, sig, args,
@@ -1324,7 +1318,7 @@ def fancy_getitem(context, builder, sig, args,
             idx_make = make_array(idxty)(context, builder, idx)
             array_indices.append((i, idx, idxty, idx_make))
 
-    bdcast_indices, subspace_shape_tuple, bdcast_cleanup = \
+    bdcast_indices, subspace_shape_tuple = \
         get_bdcast_idx(context, builder, array_indices)
 
     indices = list(indices)
@@ -1367,7 +1361,6 @@ def fancy_getitem(context, builder, sig, args,
     indexer.end_loops()
 
     indexer.cleanup(context, builder)
-    bdcast_cleanup(context, builder)
 
     return impl_ret_new_ref(context, builder, out_ty, out._getvalue())
 
@@ -1919,7 +1912,7 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
             array_indices.append((i, idx, idxty, idx_make))
 
     if len(array_indices):
-        bdcast_indices, subspace_shape_tuple, bdcast_cleanup = \
+        bdcast_indices, subspace_shape_tuple = \
             get_bdcast_idx(context, builder, array_indices)
 
         indices = list(indices)
@@ -1929,7 +1922,6 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
             index_types[i] = bdcast_idxty
     else:
         subspace_shape_tuple = ()
-        bdcast_cleanup = lambda context, builder: None
 
     indexer = FancyIndexer(context, builder, aryty, ary,
                            index_types, indices, subspace_shape_tuple)
@@ -2071,7 +2063,6 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
             context.nrt.decref(builder, retty, src_flat_instr)
 
     indexer.cleanup(context, builder)
-    bdcast_cleanup(context, builder)
 
     return context.get_dummy_value()
 

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -829,6 +829,8 @@ class IntegerArrayIndexer(Indexer):
                                            (idxary._getvalue(),))
             self.idxty = retty
             self.idxary = make_array(retty)(context, builder, res)
+            context.nrt.decref(builder, idxty,
+                    idxary._getvalue())
         else:
             self.idxty = idxty
             self.idxary = idxary
@@ -1164,6 +1166,9 @@ class FancyIndexer(object):
 
         self.subspace_index = subspace_index
         self.indexers = indexers
+        print(aryty)
+        print(indexers)
+        print(self.subspace_index)
 
     def prepare(self):
         one = self.context.get_constant(types.intp, 1)

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -816,19 +816,11 @@ class IntegerArrayIndexer(Indexer):
         self._cleanup_items = []
 
         if idxty.ndim > 1:
-            def flat_imp_nocopy(ary):
-                return ary.reshape(ary.size)
-
-            def flat_imp_copy(ary):
+            # TODO: This is bad for performance reasons.
+            # Ideally we'd want to index non-broadcasted and non copied versions
+            # of the indexing array.
+            def flat_imp(ary):
                 return ary.copy().reshape(ary.size)
-
-            # If the index array is contigous, use the nocopy version
-            if idxty.is_contig:
-                flat_imp = flat_imp_nocopy
-            # otherwise, use copy version since we don't support
-            # reshaping non-contigous arrays
-            else:
-                flat_imp = flat_imp_copy
 
             retty = types.Array(idxty.dtype, 1, idxty.layout, readonly=True)
             sig = signature(retty, idxty)
@@ -1982,40 +1974,21 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
             raise_shape_mismatch_error(context, builder, src_shapes,
                                        index_shape)
 
-        is_flattened = False
-        # Check for array overlap
-        src_strides = cgutils.unpack_tuple(builder, src.strides)
-        src_start, src_end = get_array_memory_extents(
-            context, builder, srcty, src, src_shapes,
-            src_strides, src_data
-        )
-
-        dest_lower, dest_upper = indexer.get_offset_bounds(
-            dest_strides, ary.itemsize)
-        dest_start, dest_end = compute_memory_extents(
-            context, builder, dest_lower, dest_upper, dest_data
-        )
-
-        use_copy = extents_may_overlap(
-            context, builder, src_start, src_end,
-            dest_start, dest_end
-        )
-        srcty_contig = srcty.is_contig
-
-        def flat_imp(ary, use_copy):
-            if use_copy or not srcty_contig:
-                return ary.copy().reshape(ary.size)
-            else:
-                return ary.reshape(ary.size)
+        # TODO: This is bad for performance reasons.
+        # Ideally we'd want to index non-broadcasted and non copied versions
+        # of the source array. Only exception is when the source and
+        # destination arrays overlapin which case we'd want to index
+        # a non-broadcasted but copied version of the source array.
+        def flat_imp(ary):
+            return ary.copy().reshape(ary.size)
 
         retty = types.Array(srcty.dtype, 1, srcty.layout, readonly=True)
-        sig = signature(retty, srcty, types.boolean)
+        sig = signature(retty, srcty)
         src_flat_instr = context.compile_internal(
-            builder, flat_imp, sig, (src._getvalue(), use_copy)
+            builder, flat_imp, sig, (src._getvalue(),)
         )
         src_flat = make_array(retty)(context, builder, src_flat_instr)
         src_data = src_flat.data
-        is_flattened = True
 
         def src_getitem(src_idx):
             cur = builder.load(src_idx)
@@ -2043,8 +2016,7 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
 
         indexer.end_loops()
 
-        if is_flattened:
-            context.nrt.decref(builder, retty, src_flat_instr)
+        context.nrt.decref(builder, retty, src_flat_instr)
 
     elif isinstance(srcty, types.Sequence):
         src_dtype = srcty.dtype
@@ -2091,9 +2063,6 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
         store_item(context, builder, aryty, val, dest_ptr)
 
         indexer.end_loops()
-
-        if is_flattened:
-            context.nrt.decref(builder, retty, src_flat_instr)
     else:
         # Source is a scalar (broadcast or not, depending on destination
         # shape).

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1051,7 +1051,7 @@ class SubspaceIndexer(Indexer):
         self.bb_end = builder.append_basic_block()
 
     def get_size(self):
-        return None
+        return self.size
 
     def get_shape(self):
         return self.shape_tuple
@@ -1087,9 +1087,6 @@ class SubspaceIndexer(Indexer):
         builder.store(next_index, self.global_ary_idx)
         builder.branch(self.bb_start)
         builder.position_at_end(self.bb_end)
-
-    def cleanup(self, context, builder):
-        pass
 
 
 class FancyIndexer(object):
@@ -1190,19 +1187,26 @@ class FancyIndexer(object):
                 if num_subspaces > 1:
                     subspace_index = 0
 
-                indexers.insert(subspace_index, self.subspace_indexer)
-
         self.subspace_index = subspace_index
         self.indexers = indexers
 
     def prepare(self):
         one = self.context.get_constant(types.intp, 1)
-        for i in self.indexers:
+        for idx, i in enumerate(self.indexers):
+            if idx == self.subspace_index:
+                self.subspace_indexer.prepare()
             i.prepare()
+
         # Compute the resulting shape
         res_shape = []
         for i in self.indexers:
             res_shape.append(list(i.get_shape()))
+
+        if self.subspace_index is not None:
+            res_shape.insert(
+                self.subspace_index,
+                list(self.subspace_indexer.get_shape())
+            )
 
         # Store the shape as a tuple, we can't do a simple
         # tuple(res_shape) here since res_shape is a list
@@ -1259,14 +1263,20 @@ class FancyIndexer(object):
         return lower, upper
 
     def begin_loops(self):
-        indices = list(i.loop_head() for i in self.indexers)
-        if self.subspace_index is not None:
-            indices.pop(self.subspace_index)
+        indices = []
+        for idx, i in enumerate(self.indexers):
+            if idx == self.subspace_index:
+                self.subspace_indexer.loop_head()
+            indices.append(i.loop_head())
         return tuple(indices)
 
     def end_loops(self):
+        idx = len(self.indexers) - 1
         for i in reversed(self.indexers):
             i.loop_tail()
+            if idx == self.subspace_index:
+                self.subspace_indexer.loop_tail()
+            idx -= 1
 
     def cleanup(self, context, builder):
         for i in self.indexers:
@@ -2005,12 +2015,6 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
     else:
         is_flattened = False
         if isinstance(srcty, types.Array):
-            def flat_imp_nocopy(ary):
-                return ary.reshape(ary.size)
-
-            def flat_imp_copy(ary):
-                return ary.copy().reshape(ary.size)
-
             # Check for array overlap
             src_strides = cgutils.unpack_tuple(builder, src.strides)
             src_start, src_end = get_array_memory_extents(
@@ -2028,19 +2032,19 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
                 context, builder, src_start, src_end,
                 dest_start, dest_end
             )
+            srcty_contig = srcty.is_contig
 
-            # If the source array is contigous, use the nocopy version
-            if srcty.is_contig and not use_copy:
-                flat_imp = flat_imp_nocopy
-            # otherwise, use copy version since we don't support
-            # reshaping non-contigous arrays
-            else:
-                flat_imp = flat_imp_copy
+            def flat_imp(ary, use_copy):
+                if use_copy or not srcty_contig:
+                    return ary.copy().reshape(ary.size)
+                else:
+                    return ary.reshape(ary.size)
 
             retty = types.Array(srcty.dtype, 1, srcty.layout, readonly=True)
-            sig = signature(retty, srcty)
-            src_flat_instr = context.compile_internal(builder, flat_imp, sig,
-                                                      (src._getvalue(),))
+            sig = signature(retty, srcty, types.boolean)
+            src_flat_instr = context.compile_internal(
+                builder, flat_imp, sig, (src._getvalue(), use_copy)
+            )
             src_flat = make_array(retty)(context, builder, src_flat_instr)
             src_data = src_flat.data
             is_flattened = True

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1033,7 +1033,7 @@ class SliceIndexer(Indexer):
         builder.position_at_end(self.bb_end)
 
 
-class SubspaceIndexer(object):
+class SubspaceIndexer(Indexer):
     def __init__(self, context, builder, shape_tuple, global_ary_idx):
         self.context = context
         self.builder = builder
@@ -1061,6 +1061,13 @@ class SubspaceIndexer(object):
         return (self.ll_intp(0), self.size)
 
     def loop_head(self):
+        # Subspace index is being tracked globally within self.global_ary_idx
+        # and is used by the IntegerArrayIndexers to access the element
+        # of the respective index arrays. Over here we simply increment
+        # the global index and yield control to the next indexer,
+        # hence returning None, later we remove this None index from the
+        # final list of indices in the FancyIndexer.loop_head().
+
         builder = self.builder
         # Initialize loop variable
         builder.branch(self.bb_start)

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1958,7 +1958,7 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
                                           src_shapes),
                        context.make_tuple(builder, raise_sig.args[1],
                                           index_shape)))
-    src_is_scalar = False
+
     if isinstance(srcty, types.Buffer):
         # Source is an array
         src_dtype = srcty.dtype
@@ -1982,93 +1982,48 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
             raise_shape_mismatch_error(context, builder, src_shapes,
                                        index_shape)
 
-    elif isinstance(srcty, types.Sequence):
-        src_dtype = srcty.dtype
-
-        # Check shape is equal to sequence length
-        index_shape = indexer.get_shape()
-        assert len(index_shape) == 1
-        len_impl = context.get_function(len, signature(types.intp, srcty))
-        seq_len = len_impl(builder, (src,))
-
-        shape_error = builder.icmp_signed('!=', index_shape[0], seq_len)
-
-        with builder.if_then(shape_error, likely=False):
-            raise_shape_mismatch_error(context, builder, (seq_len,),
-                                       (index_shape[0],))
-    else:
-        # Source is a scalar (broadcast or not, depending on destination
-        # shape).
-        src_dtype = srcty
-        src_is_scalar = True
-
-    if src_is_scalar:
-        dest_indices = indexer.begin_loops()
-        # No need to check for wraparound, as the indexers all ensure
-        # a positive index is returned.
-        dest_ptr = cgutils.get_item_pointer2(
-            context, builder, dest_data, dest_shapes, dest_strides,
-            aryty.layout, dest_indices, wraparound=False,
-            boundscheck=context.enable_boundscheck)
-        store_item(context, builder, aryty, src, dest_ptr)
-        indexer.end_loops()
-    else:
         is_flattened = False
-        if isinstance(srcty, types.Array):
-            # Check for array overlap
-            src_strides = cgutils.unpack_tuple(builder, src.strides)
-            src_start, src_end = get_array_memory_extents(
-                context, builder, srcty, src, src_shapes,
-                src_strides, src_data
-            )
+        # Check for array overlap
+        src_strides = cgutils.unpack_tuple(builder, src.strides)
+        src_start, src_end = get_array_memory_extents(
+            context, builder, srcty, src, src_shapes,
+            src_strides, src_data
+        )
 
-            dest_lower, dest_upper = indexer.get_offset_bounds(
-                dest_strides, ary.itemsize)
-            dest_start, dest_end = compute_memory_extents(
-                context, builder, dest_lower, dest_upper, dest_data
-            )
+        dest_lower, dest_upper = indexer.get_offset_bounds(
+            dest_strides, ary.itemsize)
+        dest_start, dest_end = compute_memory_extents(
+            context, builder, dest_lower, dest_upper, dest_data
+        )
 
-            use_copy = extents_may_overlap(
-                context, builder, src_start, src_end,
-                dest_start, dest_end
-            )
-            srcty_contig = srcty.is_contig
+        use_copy = extents_may_overlap(
+            context, builder, src_start, src_end,
+            dest_start, dest_end
+        )
+        srcty_contig = srcty.is_contig
 
-            def flat_imp(ary, use_copy):
-                if use_copy or not srcty_contig:
-                    return ary.copy().reshape(ary.size)
-                else:
-                    return ary.reshape(ary.size)
+        def flat_imp(ary, use_copy):
+            if use_copy or not srcty_contig:
+                return ary.copy().reshape(ary.size)
+            else:
+                return ary.reshape(ary.size)
 
-            retty = types.Array(srcty.dtype, 1, srcty.layout, readonly=True)
-            sig = signature(retty, srcty, types.boolean)
-            src_flat_instr = context.compile_internal(
-                builder, flat_imp, sig, (src._getvalue(), use_copy)
-            )
-            src_flat = make_array(retty)(context, builder, src_flat_instr)
-            src_data = src_flat.data
-            is_flattened = True
+        retty = types.Array(srcty.dtype, 1, srcty.layout, readonly=True)
+        sig = signature(retty, srcty, types.boolean)
+        src_flat_instr = context.compile_internal(
+            builder, flat_imp, sig, (src._getvalue(), use_copy)
+        )
+        src_flat = make_array(retty)(context, builder, src_flat_instr)
+        src_data = src_flat.data
+        is_flattened = True
 
-            def src_getitem(src_idx):
-                cur = builder.load(src_idx)
-                ptr = builder.gep(src_data, [cur])
-                val = builder.load(ptr)
-                next_idx = cgutils.increment_index(builder, cur)
-                builder.store(next_idx, src_idx)
-                return val
-        else:
-            retty = srcty
-
-            def src_getitem(src_idx):
-                cur = builder.load(src_idx)
-                getitem_impl = context.get_function(
-                    operator.getitem,
-                    signature(src_dtype, srcty, types.intp),
-                )
-                val = getitem_impl(builder, (src, cur))
-                next_idx = cgutils.increment_index(builder, cur)
-                builder.store(next_idx, src_idx)
-                return val
+        def src_getitem(src_idx):
+            cur = builder.load(src_idx)
+            ptr = builder.gep(src_data, [cur])
+            val = builder.load(ptr)
+            next_idx = cgutils.increment_index(builder, cur)
+            builder.store(next_idx, src_idx)
+            return val
 
         src_idx = cgutils.alloca_once_value(builder,
                                             context.get_constant(types.intp, 0))
@@ -2090,6 +2045,67 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
 
         if is_flattened:
             context.nrt.decref(builder, retty, src_flat_instr)
+
+    elif isinstance(srcty, types.Sequence):
+        src_dtype = srcty.dtype
+
+        # Check shape is equal to sequence length
+        index_shape = indexer.get_shape()
+        assert len(index_shape) == 1
+        len_impl = context.get_function(len, signature(types.intp, srcty))
+        seq_len = len_impl(builder, (src,))
+
+        shape_error = builder.icmp_signed('!=', index_shape[0], seq_len)
+
+        with builder.if_then(shape_error, likely=False):
+            raise_shape_mismatch_error(context, builder, (seq_len,),
+                                       (index_shape[0],))
+
+        retty = srcty
+
+        def src_getitem(src_idx):
+            cur = builder.load(src_idx)
+            getitem_impl = context.get_function(
+                operator.getitem,
+                signature(src_dtype, srcty, types.intp),
+            )
+            val = getitem_impl(builder, (src, cur))
+            next_idx = cgutils.increment_index(builder, cur)
+            builder.store(next_idx, src_idx)
+            return val
+
+        src_idx = cgutils.alloca_once_value(builder,
+                                            context.get_constant(types.intp, 0))
+        # Loop on destination and copy from source to destination
+        dest_indices = indexer.begin_loops()
+
+        # No need to check for wraparound, as the indexers all ensure
+        # a positive index is returned.
+        dest_ptr = cgutils.get_item_pointer2(
+            context, builder, dest_data, dest_shapes, dest_strides,
+            aryty.layout, dest_indices, wraparound=False,
+            boundscheck=context.enable_boundscheck)
+
+        val = src_getitem(src_idx)
+        val = context.cast(builder, val, src_dtype, aryty.dtype)
+        store_item(context, builder, aryty, val, dest_ptr)
+
+        indexer.end_loops()
+
+        if is_flattened:
+            context.nrt.decref(builder, retty, src_flat_instr)
+    else:
+        # Source is a scalar (broadcast or not, depending on destination
+        # shape).
+        dest_indices = indexer.begin_loops()
+        # No need to check for wraparound, as the indexers all ensure
+        # a positive index is returned.
+        dest_ptr = cgutils.get_item_pointer2(
+            context, builder, dest_data, dest_shapes, dest_strides,
+            aryty.layout, dest_indices, wraparound=False,
+            boundscheck=context.enable_boundscheck)
+        store_item(context, builder, aryty, src, dest_ptr)
+        indexer.end_loops()
 
     indexer.cleanup(context, builder)
 

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1934,8 +1934,8 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
         shape_error = builder.icmp_signed('!=', index_shape[0], seq_len)
 
         with builder.if_then(shape_error, likely=False):
-            msg = "cannot assign slice from input of different size"
-            context.call_conv.return_user_exc(builder, ValueError, (msg,))
+            raise_shape_mismatch_error(context, builder, (seq_len,),
+                                       (index_shape[0],))
     else:
         # Source is a scalar (broadcast or not, depending on destination
         # shape).
@@ -1953,28 +1953,52 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
         store_item(context, builder, aryty, src, dest_ptr)
         indexer.end_loops()
     else:
-        def flat_imp_nocopy(ary):
-            return ary.reshape(ary.size)
+        is_flattened = False
+        if isinstance(srcty, types.Array):
+            def flat_imp_nocopy(ary):
+                return ary.reshape(ary.size)
 
-        def flat_imp_copy(ary):
-            return ary.copy().reshape(ary.size)
+            def flat_imp_copy(ary):
+                return ary.copy().reshape(ary.size)
 
-        # If the source array is contigous, use the nocopy version
-        if srcty.is_contig:
-            flat_imp = flat_imp_nocopy
-        # otherwise, use copy version since we don't support
-        # reshaping non-contigous arrays
+            # If the source array is contigous, use the nocopy version
+            if srcty.is_contig:
+                flat_imp = flat_imp_nocopy
+            # otherwise, use copy version since we don't support
+            # reshaping non-contigous arrays
+            else:
+                flat_imp = flat_imp_copy
+
+            retty = types.Array(srcty.dtype, 1, srcty.layout, readonly=True)
+            sig = signature(retty, srcty)
+            src_flat_instr = context.compile_internal(builder, flat_imp, sig,
+                                                    (src._getvalue(),))
+            src_flat = make_array(retty)(context, builder, src_flat_instr)
+            src_data = src_flat.data
+            is_flattened = True
+
+            def src_getitem(src_idx):
+                cur = builder.load(src_idx)
+                ptr = builder.gep(src_data, [cur])
+                val = builder.load(ptr)
+                next_idx = cgutils.increment_index(builder, cur)
+                builder.store(next_idx, src_idx)
+                return val
         else:
-            flat_imp = flat_imp_copy
+            retty = srcty
 
-        retty = types.Array(srcty.dtype, 1, srcty.layout, readonly=True)
-        sig = signature(retty, srcty)
-        src_flat_instr = context.compile_internal(builder, flat_imp, sig,
-                                                (src._getvalue(),))
-        src_flat = make_array(retty)(context, builder, src_flat_instr)
-        src_data = src_flat.data
-        src_idx = cgutils.alloca_once_value(builder,
-                                            context.get_constant(types.intp, 0))
+            def src_getitem(src_idx):
+                cur = builder.load(src_idx)
+                getitem_impl = context.get_function(
+                    operator.getitem,
+                    signature(src_dtype, srcty, types.intp),
+                )
+                val = getitem_impl(builder, (src, cur))
+                next_idx = cgutils.increment_index(builder, cur)
+                builder.store(next_idx, src_idx)
+                return val
+
+        src_idx = cgutils.alloca_once_value(builder, context.get_constant(types.intp, 0))
         # Loop on destination and copy from source to destination
         dest_indices = indexer.begin_loops()
 
@@ -1985,17 +2009,14 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
                                             aryty.layout, dest_indices,
                                             wraparound=False)
 
-        cur = builder.load(src_idx)
-        ptr = builder.gep(src_data, [cur])
-        val = builder.load(ptr)
+        val = src_getitem(src_idx)
         val = context.cast(builder, val, src_dtype, aryty.dtype)
         store_item(context, builder, aryty, val, dest_ptr)
-        next_idx = cgutils.increment_index(builder, cur)
-        builder.store(next_idx, src_idx)
 
         indexer.end_loops()
 
-        context.nrt.decref(builder, retty, src_flat_instr)
+        if is_flattened:
+            context.nrt.decref(builder, retty, src_flat_instr)
 
     for indexer in indexer.indexers:
         if isinstance(indexer, (IntegerArrayIndexer, BooleanArrayIndexer)):

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1012,6 +1012,7 @@ class SliceIndexer(Indexer):
         builder.branch(self.bb_start)
         builder.position_at_end(self.bb_end)
 
+
 class SubspaceIndexer(object):
     def __init__(self, context, builder, shape_tuple, global_ary_idx):
         self.context = context
@@ -1055,17 +1056,19 @@ class SubspaceIndexer(object):
     def loop_tail(self):
         builder = self.builder
         next_index = cgutils.increment_index(builder,
-                                            builder.load(self.global_ary_idx))
+                                             builder.load(self.global_ary_idx))
         builder.store(next_index, self.global_ary_idx)
         builder.branch(self.bb_start)
         builder.position_at_end(self.bb_end)
+
 
 class FancyIndexer(object):
     """
     Perform fancy indexing on the given array.
     """
 
-    def __init__(self, context, builder, aryty, ary, index_types, indices, subspace_shape_tuple):
+    def __init__(self, context, builder, aryty, ary, index_types,
+                 indices, subspace_shape_tuple):
         self.context = context
         self.builder = builder
         self.aryty = aryty
@@ -1103,6 +1106,7 @@ class FancyIndexer(object):
                                         self.shapes[ax])
                 indexer = IntegerIndexer(context, builder, ind)
                 indexers.append(indexer)
+                new_ax -= 1
             elif isinstance(idxty, types.Array):
                 idxary = make_array(idxty)(context, builder, indexval)
                 if isinstance(idxty.dtype, types.Integer):
@@ -1133,7 +1137,9 @@ class FancyIndexer(object):
 
         assert len(indexers) == aryty.ndim, (len(indexers), aryty.ndim)
 
-        self.subspace_indexer = SubspaceIndexer(context, builder, subspace_shape_tuple, self.global_ary_idx)
+        self.subspace_indexer = SubspaceIndexer(
+            context, builder, subspace_shape_tuple, self.global_ary_idx
+        )
 
         num_subspaces = 0
         in_subspace = False
@@ -1141,15 +1147,15 @@ class FancyIndexer(object):
         if any([isinstance(i, IntegerArrayIndexer) for i in indexers]):
             for idx, i in enumerate(indexers):
                 if isinstance(i, (IntegerArrayIndexer, IntegerIndexer)):
-                    if in_subspace == False:
+                    if in_subspace is False:
                         in_subspace = True
                         num_subspaces += 1
                     if subspace_index is None:
                         subspace_index = idx
                 else:
-                    if in_subspace == True:
+                    if in_subspace is True:
                         in_subspace = False
-            
+
             if num_subspaces:
                 if num_subspaces > 1:
                     subspace_index = 0
@@ -1177,7 +1183,7 @@ class FancyIndexer(object):
         # one as a constant shape in the resulting list of shapes.
         for i in self.newaxes:
             self.indexers_shape.insert(i, one)
-        
+
     def get_shape(self):
         """
         Get the resulting data shape as Python tuple.
@@ -1238,22 +1244,32 @@ def get_bdcast_idx(context, builder, array_indices):
 
     def bdcast_idx_shapes(*args):
         return np.broadcast_shapes(*args)
-    
-    inpty = types.StarArgTuple(tuple(types.UniTuple(types.intp, count=ary_idx[2].ndim) for ary_idx in array_indices))
+
+    inpty = types.StarArgTuple(
+        tuple(types.UniTuple(
+            types.intp, count=ary_idx[2].ndim
+        ) for ary_idx in array_indices)
+    )
     retty = types.UniTuple(types.intp, count=max_dims)
-    subspace_shape = context.compile_internal(builder, bdcast_idx_shapes, signature(retty, inpty),
-                                                (cgutils.pack_struct(builder, tuple([ary_idx[3].shape for ary_idx in array_indices])),))
+    subspace_shape = context.compile_internal(
+        builder, bdcast_idx_shapes, signature(retty, inpty),
+        (cgutils.pack_struct(
+            builder, tuple([ary_idx[3].shape for ary_idx in array_indices])
+        ),)
+    )
 
     bdcast_indices = []
-    
+
     def bdcast_array(ary, shape):
         return np.broadcast_to(ary, shape)
-    
+
     for i, idx, idxty, _ in array_indices:
         inpty = (idxty, types.UniTuple(types.intp, count=max_dims))
         retty = types.Array(idxty.dtype, max_dims, 'A', readonly=True)
-        bdcast_idx = context.compile_internal(builder, bdcast_array, signature(retty, *inpty),
-                                                (idx, subspace_shape))
+        bdcast_idx = context.compile_internal(
+            builder, bdcast_array, signature(retty, *inpty),
+            (idx, subspace_shape)
+        )
         bdcast_indices.append((i, bdcast_idx, retty))
     subspace_shape = tuple(cgutils.unpack_tuple(builder, subspace_shape))
     return bdcast_indices, subspace_shape
@@ -1317,7 +1333,8 @@ def fancy_getitem(context, builder, sig, args,
 
     for indexer in indexer.indexers:
         if isinstance(indexer, (IntegerArrayIndexer, BooleanArrayIndexer)):
-            context.nrt.decref(builder, indexer.idxty, indexer.idxary._getvalue())
+            context.nrt.decref(builder, indexer.idxty,
+                               indexer.idxary._getvalue())
 
     return impl_ret_new_ref(context, builder, out_ty, out._getvalue())
 
@@ -1941,15 +1958,15 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
         # shape).
         src_dtype = srcty
         src_is_scalar = True
-    
+
     if src_is_scalar:
         dest_indices = indexer.begin_loops()
         # No need to check for wraparound, as the indexers all ensure
         # a positive index is returned.
         dest_ptr = cgutils.get_item_pointer2(context, builder, dest_data,
-                                            dest_shapes, dest_strides,
-                                            aryty.layout, dest_indices,
-                                            wraparound=False)
+                                             dest_shapes, dest_strides,
+                                             aryty.layout, dest_indices,
+                                             wraparound=False)
         store_item(context, builder, aryty, src, dest_ptr)
         indexer.end_loops()
     else:
@@ -1972,7 +1989,7 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
             retty = types.Array(srcty.dtype, 1, srcty.layout, readonly=True)
             sig = signature(retty, srcty)
             src_flat_instr = context.compile_internal(builder, flat_imp, sig,
-                                                    (src._getvalue(),))
+                                                      (src._getvalue(),))
             src_flat = make_array(retty)(context, builder, src_flat_instr)
             src_data = src_flat.data
             is_flattened = True
@@ -1998,16 +2015,17 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
                 builder.store(next_idx, src_idx)
                 return val
 
-        src_idx = cgutils.alloca_once_value(builder, context.get_constant(types.intp, 0))
+        src_idx = cgutils.alloca_once_value(builder,
+                                            context.get_constant(types.intp, 0))
         # Loop on destination and copy from source to destination
         dest_indices = indexer.begin_loops()
 
         # No need to check for wraparound, as the indexers all ensure
         # a positive index is returned.
         dest_ptr = cgutils.get_item_pointer2(context, builder, dest_data,
-                                            dest_shapes, dest_strides,
-                                            aryty.layout, dest_indices,
-                                            wraparound=False)
+                                             dest_shapes, dest_strides,
+                                             aryty.layout, dest_indices,
+                                             wraparound=False)
 
         val = src_getitem(src_idx)
         val = context.cast(builder, val, src_dtype, aryty.dtype)
@@ -2020,7 +2038,8 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
 
     for indexer in indexer.indexers:
         if isinstance(indexer, (IntegerArrayIndexer, BooleanArrayIndexer)):
-            context.nrt.decref(builder, indexer.idxty, indexer.idxary._getvalue())
+            context.nrt.decref(builder, indexer.idxty,
+                               indexer.idxary._getvalue())
 
     for i, idx, idxty, idx_make in array_indices:
         if idxty.ndim > 1:

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1989,10 +1989,10 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
         dest_indices = indexer.begin_loops()
         # No need to check for wraparound, as the indexers all ensure
         # a positive index is returned.
-        dest_ptr = cgutils.get_item_pointer2(context, builder, dest_data,
-                                             dest_shapes, dest_strides,
-                                             aryty.layout, dest_indices,
-                                             wraparound=False)
+        dest_ptr = cgutils.get_item_pointer2(
+            context, builder, dest_data, dest_shapes, dest_strides,
+            aryty.layout, dest_indices, wraparound=False,
+            boundscheck=context.enable_boundscheck)
         store_item(context, builder, aryty, src, dest_ptr)
         indexer.end_loops()
     else:
@@ -2048,10 +2048,10 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
 
         # No need to check for wraparound, as the indexers all ensure
         # a positive index is returned.
-        dest_ptr = cgutils.get_item_pointer2(context, builder, dest_data,
-                                             dest_shapes, dest_strides,
-                                             aryty.layout, dest_indices,
-                                             wraparound=False)
+        dest_ptr = cgutils.get_item_pointer2(
+            context, builder, dest_data, dest_shapes, dest_strides,
+            aryty.layout, dest_indices, wraparound=False,
+            boundscheck=context.enable_boundscheck)
 
         val = src_getitem(src_idx)
         val = context.cast(builder, val, src_dtype, aryty.dtype)

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -2011,8 +2011,26 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
             def flat_imp_copy(ary):
                 return ary.copy().reshape(ary.size)
 
+            # Check for array overlap
+            src_strides = cgutils.unpack_tuple(builder, src.strides)
+            src_start, src_end = get_array_memory_extents(
+                context, builder, srcty, src, src_shapes,
+                src_strides, src_data
+            )
+
+            dest_lower, dest_upper = indexer.get_offset_bounds(
+                dest_strides, ary.itemsize)
+            dest_start, dest_end = compute_memory_extents(
+                context, builder, dest_lower, dest_upper, dest_data
+            )
+
+            use_copy = extents_may_overlap(
+                context, builder, src_start, src_end,
+                dest_start, dest_end
+            )
+
             # If the source array is contigous, use the nocopy version
-            if srcty.is_contig:
+            if srcty.is_contig and not use_copy:
                 flat_imp = flat_imp_nocopy
             # otherwise, use copy version since we don't support
             # reshaping non-contigous arrays

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1904,7 +1904,7 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
     between the two for indexed assignment.
     """
     aryty, _, srcty = sig.args
-    ary, _, src_orig = args
+    ary, _, src = args
 
     ary = make_array(aryty)(context, builder, ary)
     dest_shapes = cgutils.unpack_tuple(builder, ary.shape)
@@ -1954,7 +1954,7 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
         # Source is an array
         src_dtype = srcty.dtype
         index_shape = indexer.get_shape()
-        src = make_array(srcty)(context, builder, src_orig)
+        src = make_array(srcty)(context, builder, src)
         # Broadcast source array to shape
         srcty, src = _broadcast_to_shape(context, builder, srcty, src,
                                          index_shape)
@@ -1980,7 +1980,7 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
         index_shape = indexer.get_shape()
         assert len(index_shape) == 1
         len_impl = context.get_function(len, signature(types.intp, srcty))
-        seq_len = len_impl(builder, (src_orig,))
+        seq_len = len_impl(builder, (src,))
 
         shape_error = builder.icmp_signed('!=', index_shape[0], seq_len)
 

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1341,6 +1341,10 @@ def fancy_getitem(context, builder, sig, args,
             context.nrt.decref(builder, indexer.idxty,
                                indexer.idxary._getvalue())
 
+    for i, idx, idxty, idx_make in array_indices:
+        if idxty.ndim > 1:
+            context.nrt.decref(builder, idxty, idx_make._getvalue())
+
     return impl_ret_new_ref(context, builder, out_ty, out._getvalue())
 
 
@@ -1876,7 +1880,7 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
     between the two for indexed assignment.
     """
     aryty, _, srcty = sig.args
-    ary, _, src = args
+    ary, _, src_orig = args
 
     ary = make_array(aryty)(context, builder, ary)
     dest_shapes = cgutils.unpack_tuple(builder, ary.shape)
@@ -1925,7 +1929,7 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
         # Source is an array
         src_dtype = srcty.dtype
         index_shape = indexer.get_shape()
-        src = make_array(srcty)(context, builder, src)
+        src = make_array(srcty)(context, builder, src_orig)
         # Broadcast source array to shape
         srcty, src = _broadcast_to_shape(context, builder, srcty, src,
                                          index_shape)
@@ -1951,7 +1955,7 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
         index_shape = indexer.get_shape()
         assert len(index_shape) == 1
         len_impl = context.get_function(len, signature(types.intp, srcty))
-        seq_len = len_impl(builder, (src,))
+        seq_len = len_impl(builder, (src_orig,))
 
         shape_error = builder.icmp_signed('!=', index_shape[0], seq_len)
 

--- a/numba/np/ufunc/dufunc.py
+++ b/numba/np/ufunc/dufunc.py
@@ -43,7 +43,8 @@ class UfuncAtIterator:
         return isinstance(self.indices_ty, types.BaseTuple)
 
     def _prepare(self, context, builder):
-        from numba.np.arrayobj import normalize_indices, FancyIndexer, make_array, get_bdcast_idx
+        from numba.np.arrayobj import (normalize_indices, FancyIndexer,
+                                       make_array, get_bdcast_idx)
 
         a, indices = self.a, self.indices
         a_ty, indices_ty = self.a_ty, self.indices_ty

--- a/numba/np/ufunc/dufunc.py
+++ b/numba/np/ufunc/dufunc.py
@@ -38,7 +38,6 @@ class UfuncAtIterator:
         loop_indices = self.indexer.begin_loops()
         self._call_ufunc(context, builder, loop_indices)
         self.indexer.end_loops()
-        self.bdcast_cleanup(context, builder)
 
     def need_advanced_indexing(self):
         return isinstance(self.indices_ty, types.BaseTuple)
@@ -75,7 +74,7 @@ class UfuncAtIterator:
                 array_indices.append((i, idx, idxty, idx_make))
 
         if array_indices:
-            bdcast_indices, subspace_shape_tuple, bdcast_cleanup = \
+            bdcast_indices, subspace_shape_tuple = \
                 get_bdcast_idx(context, builder, array_indices)
             indices = list(indices)
             index_types = list(index_types)
@@ -84,12 +83,10 @@ class UfuncAtIterator:
                 index_types[i] = bdcast_idxty
         else:
             subspace_shape_tuple = ()
-            bdcast_cleanup = lambda context, builder: None
         self.indexer = FancyIndexer(context, builder, a_ty, a,
                                     index_types, indices, subspace_shape_tuple)
         self.indexer.prepare()
         self.cres = self._compile_ufunc(context, builder)
-        self.bdcast_cleanup = bdcast_cleanup
 
     def _load_val(self, context, builder, loop_indices, array, array_ty):
         from numba.np.arrayobj import load_item

--- a/numba/np/ufunc/dufunc.py
+++ b/numba/np/ufunc/dufunc.py
@@ -38,6 +38,7 @@ class UfuncAtIterator:
         loop_indices = self.indexer.begin_loops()
         self._call_ufunc(context, builder, loop_indices)
         self.indexer.end_loops()
+        self.bdcast_cleanup(context, builder)
 
     def need_advanced_indexing(self):
         return isinstance(self.indices_ty, types.BaseTuple)
@@ -74,7 +75,7 @@ class UfuncAtIterator:
                 array_indices.append((i, idx, idxty, idx_make))
 
         if array_indices:
-            bdcast_indices, subspace_shape_tuple = \
+            bdcast_indices, subspace_shape_tuple, bdcast_cleanup = \
                 get_bdcast_idx(context, builder, array_indices)
             indices = list(indices)
             index_types = list(index_types)
@@ -83,11 +84,12 @@ class UfuncAtIterator:
                 index_types[i] = bdcast_idxty
         else:
             subspace_shape_tuple = ()
-
+            bdcast_cleanup = lambda context, builder: None
         self.indexer = FancyIndexer(context, builder, a_ty, a,
                                     index_types, indices, subspace_shape_tuple)
         self.indexer.prepare()
         self.cres = self._compile_ufunc(context, builder)
+        self.bdcast_cleanup = bdcast_cleanup
 
     def _load_val(self, context, builder, loop_indices, array, array_ty):
         from numba.np.arrayobj import load_item

--- a/numba/np/ufunc/dufunc.py
+++ b/numba/np/ufunc/dufunc.py
@@ -35,7 +35,7 @@ class UfuncAtIterator:
 
     def run(self, context, builder):
         self._prepare(context, builder)
-        loop_indices, _ = self.indexer.begin_loops()
+        loop_indices = self.indexer.begin_loops()
         self._call_ufunc(context, builder, loop_indices)
         self.indexer.end_loops()
 
@@ -43,7 +43,7 @@ class UfuncAtIterator:
         return isinstance(self.indices_ty, types.BaseTuple)
 
     def _prepare(self, context, builder):
-        from numba.np.arrayobj import normalize_indices, FancyIndexer
+        from numba.np.arrayobj import normalize_indices, FancyIndexer, make_array, get_bdcast_idx
 
         a, indices = self.a, self.indices
         a_ty, indices_ty = self.a_ty, self.indices_ty
@@ -65,8 +65,26 @@ class UfuncAtIterator:
             index_types, indices = normalize_indices(context, builder,
                                                      index_types, indices)
 
+        array_indices = []
+        for i, idxty in enumerate(index_types):
+            idx = indices[i]
+            if isinstance(idxty, types.Array):
+                idx_make = make_array(idxty)(context, builder, idx)
+                array_indices.append((i, idx, idxty, idx_make))
+
+        if array_indices:
+            bdcast_indices, subspace_shape_tuple = \
+                get_bdcast_idx(context, builder, array_indices)
+            indices = list(indices)
+            index_types = list(index_types)
+            for i, bdcast_idx, bdcast_idxty in bdcast_indices:
+                indices[i] = bdcast_idx
+                index_types[i] = bdcast_idxty
+        else:
+            subspace_shape_tuple = ()
+
         self.indexer = FancyIndexer(context, builder, a_ty, a,
-                                    index_types, indices)
+                                    index_types, indices, subspace_shape_tuple)
         self.indexer.prepare()
         self.cres = self._compile_ufunc(context, builder)
 

--- a/numba/tests/test_cfunc.py
+++ b/numba/tests/test_cfunc.py
@@ -142,8 +142,6 @@ class TestCFunc(TestCase):
         f = cfunc(div_sig, locals={'c': types.int64})(div_usecase)
         self.assertPreciseEqual(f.ctypes(8, 3), 2.0)
 
-    @unittest.skip("Skipping test because might be no longer relevant, " \
-    "ZeroDivisionError not raised")
     def test_errors(self):
         f = cfunc(div_sig)(div_usecase)
 

--- a/numba/tests/test_cfunc.py
+++ b/numba/tests/test_cfunc.py
@@ -142,6 +142,8 @@ class TestCFunc(TestCase):
         f = cfunc(div_sig, locals={'c': types.int64})(div_usecase)
         self.assertPreciseEqual(f.ctypes(8, 3), 2.0)
 
+    @unittest.skip("Skipping test because might be no longer relevant, " \
+    "ZeroDivisionError not raised")
     def test_errors(self):
         f = cfunc(div_sig)(div_usecase)
 

--- a/numba/tests/test_fancy_indexing.py
+++ b/numba/tests/test_fancy_indexing.py
@@ -12,53 +12,97 @@ from numba.tests.support import MemoryLeakMixin, TestCase
 
 
 class TestFancyIndexing(MemoryLeakMixin, TestCase):
-    # (shape or array, indices)
     # Every case has exactly one, one-dimensional array,
     # Otherwise it's not fancy indexing
+    shape = (5, 6, 7, 8, 9, 10)
     indexing_cases = [
-        # Pure integers
-        shape = (5, 6, 7, 8, 9, 10)
-        (shape, (0, 3, np.array([0, 1, 3, 4, 2]))),
-        ((5, 6, 7, 8, 9, 10), (0, np.array([0,1,3,4,2]), 5)),
-        ((5, 6, 7, 8, 9, 10), (0, -3, np.array([0,1,3,4,2]))),
-        ((5, 6, 7, 8, 9, 10), (0, np.array([0,1,3,4,2]), -5)),
-
-        # Pure Slices
-        ((5, 6, 7, 8, 9, 10), (slice(0, 1), slice(4, 5), np.array([0,1,3,4,2]))),
-        ((5, 6, 7, 8, 9, 10), (slice(3, 4), np.array([0,1,3,4,2]), slice(None))),
-
         # Slices + Integers
-        ((5, 6, 7, 8, 9, 10), (slice(4, 5), 3, np.array([0,1,3,4,2]), 1)),
-        ((5, 6, 7, 8, 9, 10), (3, np.array([0,1,3,4,2]), slice(None), slice(4))),
-
-        # Ellipsis
-        ((5, 6, 7, 8, 9, 10), (Ellipsis, np.array([0,1,3,4,2]))),
-        ((5, 6, 7, 8, 9, 10), (np.array([0,1,3,4,2]), Ellipsis)),
+        (slice(4, 5), 3, np.array([0,1,3,4,2]), 1),
+        (3, np.array([0,1,3,4,2]), slice(None), slice(4)),
 
         # Ellipsis + Integers
-        ((5, 6, 7, 8, 9, 10), (Ellipsis, 1, np.array([0,1,3,4,2]))),
-        ((5, 6, 7, 8, 9, 10), (np.array([0,1,3,4,2]), 3, Ellipsis)),
-
-        # Ellipsis + Slices
-        ((5, 6, 7, 8, 9, 10), (slice(1, 2), Ellipsis, np.array([0,1,3,4,2]))),
-        ((5, 6, 7, 8, 9, 10), (np.array([0,1,3,4,2]), slice(1, 4), Ellipsis)),
+        (Ellipsis, 1, np.array([0,1,3,4,2])),
+        (np.array([0,1,3,4,2]), 3, Ellipsis),
 
         # Ellipsis + Slices + Integers
-        ((5, 6, 7, 8, 9, 10), (Ellipsis, 1, np.array([0,1,3,4,2]), 3, slice(1,5))),
-        ((5, 6, 7, 8, 9, 10), (np.array([0,1,3,4,2]), 3, Ellipsis, slice(1,5))),
+        (Ellipsis, 1, np.array([0,1,3,4,2]), 3, slice(1,5)),
+        (np.array([0,1,3,4,2]), 3, Ellipsis, slice(1,5)),
 
-        # Boolean Arrays
-        ((5, 6, 7, 8, 9, 10), (slice(4, 5), 3,
-                               np.array([True, False, True, False, True, False, False]),
-                               1)),
-        ((5, 6, 7, 8, 9, 10), (3, np.array([True, False, True, False, True, False]),
-                               slice(None), slice(4))),
-
-        # Pure Arrays
-        ((5, 6, 7, 8, 9, 10), np.array([0,3,-2], dtype=np.int16)),
-        ((5, 6, 7, 8, 9, 10), np.array([0,3,1], dtype=np.uint16)),
-        ((5, 6, 7, 8, 9, 10), np.array([False,True,True,False,False])),
+        # Boolean Arrays + Integers
+        (slice(4, 5), 3,
+         np.array([True, False, True, False, True, False, False]),
+         1),
+        (3, np.array([True, False, True, False, True, False]),
+         slice(None), slice(4)),
     ]
+
+    rng = np.random.default_rng(1)
+
+    def generate_random_indices(self):
+        N = min(self.shape)
+        slice_choices = [slice(None, None, None),
+            slice(1, N - 1, None),
+            slice(0, None, 2),
+            slice(N - 1, None, -2),
+            slice(-N + 1, -1, None),
+            slice(-1, -N, -2),
+            slice(0, N - 1, None),
+            slice(-1, -N, -2)
+        ]
+        integer_choices = list(np.arange(N))
+
+        indices = []
+
+        # Generate 20 random slice cases
+        for i in range(20):
+            array_idx = self.rng.integers(0, 5, size=15)
+            # Randomly select 4 slices from our list
+            curr_idx = self.rng.choice(slice_choices, size=4).tolist()
+            # Replace one of the slice with the array index
+            _array_idx = self.rng.choice(4)
+            curr_idx[_array_idx] = array_idx
+            indices.append(tuple(curr_idx))
+        
+        # Generate 20 random integer cases 
+        for i in range(20):
+            array_idx = self.rng.integers(0, 5, size=15)
+            # Randomly select 4 integers from our list
+            curr_idx = self.rng.choice(integer_choices, size=4).tolist()
+            # Replace one of the slice with the array index
+            _array_idx = self.rng.choice(4)
+            curr_idx[_array_idx] = array_idx
+            indices.append(tuple(curr_idx))
+
+        # Generate 20 random ellipsis cases
+        for i in range(20):
+            array_idx = self.rng.integers(0, 5, size=15)
+            # Randomly select 4 slices from our list
+            curr_idx = self.rng.choice(slice_choices, size=4).tolist()
+            # Generate two seperate random indices, replace one with
+            # array and second with Ellipsis
+            _array_idx = self.rng.choice(4, size=2, replace=False)
+            curr_idx[_array_idx[0]] = array_idx
+            curr_idx[_array_idx[1]] = Ellipsis
+            indices.append(tuple(curr_idx))
+
+        # Generate 20 random boolean cases
+        for i in range(20):
+            array_idx = self.rng.integers(0, 5, size=15)
+            # Randomly select 4 slices from our list
+            curr_idx = self.rng.choice(slice_choices, size=4).tolist()
+            # Generate two seperate random indices, replace one with
+            # array and second with a boolean array of that shape
+            _array_idx = self.rng.choice(4, size=2, replace=False)
+            curr_idx[_array_idx[0]] = array_idx
+            bool_arr_shape = self.shape[_array_idx[1]]
+            curr_idx[_array_idx[1]] = np.array(
+                self.rng.choice(2, size=bool_arr_shape),
+                dtype=bool
+            )
+
+            indices.append(tuple(curr_idx))
+
+        return indices
 
     def check_getitem_indices(self, arr_shape, index):
         def get_item(array, idx):
@@ -81,9 +125,8 @@ class TestFancyIndexing(MemoryLeakMixin, TestCase):
         np.testing.assert_equal(got, expected)
 
         # Check a copy was *really* returned by Numba
-        if got.size:
-            got.fill(42)
-            np.testing.assert_equal(arr, orig)
+        got.fill(42)
+        np.testing.assert_equal(arr, orig)
 
     def check_setitem_indices(self, arr_shape, index):
         @njit     
@@ -106,22 +149,32 @@ class TestFancyIndexing(MemoryLeakMixin, TestCase):
         np.testing.assert_equal(got, expected)
 
     def test_getitem(self):
-        for arr_shape, idx in self.indexing_cases:
+        # Cases with a combination of integers + other objects
+        indices = self.indexing_cases
+
+        # Cases with permutations of either integers or objects
+        indices += self.generate_random_indices()
+
+        for arr_shape, idx in indices:
             with self.subTest(arr_shape=arr_shape, idx=idx):
                 self.check_getitem_indices(arr_shape, idx)
 
     def test_setitem(self):
-        for arr_shape, idx in self.indexing_cases:
+        # Cases with a combination of integers + other objects
+        indices = self.indexing_cases
+
+        # Cases with permutations of either integers or objects
+        indices += self.generate_random_indices()
+
+        for arr_shape, idx in indices:
             with self.subTest(arr_shape=arr_shape, idx=idx):
                 self.check_setitem_indices(arr_shape, idx)
 
     def test_unsupported_condition_exceptions(self):
-        arr_shape = (5, 6, 7, 8, 9, 10)
-
         # Cases with multi-dimensional indexing array
         idx = (0, 3, np.array([[1, 2], [2, 3]]))
         with self.assertRaises(TypingError) as raises:
-            self.check_getitem_indices(arr_shape, idx)
+            self.check_getitem_indices(self.shape, idx)
         self.assertIn(
             'Numba does not support multidimensional indices.',
             str(raises.exception)
@@ -130,7 +183,7 @@ class TestFancyIndexing(MemoryLeakMixin, TestCase):
         # Cases with more than one indexing array
         idx = (0, 3, np.array([1, 2]), np.array([1, 2]))
         with self.assertRaises(TypingError) as raises:
-            self.check_getitem_indices(arr_shape, idx)
+            self.check_getitem_indices(self.shape, idx)
         self.assertIn(
             'Numba doesn\'t support more than one non-scalar array index.',
             str(raises.exception)
@@ -140,11 +193,37 @@ class TestFancyIndexing(MemoryLeakMixin, TestCase):
         # (The subspaces here are separated by slice(None))
         idx = (0, np.array([1, 2]), slice(None), 3, 4)
         with self.assertRaises(TypingError) as raises:
-            self.check_getitem_indices(arr_shape, idx)
+            self.check_getitem_indices(self.shape, idx)
         self.assertIn(
             'Numba doesn\'t support more than one indexing subspace',
             str(raises.exception)
         )
+
+    def test_setitem_0d(self):
+        @njit     
+        def set_item(array, idx, item):
+            array[idx] = item
+        # Test setitem with a 0d-array
+        pyfunc = set_item.py_func
+        cfunc = set_item
+
+        inps = [
+            (np.zeros(3), np.array(3.14)),
+            (np.zeros(2), np.array(2)),
+            (np.zeros(3, dtype=np.int64), np.array(3, dtype=np.int64)),
+            (np.zeros(3, dtype=np.float64), np.array(1, dtype=np.int64)),
+            (np.zeros(5, dtype='<U3'), np.array('abc')),
+            (np.zeros((3,), dtype='<U3'), np.array('a')),
+            (np.array(['abc','def','ghi'], dtype='<U3'),
+             np.array('WXYZ', dtype='<U4')),
+            (np.zeros(3, dtype=complex), np.array(2+3j, dtype=complex)),
+        ]
+
+        for x1, v in inps:
+            x2 = x1.copy()
+            pyfunc(x1, 0, v)
+            cfunc(x2, 0, v)
+            self.assertPreciseEqual(x1, x2)
 
     def test_ellipsis_getsetitem(self):
         # See https://github.com/numba/numba/issues/3225

--- a/numba/tests/test_fancy_indexing.py
+++ b/numba/tests/test_fancy_indexing.py
@@ -12,21 +12,27 @@ from numba.tests.support import MemoryLeakMixin, TestCase
 
 
 class TestFancyIndexing(MemoryLeakMixin, TestCase):
-    # Every case has exactly one, one-dimensional array,
+    # Every case has exactly one array,
     # Otherwise it's not fancy indexing
     shape = (5, 6, 7, 8, 9, 10)
     indexing_cases = [
         # Slices + Integers
         (slice(4, 5), 3, np.array([0,1,3,4,2]), 1),
         (3, np.array([0,1,3,4,2]), slice(None), slice(4)),
+        (3, np.array([[0,1,3,4,2], [0,1,2,3,2], [3,1,3,4,1]]),
+         slice(None), slice(4)), # multidimensional
 
         # Ellipsis + Integers
         (Ellipsis, 1, np.array([0,1,3,4,2])),
         (np.array([0,1,3,4,2]), 3, Ellipsis),
+        (np.array([[0,1,3,4,2], [0,1,2,3,2], [3,1,3,4,1]]),
+         3, Ellipsis), # multidimensional
 
         # Ellipsis + Slices + Integers
         (Ellipsis, 1, np.array([0,1,3,4,2]), 3, slice(1,5)),
         (np.array([0,1,3,4,2]), 3, Ellipsis, slice(1,5)),
+        (np.array([[0,1,3,4,2], [0,1,2,3,2], [3,1,3,4,1]]),
+         3, Ellipsis, slice(1,5)), # multidimensional
 
         # Boolean Arrays + Integers
         (slice(4, 5), 3,
@@ -169,15 +175,6 @@ class TestFancyIndexing(MemoryLeakMixin, TestCase):
                 self.check_setitem_indices(self.shape, idx)
 
     def test_unsupported_condition_exceptions(self):
-        # Cases with multi-dimensional indexing array
-        idx = (0, 3, np.array([[1, 2], [2, 3]]))
-        with self.assertRaises(TypingError) as raises:
-            self.check_getitem_indices(self.shape, idx)
-        self.assertIn(
-            'Multi-dimensional indices are not supported.',
-            str(raises.exception)
-        )
-
         # Cases with more than one indexing array
         idx = (0, 3, np.array([1, 2]), np.array([1, 2]))
         with self.assertRaises(TypingError) as raises:

--- a/numba/tests/test_fancy_indexing.py
+++ b/numba/tests/test_fancy_indexing.py
@@ -90,12 +90,10 @@ class TestFancyIndexing(MemoryLeakMixin, TestCase):
             array_idx = self.rng.integers(0, 5, size=15)
             # Randomly select 4 slices from our list
             curr_idx = self.rng.choice(slice_choices, size=4).tolist()
-            # Generate two seperate random indices, replace one with
-            # array and second with a boolean array of that shape
-            _array_idx = self.rng.choice(4, size=2, replace=False)
-            curr_idx[_array_idx[0]] = array_idx
-            bool_arr_shape = self.shape[_array_idx[1]]
-            curr_idx[_array_idx[1]] = np.array(
+            # Replace one of the slice with the boolean array index
+            _array_idx = self.rng.choice(4)
+            bool_arr_shape = self.shape[_array_idx]
+            curr_idx[_array_idx] = np.array(
                 self.rng.choice(2, size=bool_arr_shape),
                 dtype=bool
             )
@@ -155,9 +153,9 @@ class TestFancyIndexing(MemoryLeakMixin, TestCase):
         # Cases with permutations of either integers or objects
         indices += self.generate_random_indices()
 
-        for arr_shape, idx in indices:
-            with self.subTest(arr_shape=arr_shape, idx=idx):
-                self.check_getitem_indices(arr_shape, idx)
+        for idx in indices:
+            with self.subTest(idx=idx):
+                self.check_getitem_indices(self.shape, idx)
 
     def test_setitem(self):
         # Cases with a combination of integers + other objects
@@ -166,9 +164,9 @@ class TestFancyIndexing(MemoryLeakMixin, TestCase):
         # Cases with permutations of either integers or objects
         indices += self.generate_random_indices()
 
-        for arr_shape, idx in indices:
-            with self.subTest(arr_shape=arr_shape, idx=idx):
-                self.check_setitem_indices(arr_shape, idx)
+        for idx in indices:
+            with self.subTest(idx=idx):
+                self.check_setitem_indices(self.shape, idx)
 
     def test_unsupported_condition_exceptions(self):
         # Cases with multi-dimensional indexing array
@@ -176,7 +174,7 @@ class TestFancyIndexing(MemoryLeakMixin, TestCase):
         with self.assertRaises(TypingError) as raises:
             self.check_getitem_indices(self.shape, idx)
         self.assertIn(
-            'Numba does not support multidimensional indices.',
+            'Multi-dimensional indices are not supported.',
             str(raises.exception)
         )
 
@@ -185,7 +183,7 @@ class TestFancyIndexing(MemoryLeakMixin, TestCase):
         with self.assertRaises(TypingError) as raises:
             self.check_getitem_indices(self.shape, idx)
         self.assertIn(
-            'Numba doesn\'t support more than one non-scalar array index.',
+            'Using more than one non-scalar array index is unsupported.',
             str(raises.exception)
         )
 
@@ -194,8 +192,10 @@ class TestFancyIndexing(MemoryLeakMixin, TestCase):
         idx = (0, np.array([1, 2]), slice(None), 3, 4)
         with self.assertRaises(TypingError) as raises:
             self.check_getitem_indices(self.shape, idx)
+        msg = "Using more than one indexing subspace (consecutive group " +\
+                "of integer or array indices) is unsupported."
         self.assertIn(
-            'Numba doesn\'t support more than one indexing subspace',
+            msg,
             str(raises.exception)
         )
 

--- a/numba/tests/test_fancy_indexing.py
+++ b/numba/tests/test_fancy_indexing.py
@@ -5,121 +5,149 @@ import numpy as np
 
 import unittest
 from numba import jit, typeof, njit
+from numba import njit, typeof
 from numba.core import types
 from numba.core.errors import TypingError
 from numba.tests.support import MemoryLeakMixin, TestCase
 
 
-def getitem_usecase(a, b):
-    return a[b]
-
-def setitem_usecase(a, idx, b):
-    a[idx] = b
-
-def np_take(A, indices):
-    return np.take(A, indices)
-
-def np_take_kws(A, indices, axis):
-    return np.take(A, indices, axis=axis)
-
 class TestFancyIndexing(MemoryLeakMixin, TestCase):
+    # (shape or array, indices)
+    # Every case has exactly one, one-dimensional array,
+    # Otherwise it's not fancy indexing
+    indexing_cases = [
+        # Pure integers
+        ((5, 6, 7, 8, 9, 10), (0, 3, np.array([0,1,3,4,2]))),
+        ((5, 6, 7, 8, 9, 10), (0, np.array([0,1,3,4,2]), 5)),
+        ((5, 6, 7, 8, 9, 10), (0, -3, np.array([0,1,3,4,2]))),
+        ((5, 6, 7, 8, 9, 10), (0, np.array([0,1,3,4,2]), -5)),
 
-    def generate_advanced_indices(self, N, many=True):
-        choices = [np.int16([0, N - 1, -2])]
-        if many:
-            choices += [np.uint16([0, 1, N - 1]),
-                        np.bool_([0, 1, 1, 0])]
-        return choices
+        # Pure Slices
+        ((5, 6, 7, 8, 9, 10), (slice(0, 1), slice(4, 5), np.array([0,1,3,4,2]))),
+        ((5, 6, 7, 8, 9, 10), (slice(3, 4), np.array([0,1,3,4,2]), slice(None))),
 
-    def generate_basic_index_tuples(self, N, maxdim, many=True):
-        """
-        Generate basic index tuples with 0 to *maxdim* items.
-        """
-        # Note integers can be considered advanced indices in certain
-        # cases, so we avoid them here.
-        # See "Combining advanced and basic indexing"
-        # in http://docs.scipy.org/doc/numpy/reference/arrays.indexing.html
-        if many:
-            choices = [slice(None, None, None),
-                       slice(1, N - 1, None),
-                       slice(0, None, 2),
-                       slice(N - 1, None, -2),
-                       slice(-N + 1, -1, None),
-                       slice(-1, -N, -2),
-                       ]
-        else:
-            choices = [slice(0, N - 1, None),
-                       slice(-1, -N, -2)]
-        for ndim in range(maxdim + 1):
-            for tup in itertools.product(choices, repeat=ndim):
-                yield tup
+        # Slices + Integers
+        ((5, 6, 7, 8, 9, 10), (slice(4, 5), 3, np.array([0,1,3,4,2]), 1)),
+        ((5, 6, 7, 8, 9, 10), (3, np.array([0,1,3,4,2]), slice(None), slice(4))),
 
-    def generate_advanced_index_tuples(self, N, maxdim, many=True):
-        """
-        Generate advanced index tuples by generating basic index tuples
-        and adding a single advanced index item.
-        """
-        # (Note Numba doesn't support advanced indices with more than
-        #  one advanced index array at the moment)
-        choices = list(self.generate_advanced_indices(N, many=many))
-        for i in range(maxdim + 1):
-            for tup in self.generate_basic_index_tuples(N, maxdim - 1, many):
-                for adv in choices:
-                    yield tup[:i] + (adv,) + tup[i:]
+        # Ellipsis
+        ((5, 6, 7, 8, 9, 10), (Ellipsis, np.array([0,1,3,4,2]))),
+        ((5, 6, 7, 8, 9, 10), (np.array([0,1,3,4,2]), Ellipsis)),
 
-    def generate_advanced_index_tuples_with_ellipsis(self, N, maxdim, many=True):
-        """
-        Same as generate_advanced_index_tuples(), but also insert an
-        ellipsis at various points.
-        """
-        for tup in self.generate_advanced_index_tuples(N, maxdim, many):
-            for i in range(len(tup) + 1):
-                yield tup[:i] + (Ellipsis,) + tup[i:]
+        # Ellipsis + Integers
+        ((5, 6, 7, 8, 9, 10), (Ellipsis, 1, np.array([0,1,3,4,2]))),
+        ((5, 6, 7, 8, 9, 10), (np.array([0,1,3,4,2]), 3, Ellipsis)),
 
-    def check_getitem_indices(self, arr, indices):
-        pyfunc = getitem_usecase
-        cfunc = jit(nopython=True)(pyfunc)
+        # Ellipsis + Slices
+        ((5, 6, 7, 8, 9, 10), (slice(1, 2), Ellipsis, np.array([0,1,3,4,2]))),
+        ((5, 6, 7, 8, 9, 10), (np.array([0,1,3,4,2]), slice(1, 4), Ellipsis)),
+
+        # Ellipsis + Slices + Integers
+        ((5, 6, 7, 8, 9, 10), (Ellipsis, 1, np.array([0,1,3,4,2]), 3, slice(1,5))),
+        ((5, 6, 7, 8, 9, 10), (np.array([0,1,3,4,2]), 3, Ellipsis, slice(1,5))),
+
+        # Boolean Arrays
+        ((5, 6, 7, 8, 9, 10), (slice(4, 5), 3,
+                               np.array([True, False, True, False, True, False, False]),
+                               1)),
+        ((5, 6, 7, 8, 9, 10), (3, np.array([True, False, True, False, True, False]),
+                               slice(None), slice(4))),
+
+        # Pure Arrays
+        ((5, 6, 7, 8, 9, 10), np.array([0,3,-2], dtype=np.int16)),
+        ((5, 6, 7, 8, 9, 10), np.array([0,3,1], dtype=np.uint16)),
+        ((5, 6, 7, 8, 9, 10), np.array([False,True,True,False,False])),
+    ]
+
+    def check_getitem_indices(self, arr_shape, index):
+        def get_item(array, idx):
+            return array[index]
+
+        arr = np.random.random_integers(0, 10, size=arr_shape)
+        get_item_numba = njit(get_item)
         orig = arr.copy()
         orig_base = arr.base or arr
 
-        for index in indices:
-            expected = pyfunc(arr, index)
-            # Sanity check: if a copy wasn't made, this wasn't advanced
-            # but basic indexing, and shouldn't be tested here.
-            assert expected.base is not orig_base
-            got = cfunc(arr, index)
-            # Note Numba may not return the same array strides and
-            # contiguity as Numpy
-            self.assertEqual(got.shape, expected.shape)
-            self.assertEqual(got.dtype, expected.dtype)
-            np.testing.assert_equal(got, expected)
-            # Check a copy was *really* returned by Numba
-            if got.size:
-                got.fill(42)
-                np.testing.assert_equal(arr, orig)
+        expected = get_item(arr, index)
+        got = get_item_numba(arr, index)
+        # Sanity check: In advanced indexing, the result is always a copy.
+        assert expected.base is not orig_base
 
-    def test_getitem_tuple(self):
-        # Test many variations of advanced indexing with a tuple index
-        N = 4
-        ndim = 3
-        arr = np.arange(N ** ndim).reshape((N,) * ndim).astype(np.int32)
-        indices = self.generate_advanced_index_tuples(N, ndim)
+        # Note: Numba may not return the same array strides and
+        # contiguity as Numpy
+        self.assertEqual(got.shape, expected.shape)
+        self.assertEqual(got.dtype, expected.dtype)
+        np.testing.assert_equal(got, expected)
 
-        self.check_getitem_indices(arr, indices)
+        # Check a copy was *really* returned by Numba
+        if got.size:
+            got.fill(42)
+            np.testing.assert_equal(arr, orig)
 
-    def test_getitem_tuple_and_ellipsis(self):
-        # Same, but also insert an ellipsis at a random point
-        N = 4
-        ndim = 3
-        arr = np.arange(N ** ndim).reshape((N,) * ndim).astype(np.int32)
-        indices = self.generate_advanced_index_tuples_with_ellipsis(N, ndim,
-                                                                    many=False)
+    def check_setitem_indices(self, arr_shape, index):
+        def set_item(array, idx, item):
+            array[idx] = item
 
-        self.check_getitem_indices(arr, indices)
+        arr = np.random.random_integers(0, 10, size=arr_shape)
+        set_item_numba = njit(set_item)
+        src = arr[index]
+        expected = np.zeros_like(arr)
+        got = np.zeros_like(arr)
+
+        set_item(expected, index, src)
+        set_item_numba(got, index, src)
+
+        # Note: Numba may not return the same array strides and
+        # contiguity as Numpy
+        self.assertEqual(got.shape, expected.shape)
+        self.assertEqual(got.dtype, expected.dtype)
+
+        np.testing.assert_equal(got, expected)
+
+    def test_getitem(self):
+        for arr_shape, idx in self.indexing_cases:
+            with self.subTest(arr_shape=arr_shape, idx=idx):
+                self.check_getitem_indices(arr_shape, idx)
+
+    def test_setitem(self):
+        for arr_shape, idx in self.indexing_cases:
+            with self.subTest(arr_shape=arr_shape, idx=idx):
+                self.check_setitem_indices(arr_shape, idx)
+
+    def test_fancy_errors(self):
+        arr_shape = (5, 6, 7, 8, 9, 10)
+
+        # Cases with multi-dimensional indexing array
+        idx = (0, 3, np.array([[1, 2], [2, 3]]))
+        with self.assertRaises(TypingError) as raises:
+            self.check_getitem_indices(arr_shape, idx)
+        self.assertIn(
+            'Numba does not support multidimensional indices.',
+            str(raises.exception)
+        )
+
+        # Cases with more than one indexing array
+        idx = (0, 3, np.array([1, 2]), np.array([1, 2]))
+        with self.assertRaises(TypingError) as raises:
+            self.check_getitem_indices(arr_shape, idx)
+        self.assertIn(
+            'Numba doesn\'t support more than one non-scalar array index.',
+            str(raises.exception)
+        )
+
+        # Cases with more than one indexing subspace
+        # (The subspaces here are separated by slice(None))
+        idx = (0, np.array([1, 2]), slice(None), 3, 4)
+        with self.assertRaises(TypingError) as raises:
+            self.check_getitem_indices(arr_shape, idx)
+        self.assertIn(
+            'Numba doesn\'t support more than one indexing subspace',
+            str(raises.exception)
+        )
 
     def test_ellipsis_getsetitem(self):
         # See https://github.com/numba/numba/issues/3225
-        @jit(nopython=True)
+        @njit
         def foo(arr, v):
             arr[..., 0] = arr[..., 1]
 
@@ -127,83 +155,13 @@ class TestFancyIndexing(MemoryLeakMixin, TestCase):
         foo(arr, 1)
         self.assertEqual(arr[0], arr[1])
 
-    def test_getitem_array(self):
-        # Test advanced indexing with a single array index
-        N = 4
-        ndim = 3
-        arr = np.arange(N ** ndim).reshape((N,) * ndim).astype(np.int32)
-        indices = self.generate_advanced_indices(N)
-        self.check_getitem_indices(arr, indices)
-
-    def check_setitem_indices(self, arr, indices):
-        pyfunc = setitem_usecase
-        cfunc = jit(nopython=True)(pyfunc)
-
-        for index in indices:
-            src = arr[index]
-            expected = np.zeros_like(arr)
-            got = np.zeros_like(arr)
-            pyfunc(expected, index, src)
-            cfunc(got, index, src)
-            # Note Numba may not return the same array strides and
-            # contiguity as Numpy
-            self.assertEqual(got.shape, expected.shape)
-            self.assertEqual(got.dtype, expected.dtype)
-            np.testing.assert_equal(got, expected)
-
-    def test_setitem_tuple(self):
-        # Test many variations of advanced indexing with a tuple index
-        N = 4
-        ndim = 3
-        arr = np.arange(N ** ndim).reshape((N,) * ndim).astype(np.int32)
-        indices = self.generate_advanced_index_tuples(N, ndim)
-        self.check_setitem_indices(arr, indices)
-
-    def test_setitem_tuple_and_ellipsis(self):
-        # Same, but also insert an ellipsis at a random point
-        N = 4
-        ndim = 3
-        arr = np.arange(N ** ndim).reshape((N,) * ndim).astype(np.int32)
-        indices = self.generate_advanced_index_tuples_with_ellipsis(N, ndim,
-                                                                    many=False)
-
-        self.check_setitem_indices(arr, indices)
-
-    def test_setitem_array(self):
-        # Test advanced indexing with a single array index
-        N = 4
-        ndim = 3
-        arr = np.arange(N ** ndim).reshape((N,) * ndim).astype(np.int32) + 10
-        indices = self.generate_advanced_indices(N)
-        self.check_setitem_indices(arr, indices)
-
-    def test_setitem_0d(self):
-        # Test setitem with a 0d-array
-        pyfunc = setitem_usecase
-        cfunc = jit(nopython=True)(pyfunc)
-
-        inps = [
-            (np.zeros(3), np.array(3.14)),
-            (np.zeros(2), np.array(2)),
-            (np.zeros(3, dtype=np.int64), np.array(3, dtype=np.int64)),
-            (np.zeros(3, dtype=np.float64), np.array(1, dtype=np.int64)),
-            (np.zeros(5, dtype='<U3'), np.array('abc')),
-            (np.zeros((3,), dtype='<U3'), np.array('a')),
-            (np.array(['abc','def','ghi'], dtype='<U3'),
-             np.array('WXYZ', dtype='<U4')),
-            (np.zeros(3, dtype=complex), np.array(2+3j, dtype=complex)),
-        ]
-
-        for x1, v in inps:
-            x2 = x1.copy()
-            pyfunc(x1, 0, v)
-            cfunc(x2, 0, v)
-            self.assertPreciseEqual(x1, x2)
-
     def test_np_take(self):
+        def np_take(array, indices):
+            return np.take(array, indices)
+
         # shorter version of array.take test in test_array_methods
         pyfunc = np_take
-        cfunc = jit(nopython=True)(pyfunc)
+        cfunc = njit(pyfunc)
 
         def check(arr, ind):
             expected = pyfunc(arr, ind)
@@ -248,6 +206,19 @@ class TestFancyIndexing(MemoryLeakMixin, TestCase):
         # check float indexing raises
         with self.assertRaises(TypingError):
             cfunc(A, [1.7])
+
+        def np_take_kws(array, indices, axis):
+            return np.take(array, indices, axis=axis)
+    
+        # check unsupported arg raises
+        with self.assertRaises(TypingError):
+            take_kws = njit(np_take_kws)
+            take_kws(A, 1, 1)
+
+        # check kwarg unsupported raises
+        with self.assertRaises(TypingError):
+            take_kws = njit(np_take_kws)
+            take_kws(A, 1, axis=1)
 
         #exceptions leak refs
         self.disable_leak_check()

--- a/numba/tests/test_fancy_indexing.py
+++ b/numba/tests/test_fancy_indexing.py
@@ -289,7 +289,7 @@ class TestFancyIndexing(MemoryLeakMixin, TestCase):
 
         def np_take_kws(array, indices, axis):
             return np.take(array, indices, axis=axis)
-    
+
         # check unsupported arg raises
         with self.assertRaises(TypingError):
             take_kws = njit(np_take_kws)

--- a/numba/tests/test_fancy_indexing.py
+++ b/numba/tests/test_fancy_indexing.py
@@ -17,7 +17,8 @@ class TestFancyIndexing(MemoryLeakMixin, TestCase):
     # Otherwise it's not fancy indexing
     indexing_cases = [
         # Pure integers
-        ((5, 6, 7, 8, 9, 10), (0, 3, np.array([0,1,3,4,2]))),
+        shape = (5, 6, 7, 8, 9, 10)
+        (shape, (0, 3, np.array([0, 1, 3, 4, 2]))),
         ((5, 6, 7, 8, 9, 10), (0, np.array([0,1,3,4,2]), 5)),
         ((5, 6, 7, 8, 9, 10), (0, -3, np.array([0,1,3,4,2]))),
         ((5, 6, 7, 8, 9, 10), (0, np.array([0,1,3,4,2]), -5)),
@@ -85,20 +86,20 @@ class TestFancyIndexing(MemoryLeakMixin, TestCase):
             np.testing.assert_equal(arr, orig)
 
     def check_setitem_indices(self, arr_shape, index):
+        @njit     
         def set_item(array, idx, item):
             array[idx] = item
 
         arr = np.random.random_integers(0, 10, size=arr_shape)
-        set_item_numba = njit(set_item)
         src = arr[index]
         expected = np.zeros_like(arr)
         got = np.zeros_like(arr)
 
-        set_item(expected, index, src)
-        set_item_numba(got, index, src)
+        set_item.py_func(expected, index, src)
+        set_item(got, index, src)
 
         # Note: Numba may not return the same array strides and
-        # contiguity as Numpy
+        # contiguity as NumPy
         self.assertEqual(got.shape, expected.shape)
         self.assertEqual(got.dtype, expected.dtype)
 
@@ -114,7 +115,7 @@ class TestFancyIndexing(MemoryLeakMixin, TestCase):
             with self.subTest(arr_shape=arr_shape, idx=idx):
                 self.check_setitem_indices(arr_shape, idx)
 
-    def test_fancy_errors(self):
+    def test_unsupported_condition_exceptions(self):
         arr_shape = (5, 6, 7, 8, 9, 10)
 
         # Cases with multi-dimensional indexing array

--- a/numba/tests/test_fancy_indexing.py
+++ b/numba/tests/test_fancy_indexing.py
@@ -262,19 +262,6 @@ class TestFancyIndexing(MemoryLeakMixin, TestCase):
         with self.assertRaises(TypingError):
             cfunc(A, [1.7])
 
-        def np_take_kws(array, indices, axis):
-            return np.take(array, indices, axis=axis)
-
-        # check unsupported arg raises
-        with self.assertRaises(TypingError):
-            take_kws = njit(np_take_kws)
-            take_kws(A, 1, 1)
-
-        # check kwarg unsupported raises
-        with self.assertRaises(TypingError):
-            take_kws = njit(np_take_kws)
-            take_kws(A, 1, axis=1)
-
         #exceptions leak refs
         self.disable_leak_check()
 

--- a/numba/tests/test_fancy_indexing.py
+++ b/numba/tests/test_fancy_indexing.py
@@ -398,6 +398,10 @@ class TestFancyIndexingMultiDim(MemoryLeakMixin, TestCase):
          1),
         (3, np.array([True, False, True, False, True, False]),
          slice(None), slice(4)),
+
+        # Mutiple multidimensional array indices
+        (3, np.array([[0,1,3,4,2], [0,1,2,3,2], [3,1,3,4,1]]), slice(None), np.array([[0,1,3,4,2], [0,1,2,3,2], [3,1,3,4,1]])),
+        (np.array([[0,1,3,4,2], [0,1,2,3,2], [3,1,3,4,1]]), 3, Ellipsis, np.array([[0,1,3,4,2], [0,1,2,3,2], [3,1,3,4,1]])),
     ]
 
     def setUp(self):

--- a/numba/tests/test_fancy_indexing.py
+++ b/numba/tests/test_fancy_indexing.py
@@ -400,8 +400,10 @@ class TestFancyIndexingMultiDim(MemoryLeakMixin, TestCase):
          slice(None), slice(4)),
 
         # Mutiple multidimensional array indices
-        (3, np.array([[0,1,3,4,2], [0,1,2,3,2], [3,1,3,4,1]]), slice(None), np.array([[0,1,3,4,2], [0,1,2,3,2], [3,1,3,4,1]])),
-        (np.array([[0,1,3,4,2], [0,1,2,3,2], [3,1,3,4,1]]), 3, Ellipsis, np.array([[0,1,3,4,2], [0,1,2,3,2], [3,1,3,4,1]])),
+        (3, np.array([[0,1,3,4,2], [0,1,2,3,2], [3,1,3,4,1]]), np.array([[0,1,3,4,2], [0,1,2,3,2], [3,1,3,4,1]]), slice(None)), # Consecutive multidimensional array indices
+        (3, np.array([[0,1,3,4,2], [0,1,2,3,2], [3,1,3,4,1]]), slice(None), np.array([[0,1,3,4,2], [0,1,2,3,2], [3,1,3,4,1]])), # Non-consecutive multidimensional array indices
+        (np.array([[0,1,3,4,2], [0,1,2,3,2], [3,1,3,4,1]]), np.array([[0,1,3,4,2], [0,1,2,3,2], [3,1,3,4,1]]), 3, Ellipsis), # Consecutive multidimensional array indices with Ellipsis
+        (np.array([[0,1,3,4,2], [0,1,2,3,2], [3,1,3,4,1]]), 3, Ellipsis, np.array([[0,1,3,4,2], [0,1,2,3,2], [3,1,3,4,1]])), # Non-consecutive multidimensional array indices with Ellipsis
     ]
 
     def setUp(self):

--- a/numba/tests/test_fancy_indexing.py
+++ b/numba/tests/test_fancy_indexing.py
@@ -4,9 +4,7 @@ import itertools
 import numpy as np
 
 import unittest
-from numba import jit, typeof, njit
-from numba import njit, typeof
-from numba.core import types
+from numba import jit, njit
 from numba.core.errors import TypingError
 from numba.tests.support import MemoryLeakMixin, TestCase
 


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->


As titled, 

This PR adds fancy indexing support in Numba. 

Example:

```
import numba
import numpy as np

@numba.njit
def non_shifted_subspace(x, idx, idx2):
    return x[:, idx, idx2, :]

@numba.njit
def shifted_subspace(x, idx, idx2):
    return x[:, idx, :, idx2]

a = np.random.randint(0, 100, (10, 11, 12, 13, 14))
b = np.random.randint(0, 4, (4, 5)) # Previously, these were limited to 1-D.
c = np.random.randint(0, 4, (4, 5)) # Previously, these were limited to a single array

print(non_shifted_subspace(a, b, c).shape) 
# (10, 4, 5, 13, 14)
print(np.allclose(non_shifted_subspace(a, b, c), non_shifted_subspace.py_func(a, b, c)))
# True

print(shifted_subspace(a, b, c).shape) 
# (4, 5, 10, 13, 14)
print(np.allclose(shifted_subspace(a, b, c), shifted_subspace.py_func(a, b, c)))
# True

```