### PR TITLE
Fix structref identity comparison (is operator) in jitted code

### DIFF
--- a/numba/experimental/structref.py
+++ b/numba/experimental/structref.py
@@ -397,4 +397,6 @@ def structref_is(context, builder, sig, args):
     aty, bty = sig.args
     a_ptr = create_struct_proxy(aty)(context, builder, value=a).meminfo
     b_ptr = create_struct_proxy(bty)(context, builder, value=b).meminfo
-    return builder.icmp_unsigned("==", a_ptr, b_ptr)
+    ma = builder.ptrtoint(a_ptr, cgutils.intp_t)
+    mb = builder.ptrtoint(b_ptr, cgutils.intp_t)
+    return builder.icmp_signed('==', ma, mb)


### PR DESCRIPTION
Fixes #9936

## Summary

The `is` operator for structref instances was incorrectly returning `False` when comparing a structref to itself in jitted code. This was caused by the `structref_is` function comparing LLVM pointer values directly instead of converting them to integers first.

## Changes

- Modified `structref_is` in `numba/experimental/structref.py` to convert meminfo pointers to integers using `builder.ptrtoint()` before comparison, matching the pattern used by list, set, and typed list implementations.
- Changed from `icmp_unsigned` to `icmp_signed` for consistency with other identity comparison implementations.

## Testing

The existing test `TestStructRefIs.test_is_identity` in `numba/tests/test_struct_ref.py` covers this fix. It verifies that:
- `c is c` returns `True` (same structref instance)
- `c is d` returns `False` (different structref instances)

```
 numba/experimental/structref.py | 4 +++-
 1 file changed, 3 insertions(+), 1 deletion(-)
```