### PR TITLE
type annotations for `jit`, `njit`, `cfunc`, and `jit_module`

### DIFF
--- a/docs/upcoming_changes/10505.improvement.rst
+++ b/docs/upcoming_changes/10505.improvement.rst
@@ -1,0 +1,6 @@
+Type annotations for ``jit``, ``njit``, ``cfunc``, and ``jit_module``
+----------------------------------------------------------------------
+
+Numba now ships type annotations for the ``jit``, ``njit``, and
+``cfunc`` decorators, plus ``jit_module``. This improves type checker
+and IDE support for these APIs.

--- a/docs/upcoming_changes/10505.improvement.rst
+++ b/docs/upcoming_changes/10505.improvement.rst
@@ -1,5 +1,5 @@
 Type annotations for ``jit``, ``njit``, ``cfunc``, and ``jit_module``
-----------------------------------------------------------------------
+---------------------------------------------------------------------
 
 Numba now ships type annotations for the ``jit``, ``njit``, and
 ``cfunc`` decorators, plus ``jit_module``. This improves type checker

--- a/numba/core/decorators.pyi
+++ b/numba/core/decorators.pyi
@@ -1,0 +1,126 @@
+from collections.abc import Callable, Mapping
+from typing import (
+    Literal,
+    Protocol,
+    TypeAlias,
+    TypedDict,
+    TypeVar,
+    overload,
+    type_check_only,
+)
+
+from typing_extensions import Unpack
+
+from . import compiler, ir, types, typing
+from .typing.templates import _inline_info
+
+###
+# type-check only helpers
+
+_FnInlineUntyped: TypeAlias = Callable[[ir.Expr, ir.FunctionIR, ir.FunctionIR], bool]
+_FnInlineTyped: TypeAlias = Callable[[ir.Expr, _inline_info, _inline_info], bool]
+_FnInline: TypeAlias = _FnInlineUntyped | _FnInlineTyped
+
+_ToSignature: TypeAlias = (
+    typing.Signature | tuple[types.Type | typing.Signature, ...] | str
+)
+# The generic `list` type is invariant, so we can't use `list[_ToSignature]`.
+# So we instead use a "free" type variable allow the list type argument to vary.
+_ToSignatureT = TypeVar("_ToSignatureT", bound=_ToSignature)
+
+_ToLocals: TypeAlias = Mapping[str, types.Type | str]
+
+_FunctionT = TypeVar("_FunctionT", bound=Callable[..., object])
+
+@type_check_only
+class _JITOptions(TypedDict, total=False):
+    looplift: bool
+    nogil: bool
+    parallel: bool
+    fastmath: bool | set[str]
+    error_model: Literal["python", "numpy"]
+    inline: Literal["never", "always"] | _FnInline
+    forceinline: bool
+
+@type_check_only
+class _JITWrapper(Protocol):
+    # TODO: Return `Dispatcher[_FunctionT]` once `Dispatcher` is annotated and generic.
+    def __call__(self, fn: _FunctionT, /) -> _FunctionT: ...
+
+@type_check_only
+class _CFuncOptions(TypedDict, total=False):
+    nogil: bool
+
+@type_check_only
+class _CFuncWrapper(Protocol):
+    # TODO: Return `CFunc[_FunctionT]` once `CFunc` is annotated and generic.
+    def __call__(self, fn: _FunctionT, /) -> _FunctionT: ...
+
+###
+# stubs
+
+@overload  # signature
+def jit(
+    signature_or_function: _ToSignature | list[_ToSignatureT] | None = None,
+    locals: _ToLocals = ...,
+    cache: bool = False,
+    pipeline_class: type[compiler.CompilerBase] | None = None,
+    boundscheck: bool | None = None,
+    *,
+    nopython: bool = True,
+    forceobj: bool = False,
+    **options: Unpack[_JITOptions],
+) -> _JITWrapper: ...
+@overload  # function
+def jit(
+    signature_or_function: _FunctionT,
+    locals: _ToLocals = ...,
+    cache: bool = False,
+    pipeline_class: type[compiler.CompilerBase] | None = None,
+    boundscheck: bool | None = None,
+    *,
+    nopython: bool = True,
+    forceobj: bool = False,
+    **options: Unpack[_JITOptions],
+) -> _FunctionT: ...
+
+#
+@overload  # signature
+def njit(
+    signature_or_function: _ToSignature | list[_ToSignatureT] | None = None,
+    locals: _ToLocals = ...,
+    cache: bool = False,
+    pipeline_class: type[compiler.CompilerBase] | None = None,
+    boundscheck: bool | None = None,
+    **options: Unpack[_JITOptions],
+) -> _JITWrapper: ...
+@overload  # function
+def njit(
+    signature_or_function: _FunctionT,
+    locals: _ToLocals = ...,
+    cache: bool = False,
+    pipeline_class: type[compiler.CompilerBase] | None = None,
+    boundscheck: bool | None = None,
+    **options: Unpack[_JITOptions],
+) -> _FunctionT: ...
+
+#
+def cfunc(
+    sig: _ToSignature,
+    locals: _ToLocals = ...,
+    cache: bool = False,
+    pipeline_class: type[compiler.CompilerBase] | None = None,
+    **options: Unpack[_JITOptions],
+) -> _CFuncWrapper: ...
+
+#
+def jit_module(
+    *,
+    locals: _ToLocals = ...,
+    cache: bool = False,
+    pipeline_class: type[compiler.CompilerBase] | None = None,
+    boundscheck: bool | None = None,
+    nopython: bool = True,
+    forceobj: bool = False,
+    **kwargs: Unpack[_JITOptions],
+) -> None: ...

--- a/numba/core/decorators.pyi
+++ b/numba/core/decorators.pyi
@@ -41,6 +41,7 @@ class _JITOptions(TypedDict, total=False):
     error_model: Literal["python", "numpy"]
     inline: Literal["never", "always"] | _FnInline
     forceinline: bool
+    debug: bool
 
 @type_check_only
 class _JITWrapper(Protocol):

--- a/numba/core/decorators.pyi
+++ b/numba/core/decorators.pyi
@@ -49,10 +49,6 @@ class _JITWrapper(Protocol):
     def __call__(self, fn: _FunctionT, /) -> _FunctionT: ...
 
 @type_check_only
-class _CFuncOptions(TypedDict, total=False):
-    nogil: bool
-
-@type_check_only
 class _CFuncWrapper(Protocol):
     # TODO: Return `CFunc[_FunctionT]` once `CFunc` is annotated and generic.
     def __call__(self, fn: _FunctionT, /) -> _FunctionT: ...


### PR DESCRIPTION
ref:  https://github.com/numba/numba/pull/10478#issuecomment-4163154566

I verified that there are no typing errors by running this through basedpyright, pyrefly, and ty. 

Currently, as a temporary measure, these decorators return the wrapped function types as-is. For most use-cases that won't be an issue, but if you e.g. access `.stats`, then type-checkers will complain. 
So the next step is to annotate the `Dispatcher` and `CFunc` classes as generic types (they don't need to be generic at runtime, only in the stubs). That way, we'll be able to e.g. have `@jit` return a full-fledged `Dispatch` type that "statically wraps" the decorated function type, i.e. as `Dispatcher[_FunctionT]`.
