### PR TITLE
Add scalar support for np.var and np.std

### DIFF
--- a/docs/upcoming_changes/10408.bug_fix.rst
+++ b/docs/upcoming_changes/10408.bug_fix.rst
@@ -1,0 +1,7 @@
+Fix scalar handling in ``np.var`` and ``np.std``
+-------------------------------------------------
+
+Fix scalar handling in ``np.var`` and ``np.std``. Previously, these
+functions would fail when called with scalar inputs. Now they properly
+handle both scalar and array inputs, returning 0.0 for scalar variance
+and standard deviation (consistent with NumPy behavior).

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -460,7 +460,19 @@ def array_mean(a):
 @overload(np.var)
 @overload_method(types.Array, "var")
 def array_var(a):
-    if isinstance(a, types.Array):
+    if isinstance(a, (types.Integer, types.Boolean)):
+        def _scalar_var(a):
+            return np.float64(0.0)
+        return _scalar_var
+    elif isinstance(a, types.Float):
+        def _scalar_var(a):
+            return type(a)(0.0)
+        return _scalar_var
+    elif isinstance(a, types.Complex):
+        def _scalar_var(a):
+            return np.float64(0.0)
+        return _scalar_var
+    elif isinstance(a, types.Array):
         def array_var_impl(a):
             # Compute the mean
             m = a.mean()
@@ -473,16 +485,30 @@ def array_var(a):
             return ssd / a.size
 
         return array_var_impl
+    return None
 
 
 @overload(np.std)
 @overload_method(types.Array, "std")
 def array_std(a):
-    if isinstance(a, types.Array):
+    if isinstance(a, (types.Integer, types.Boolean)):
+        def _scalar_std(a):
+            return np.float64(0.0)
+        return _scalar_std
+    elif isinstance(a, types.Float):
+        def _scalar_std(a):
+            return type(a)(0.0)
+        return _scalar_std
+    elif isinstance(a, types.Complex):
+        def _scalar_std(a):
+            return np.float64(0.0)
+        return _scalar_std
+    elif isinstance(a, types.Array):
         def array_std_impl(a):
             return a.var() ** 0.5
 
         return array_std_impl
+    return None
 
 
 @register_jitable

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -428,8 +428,72 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
     def test_var_basic(self):
         self.check_reduction_basic(array_var, prec='double')
 
+    def test_np_var_scalar(self):
+        cfunc = jit(nopython=True)(array_var_global)
+
+        def check(arg):
+            expected = array_var_global(arg)
+            got = cfunc(arg)
+            self.assertPreciseEqual(got, expected)
+
+        # NumPy integer and boolean scalars
+        check(np.int32(2))
+        check(np.int64(-3))
+        check(np.uint32(5))
+        check(np.bool_(True))
+        check(np.bool_(False))
+
+        # NumPy floating scalars
+        check(np.float32(1.25))
+        check(np.float64(-2.5))
+
+        # Complex values
+        check(np.complex64(7+0j))
+        check(np.complex128(61+74j))
+
+        # Special floating values
+        check(np.float64(0.0))
+        check(np.float64(0.0000042))
+        check(np.float64(-0.25863))
+
+        # Error cases
+        with self.assertTypingError():
+            cfunc('test String')
+
     def test_std_basic(self):
         self.check_reduction_basic(array_std)
+
+    def test_np_std_scalar(self):
+        cfunc = jit(nopython=True)(array_std_global)
+
+        def check(arg):
+            expected = array_std_global(arg)
+            got = cfunc(arg)
+            self.assertPreciseEqual(got, expected)
+
+        # NumPy integer and boolean scalars
+        check(np.int32(2))
+        check(np.int64(-3))
+        check(np.uint32(5))
+        check(np.bool_(True))
+        check(np.bool_(False))
+
+        # NumPy floating scalars
+        check(np.float32(1.25))
+        check(np.float64(-2.5))
+
+        # Complex values
+        check(np.complex64(7+0j))
+        check(np.complex128(61+74j))
+
+        # Special floating values
+        check(np.float64(0.0))
+        check(np.float64(0.0000042))
+        check(np.float64(-0.25863))
+
+        # Error cases
+        with self.assertTypingError():
+            cfunc('test String')
 
     def test_min_basic(self):
         #scalar testing


### PR DESCRIPTION
## Summary
Partially addresses #10408

Adds scalar input support for `np.var` and `np.std`, which previously raised `TypingError` when called with scalar arguments.

## Changes
- **`numba/np/arraymath.py`**: Added scalar type handling to `array_var` and `array_std` overloads, following the same pattern as `np.mean` (PR #10428) and `np.min`/`np.max` (PR #10435)
- **`numba/tests/test_array_reductions.py`**: Added `test_np_var_scalar` and `test_np_std_scalar` tests covering integer, boolean, float, complex, and error cases
- **`docs/upcoming_changes/10408.bug_fix.rst`**: Added changelog entry

## Behavior
For scalar inputs, variance and standard deviation are always `0.0` (consistent with NumPy):
- Integer/Boolean scalars → `np.float64(0.0)`
- Float scalars → preserve input type (e.g., `np.float32(0.0)`)
- Complex scalars → `np.float64(0.0)` (real-valued result)

```python
import numpy as np
from numba import njit

@njit
def foo(a):
    return np.var(a), np.std(a)

print(foo(np.float64(3.0)))  # (0.0, 0.0) — previously TypingError
```

## Checklist from #10408
- [ ] `np.var` ← **this PR**
- [ ] `np.std` ← **this PR**