### PR TITLE
add scalar handling for np.std overload (Part of #10408)

### DIFF
--- a/docs/upcoming_changes/10493.bug_fix.rst
+++ b/docs/upcoming_changes/10493.bug_fix.rst
@@ -1,9 +1,10 @@
 Fix scalar handling in ``np.std``
--------------------------------------------------------
+---------------------------------
 
 Fix scalar handling in ``np.std`` function. 
-Previously, this function would fail when called with scalar inputs.
+Previously, this function would fail when 
+called with scalar inputs.
 Now scalar arguments are handled properly:
 - Integer and boolean inputs return ``float64(0.0)``
-- Float and complex inputs preserve the input dtype (e.g., ``np.float32`` in
-  returns ``float32(0.0)``)
+- Float and complex inputs preserve the input dtype 
+(e.g., ``np.float32`` in returns ``float32(0.0)``)

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -498,12 +498,15 @@ def array_std(a):
             return np.float64(0.0)
         return std_scalar_integer_impl
 
-    # Floats and complex numbers preserve types in numpy.std
+    # Floats and numbers preserve types in numpy.std
     elif isinstance(a, (types.Float, types.Complex)):
-        out_dtype = as_dtype(a)
+        out_dtype = as_dtype(getattr(a,'underlying_float',a))
         zero = out_dtype.type(0)
+        nan_val = out_dtype.type(np.nan)
 
         def std_scalar_float_impl(a):
+            if not np.isfinite(a):
+                return nan_val
             return zero
         return std_scalar_float_impl
 

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -429,9 +429,9 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
         self.check_reduction_basic(array_var, prec='double')
 
     def test_std_basic(self):
-	#scalar testing
-        self.check_reduction_basic(array_std_global)
-	#array testing
+        #scalar testing
+        self.check_scalar_basic(array_std_global)
+        #array testing
         self.check_reduction_basic(array_std)
 
     def test_min_basic(self):


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
Adds scalar input support for `np.std` in nopython mode.

Part of https://github.com/numba/numba/issues/10408.

## What changed

- **Integer/boolean scalar** → always `float64(0.0)`  
  (std of a single value is zero by definition, and integers can't be NaN)
- **Float/complex scalar** → types are preserved

## Example

| Input | Output |
|-------|--------|
| `int64(5)` | `float64(0.0)` |
| `np.float32(5)` | `float32(0.0)` |
