### PR TITLE
Removed NumPy based unicode charseq type width detection and indexing

### DIFF
--- a/docs/upcoming_changes/10490.improvement.rst
+++ b/docs/upcoming_changes/10490.improvement.rst
@@ -1,0 +1,6 @@
+Removed NumPy based Unicode Character Sequence type width detection and indexing
+--------------------------------------------------------------------------------
+
+This PR removes the dependency of CPython module on NumPy for automatic detection of
+width of the Unicode Characters. This functionality is now provided by the ``ctypes``
+module.

--- a/numba/cpython/charseq.py
+++ b/numba/cpython/charseq.py
@@ -25,6 +25,7 @@ bytes_type = types.Bytes(types.uint8, 1, "C", readonly=True)
 # arrays.
 unicode_byte_width = ctypes.sizeof(ctypes.c_byte) * 4
 
+
 # this is modified version of numba.unicode.make_deref_codegen
 def make_deref_codegen(bitsize):
     def codegen(context, builder, signature, args):


### PR DESCRIPTION
As titled, 

This PR attempts to remove NumPy based width detection for the CPython charseq unicode type.