### PR TITLE
Fix jit decorator docstring formatting

### DIFF
--- a/numba/core/decorators.py
+++ b/numba/core/decorators.py
@@ -95,7 +95,7 @@ def jit(signature_or_function=None, locals=MappingProxyType({}), cache=False,
                 enabled.
 
     Returns
-    --------
+    -------
     A callable usable as a compiled function.  Actual compiling will be
     done lazily if no explicit signatures are passed.
 


### PR DESCRIPTION
A trivial fix, just an extra hyphen character, found it through some sphinx warnings on a project that links to numba through intersphinx.