### PR TITLE
Add scalar support for np.argmin and np.argmax

### DIFF
--- a/docs/upcoming_changes/10408.bug_fix.rst
+++ b/docs/upcoming_changes/10408.bug_fix.rst
@@ -1,0 +1,7 @@
+Fix scalar handling in ``np.argmin`` and ``np.argmax``
+------------------------------------------------------
+
+Fix scalar handling in ``np.argmin`` and ``np.argmax``. Previously,
+these functions would fail when called with scalar inputs. Now they
+properly handle both scalar and array inputs, returning 0 for scalar
+argmin and argmax (consistent with NumPy behavior).

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -679,6 +679,11 @@ def array_argmin_impl_generic(arry):
 @overload(np.argmin)
 @overload_method(types.Array, "argmin")
 def array_argmin(a, axis=None):
+    if isinstance(a, (types.Number, types.Boolean)):
+        def scalar_argmin_impl(a, axis=None):
+            return np.intp(0)
+        return scalar_argmin_impl
+
     if isinstance(a.dtype, (types.NPDatetime, types.NPTimedelta)):
         flatten_impl = array_argmin_impl_datetime
     elif isinstance(a.dtype, types.Float):
@@ -805,6 +810,11 @@ def build_argmax_or_argmin_with_axis_impl(a, axis, flatten_impl):
 @overload(np.argmax)
 @overload_method(types.Array, "argmax")
 def array_argmax(a, axis=None):
+    if isinstance(a, (types.Number, types.Boolean)):
+        def scalar_argmax_impl(a, axis=None):
+            return np.intp(0)
+        return scalar_argmax_impl
+
     if isinstance(a.dtype, (types.NPDatetime, types.NPTimedelta)):
         flatten_impl = array_argmax_impl_datetime
     elif isinstance(a.dtype, types.Float):

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -459,8 +459,14 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
     def test_argmin_basic(self):
         self.check_reduction_basic(array_argmin)
 
+    def test_np_argmin_scalar(self):
+        self.check_scalar_basic(array_argmin_global)
+
     def test_argmax_basic(self):
         self.check_reduction_basic(array_argmax)
+
+    def test_np_argmax_scalar(self):
+        self.check_scalar_basic(array_argmax_global)
 
     def test_nanmin_basic(self):
         self.check_reduction_basic(array_nanmin)


### PR DESCRIPTION
## Summary

Add scalar handling for `np.argmin` and `np.argmax`, addressing part of #10408.

For scalar inputs, both functions return `np.intp(0)`, consistent with NumPy behavior:
```python
>>> np.argmin(5.0)
0
>>> np.argmax(np.int32(-3))
0
```

## Changes

| File | Change |
|------|--------|
| `numba/np/arraymath.py` | Add scalar type check (`types.Number`, `types.Boolean`) before the array dtype dispatch in both `array_argmin` and `array_argmax` |
| `numba/tests/test_array_reductions.py` | Add `test_np_argmin_scalar` and `test_np_argmax_scalar` using existing `check_scalar_basic` harness |
| `docs/upcoming_changes/10408.bug_fix.rst` | Changelog entry |

## Pattern

Follows the same approach used in:
- `np.all` / `np.any` (scalar branch before array branch)
- PR #10428 (`np.mean` scalar support)
- PR #10452 (`np.var` / `np.std` scalar support)

🤖 Generated with [Claude Code](https://claude.com/claude-code)