### PR TITLE
Add scalar handling for np.nanvar overload

### DIFF
--- a/docs/upcoming_changes/nanvar_scalar.bug_fix.rst
+++ b/docs/upcoming_changes/nanvar_scalar.bug_fix.rst
@@ -1,0 +1,7 @@
+Fix scalar handling in ``np.nanvar``
+------------------------------------
+
+Fixed scalar handling in the ``np.nanvar`` function. Previously, this
+function would fail when called with scalar inputs. Now it properly handles
+both scalar and array inputs, returning ``0.0`` for numeric scalars and
+``nan`` for NaN inputs, matching NumPy behavior.

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -1264,6 +1264,21 @@ def np_nanmean(a):
 
 @overload(np.nanvar)
 def np_nanvar(a):
+    # Handle scalar inputs
+    if isinstance(a, (types.Number, types.Boolean)):
+        # For scalars, variance of a single value is 0.0, except for NaN which returns NaN
+        if isinstance(a, (types.Float, types.Complex)):
+            def nanvar_scalar_impl(a):
+                if np.isnan(a):
+                    return np.float64(np.nan)
+                return np.float64(0.0)
+            return nanvar_scalar_impl
+        else:
+            # Integer and boolean scalars always return 0.0
+            def nanvar_scalar_int_impl(a):
+                return np.float64(0.0)
+            return nanvar_scalar_int_impl
+
     if not isinstance(a, types.Array):
         return
     isnan = get_isnan(a.dtype)

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -483,6 +483,43 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
     def test_nanvar_basic(self):
         self.check_reduction_basic(array_nanvar, prec='double')
 
+    def test_nanvar_scalar(self):
+        cfunc = jit(nopython=True)(array_nanvar)
+
+        def check(arg):
+            expected = array_nanvar(arg)
+            got = cfunc(arg)
+            self.assertPreciseEqual(got, expected)
+
+        # NumPy integer and boolean scalars
+        check(np.int32(2))
+        check(np.int64(-3))
+        check(np.uint32(5))
+        check(np.bool_(True))
+        check(np.bool_(False))
+
+        # NumPy floating scalars
+        check(np.float32(1.25))
+        check(np.float64(-2.5))
+
+        # Complex values
+        check(np.complex64(7+0j))
+        check(np.complex128(61+74j))
+
+        # Special floating values - nan returns nan for nanvar
+        check(np.nan)
+        check(np.inf)
+        check(-np.inf)
+        check(-0.0)
+        check(0.0)
+        check(0)
+        check(0.0000042)
+        check(-0.25863)
+
+        # Error cases
+        with self.assertTypingError():
+            cfunc('test String')
+
     def check_median_basic(self, pyfunc, array_variations):
         cfunc = jit(nopython=True)(pyfunc)
         def check(arr):


### PR DESCRIPTION
This PR adds support for scalar inputs to np.nanvar, fixing part of #10408.

## Changes
- Modified np_nanvar in numba/np/arraymath.py to handle scalar inputs (integers, floats, booleans, complex)
- For numeric scalars, returns 0.0 (variance of a single value)
- For NaN inputs, returns NaN
- Added comprehensive test_nanvar_scalar test
- Added release note

## Testing
The test covers:
- Integer scalars (int32, int64, uint32)
- Boolean scalars
- Floating point scalars (float32, float64)
- Complex numbers
- Special values (nan, inf, -inf, -0.0)
- Error case for strings

See also:
- Related PRs: #10223, #10224 (for np.all and np.any scalar support)
- Tracking issue: #10408