### PR TITLE
Fix: add scalar handling for np.var overload

### DIFF
--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -480,7 +480,20 @@ def array_var(a):
             return ssd / a.size
 
         return array_var_impl
-
+    elif isinstance(a, (types.Integer, types.Boolean)):
+        def _scalar_var(a):
+            return np.float64(0)
+        return _scalar_var
+    elif isinstance(a, types.Float):
+        def _scalar_var(a):
+            return a - a
+        return _scalar_var
+    elif isinstance(a, types.Complex):
+        typed_zero = as_dtype(a).type(0).real
+        def _scalar_var(a):
+            return typed_zero
+        return _scalar_var
+    return None
 
 @overload(np.std)
 @overload_method(types.Array, "std")

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -427,7 +427,43 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
 
     def test_var_basic(self):
         self.check_reduction_basic(array_var, prec='double')
+        
+    def test_var_scalar(self):
+        cfunc = jit(nopython = True)(array_var_global)
 
+        def check(arg):
+            expected = array_var_global(arg)
+            got = cfunc(arg)
+            self.assertPreciseEqual(got, expected)
+
+        # Scalar tests
+        # Integers and booleans
+        check(np.int32(1))
+        check(np.int64(-1))
+        check(np.uint32(2))
+        check(np.bool_(True))
+        check(np.bool_(False))
+
+        # Floating point numbers tests
+        check(np.float32(1.11111))
+        check(np.float64(-2.22222))
+
+        # Complex numbers tests
+        check(np.complex64(1+1j))
+        check(np.complex128(2+2j))
+
+        # Special cases
+        check(np.nan)
+        check(np.inf)
+        check(-np.inf)
+        check(-0.0)
+        check(0.0)
+        check(0)
+
+        # Error cases
+        with self.assertTypingError():
+            cfunc([1, 0, 1, 0])
+    
     def test_std_basic(self):
         self.check_reduction_basic(array_std)
 


### PR DESCRIPTION
Added scalar support for `np.var` to handle input types like `types.Integer`, `types.Boolean`, `types.Float`, and `types.Complex`.

Previously, calling `np.var` with a scalar input would fail with an error. This fix adds scalar support, which returns a value instead of an error.