### PR TITLE
Add scalar support for np.nanstd and np.nanprod (Part of #10408)

### DIFF
--- a/docs/upcoming_changes/10457.bug_fix.rst
+++ b/docs/upcoming_changes/10457.bug_fix.rst
@@ -1,0 +1,9 @@
+Fix scalar handling in ``np.nanstd`` and ``np.nanprod``
+-------------------------------------------------------
+
+Fix scalar handling in ``np.nanstd`` and ``np.nanprod`` functions. Previously,
+these functions would fail when called with scalar inputs. They now properly
+handle scalar arguments: ``np.nanstd`` returns ``float64(0.0)`` for a single
+non-NaN value (and ``nan`` if the scalar is ``NaN``), while ``np.nanprod``
+returns the scalar value cast to the appropriate accumulator type (treating
+``NaN`` as the identity element ``1``).

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -1282,8 +1282,25 @@ def np_nanvar(a):
 
 @overload(np.nanstd)
 def np_nanstd(a):
-    if not isinstance(a, types.Array):
-        return
+    if isinstance(a, (types.Integer, types.Boolean)):
+        # Scalar integers/booleans cannot be NaN; std of a single value is 0
+        def nanstd_int_scalar(a):
+            return np.float64(0.0)
+        return nanstd_int_scalar
+    elif isinstance(a, (types.Float, types.Complex)):
+        # NaN scalar → NaN output; std of a single non-NaN value is 0
+        # Preserve the input dtype (e.g. float32 in → float32 out)
+        out_dtype = as_dtype(a)
+        zero = out_dtype.type(0)
+        nan_val = out_dtype.type(np.nan)
+        isnan = get_isnan(a)
+        def nanstd_float_scalar(a):
+            if isnan(a):
+                return nan_val
+            return zero
+        return nanstd_float_scalar
+    elif not isinstance(a, types.Array):
+        return None
 
     def nanstd_impl(a):
         return np.nanvar(a) ** 0.5
@@ -1315,8 +1332,29 @@ def np_nansum(a):
 
 @overload(np.nanprod)
 def np_nanprod(a):
-    if not isinstance(a, types.Array):
-        return
+    if isinstance(a, (types.Integer, types.Boolean)):
+        # Mirrors the array path: integer/bool dtype → intp accumulator, no NaN possible
+        out_dtype = as_dtype(types.intp)
+        acc_init = get_accumulator(out_dtype, 1)
+        def nanprod_int_scalar(a):
+            c = acc_init
+            c *= a
+            return c
+        return nanprod_int_scalar
+    elif isinstance(a, (types.Float, types.Complex)):
+        # NaN → treat as identity element (1); otherwise return the value
+        out_dtype = as_dtype(a)
+        acc_init = get_accumulator(out_dtype, 1)
+        isnan = get_isnan(a)
+        def nanprod_float_scalar(a):
+            c = acc_init
+            if not isnan(a):
+                c *= a
+            return c
+        return nanprod_float_scalar
+    elif not isinstance(a, types.Array):
+        return None
+
     if isinstance(a.dtype, types.Integer):
         retty = types.intp
     else:

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -477,8 +477,14 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
     def test_nanprod_basic(self):
         self.check_reduction_basic(array_nanprod)
 
+    def test_np_nanprod_scalar(self):
+        self.check_scalar_basic(array_nanprod)
+
     def test_nanstd_basic(self):
         self.check_reduction_basic(array_nanstd)
+
+    def test_np_nanstd_scalar(self):
+        self.check_scalar_basic(array_nanstd)
 
     def test_nanvar_basic(self):
         self.check_reduction_basic(array_nanvar, prec='double')


### PR DESCRIPTION
## Summary

Adds scalar input support for `np.nanstd` and `np.nanprod` in nopython
mode. Both functions previously raised a typing error when passed a
scalar — this fixes that.

Part of #10408.

## What changed

**`np.nanstd`**
- Integer/boolean scalar → always `float64(0.0)` (std of a single value
  is zero by definition, and integers can't be NaN)
- Float/complex scalar → `float64(nan)` if the input is NaN, otherwise
  `float64(0.0)`

**`np.nanprod`**
- Integer/boolean scalar → returns the value cast to `intp` (same
  accumulator type as the array path)
- Float/complex scalar → treats NaN as the identity element `1` and
  returns `1.0`, otherwise returns the value — matches NumPy behaviour

## Example
```python
@njit
def foo(x):
    return np.nanstd(x), np.nanprod(x)

foo(np.float64(3.5))          # -> (0.0, 3.5)
foo(np.float64(np.nan))       # -> (nan, 1.0)
foo(np.int32(5))              # -> (0.0, 5)
```

## Testing

Tests delegate to the existing `check_scalar_basic` helper to keep
things consistent with the rest of the suite.
```bash
python -m pytest numba/tests/test_array_reductions.py \
    -k "test_np_nanprod_scalar or test_np_nanstd_scalar" -v
```

## What's not in this PR

- `np.median`, `np.cumsum`, `np.cumprod` scalar fixes are in separate
  PRs (#10455, #10456)
- No changes to existing array behaviour

Closes #10408 (partial)