### PR TITLE
Fix false NumbaPerformanceWarning when using newaxis on contiguous ar...

### DIFF
--- a/numba/core/typing/arraydecl.py
+++ b/numba/core/typing/arraydecl.py
@@ -154,7 +154,10 @@ def get_array_index_type(ary, idx):
         def keeps_contiguity(ty, is_innermost):
             # A slice can only keep an array contiguous if it is the
             # innermost index and it is not strided
+            # newaxis (None) always keeps contiguity as it just adds a
+            # dimension of size 1
             return (ty is types.ellipsis or isinstance(ty, types.Integer)
+                    or is_nonelike(ty)
                     or (is_innermost and isinstance(ty, types.SliceType)
                         and not ty.has_step))
 


### PR DESCRIPTION
Fixes #10086

## Description

This PR fixes a false `NumbaPerformanceWarning` that was incorrectly triggered when using `newaxis` (None) on contiguous arrays. The warning claimed that `np.dot()` would be faster on contiguous arrays even when the arrays were already contiguous.

## Root Cause

The issue was in the `keeps_contiguity` function in `numba/core/typing/arraydecl.py`. When determining if array indexing operations preserve contiguity, the function didn't recognize that adding a newaxis (None) preserves contiguity. 

Operations like `x[:, None]` on a contiguous 1D array should result in a contiguous 2D array (C-contiguous in this case), but the function was incorrectly marking the result with layout 'A' (any layout), triggering the performance warning.

## Changes

- Modified the `keeps_contiguity` function to recognize that newaxis (None) always preserves contiguity
- Added `is_nonelike(ty)` check to the contiguity-preserving conditions
- Added explanatory comment about why newaxis preserves contiguity

## Technical Details

Adding a newaxis (None) to an array index only adds a dimension of size 1 without changing the memory layout. For example:
- A 1D C-contiguous array `[1, 2, 3, 4, 5]` with shape `(5,)`
- After `x[:, None]`, becomes `[[1], [2], [3], [4], [5]]` with shape `(5, 1)`
- The underlying memory layout remains unchanged and contiguous

## Testing

The fix ensures that operations like:
```python
@numba.njit
def dot(A, x):
    return np.dot(A, x[:, None])
```

no longer trigger the spurious warning, while still correctly warning for genuinely non-contiguous arrays (e.g., arrays created with `[::-1]`).

## Files Changed

```
numba/core/typing/arraydecl.py | 3 ++-
1 file changed, 3 insertions(+)
```