### PR TITLE
remove Python 2 `__nonzero__` methods

### DIFF
--- a/numba/core/cpu_options.py
+++ b/numba/core/cpu_options.py
@@ -53,8 +53,6 @@ class FastMathOptions(AbstractOptionValue):
     def __bool__(self):
         return bool(self.flags)
 
-    __nonzero__ = __bool__
-
     def encode(self) -> str:
         return str(self.flags)
 

--- a/numba/core/dispatcher.py
+++ b/numba/core/dispatcher.py
@@ -186,8 +186,6 @@ class CompilingCounter(object):
     def __bool__(self):
         return self.counter > 0
 
-    __nonzero__ = __bool__
-
 
 class _DispatcherBase(_dispatcher.Dispatcher):
     """

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -526,8 +526,6 @@ class _ActiveContext(object):
         """
         return self.context_handle is not None
 
-    __nonzero__ = __bool__
-
 
 driver = Driver()
 


### PR DESCRIPTION
I noticed these old-timers while working on the type annotations, so I figured I might as well retire them.