### PR TITLE
Add scalar support for np.nanmean and np.nanvar (Part of #10408)

### DIFF
--- a/docs/upcoming_changes/10458.bug_fix.rst
+++ b/docs/upcoming_changes/10458.bug_fix.rst
@@ -1,0 +1,10 @@
+Fix scalar handling in ``np.nanmean`` and ``np.nanvar``
+-------------------------------------------------------
+
+Fix scalar handling in ``np.nanmean`` and ``np.nanvar`` functions. Previously,
+these functions would fail when called with scalar inputs. They now properly
+handle scalar arguments: ``np.nanmean`` returns the scalar value cast to the
+appropriate type (``float64`` for integer/boolean inputs, preserving the dtype
+for float/complex inputs, and returning ``NaN`` if the input is ``NaN``), while
+``np.nanvar`` returns ``0.0`` for a single non-NaN value (variance of a single
+value is zero by definition) and ``NaN`` if the input is ``NaN``.

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -1237,8 +1237,26 @@ def np_nanmax(a):
 
 @overload(np.nanmean)
 def np_nanmean(a):
-    if not isinstance(a, types.Array):
-        return
+    if isinstance(a, (types.Integer, types.Boolean)):
+        # No NaN possible; mirrors np.mean scalar — integers/booleans upcast to float64
+        def nanmean_int_scalar(a):
+            return np.float64(a)
+        return nanmean_int_scalar
+    elif isinstance(a, (types.Float, types.Complex)):
+        # NaN scalar: nanmean of all-NaN returns NaN; otherwise preserve dtype
+        out_dtype = as_dtype(a)
+        nan_val = out_dtype.type(np.nan)
+        zero = out_dtype.type(0)
+        isnan = get_isnan(a)
+
+        def nanmean_float_scalar(a):
+            if isnan(a):
+                return nan_val
+            return a + zero  # +0 normalises -0.0 → 0.0, matching NumPy
+        return nanmean_float_scalar
+    elif not isinstance(a, types.Array):
+        return None
+
     isnan = get_isnan(a.dtype)
 
     def nanmean_impl(a):
@@ -1257,8 +1275,27 @@ def np_nanmean(a):
 
 @overload(np.nanvar)
 def np_nanvar(a):
-    if not isinstance(a, types.Array):
-        return
+    if isinstance(a, (types.Integer, types.Boolean)):
+        # Variance of a single non-NaN value is always 0; int/bool can't be NaN
+        def nanvar_int_scalar(a):
+            return np.float64(0.0)
+        return nanvar_int_scalar
+    elif isinstance(a, (types.Float, types.Complex)):
+        # NaN scalar → NaN output; var of single non-NaN value is 0
+        out_dtype = as_dtype(a)
+        nan_val = out_dtype.type(np.nan)
+        isnan = get_isnan(a)
+
+        def nanvar_float_scalar(a):
+            if isnan(a):
+                return nan_val
+            # (a - a) is 0 for finite, nan for inf — matches NumPy
+            diff = a - a
+            return out_dtype.type(np.real(diff * np.conj(diff)))
+        return nanvar_float_scalar
+    elif not isinstance(a, types.Array):
+        return None
+
     isnan = get_isnan(a.dtype)
 
     def nanvar_impl(a):

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -471,6 +471,9 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
     def test_nanmean_basic(self):
         self.check_reduction_basic(array_nanmean)
 
+    def test_np_nanmean_scalar(self):
+        self.check_scalar_basic(array_nanmean)
+
     def test_nansum_basic(self):
         self.check_reduction_basic(array_nansum)
 
@@ -482,6 +485,9 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
 
     def test_nanvar_basic(self):
         self.check_reduction_basic(array_nanvar, prec='double')
+
+    def test_np_nanvar_scalar(self):
+        self.check_scalar_basic(array_nanvar, prec='double')
 
     def check_median_basic(self, pyfunc, array_variations):
         cfunc = jit(nopython=True)(pyfunc)


### PR DESCRIPTION
## Summary

Adds scalar input support for `np.nanmean` and `np.nanvar` in nopython
mode. Both functions previously raised a typing error when passed a
scalar — this fixes that.

Part of #10408.

## What changed

**`np.nanmean`**
- Integer/boolean scalar → `float64(a)` (integers can't be NaN, so just
  cast and return)
- Float/complex scalar → returns `NaN` if input is NaN, otherwise
  returns the value preserving dtype

**`np.nanvar`**
- Integer/boolean scalar → `float64(0.0)` (variance of a single value
  is always zero, and integers can't be NaN)
- Float/complex scalar → returns `NaN` if input is NaN, otherwise
  returns `0.0` preserving dtype

## Example
```python
@njit
def foo(x):
    return np.nanmean(x), np.nanvar(x)

foo(np.float64(3.5))        # -> (3.5, 0.0)
foo(np.float64(np.nan))     # -> (nan, nan)
foo(np.int32(5))            # -> (5.0, 0.0)
```

## Testing

Delegates to the existing `check_scalar_basic` helper, keeping things
consistent with the rest of the suite.
```bash
python -m pytest numba/tests/test_array_reductions.py \
    -k "test_np_nanmean_scalar or test_np_nanvar_scalar" -v
```

## What's not in this PR

- `np.median` → #10455
- `np.cumsum`, `np.cumprod` → #10456
- `np.nanstd`, `np.nanprod` → #10457
- No changes to existing array behaviour

Closes #10408 (partial)