### PR TITLE
rename classmethod param from ``self`` to ``cls`` in ``cuda.cudadrv.driver``

### DIFF
--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -548,7 +548,7 @@ class Device(object):
     object.  User should not construct devices directly.
     """
     @classmethod
-    def from_identity(self, identity):
+    def from_identity(cls, identity):
         """Create Device object from device identity created by
         ``Device.get_device_identity()``.
         """


### PR DESCRIPTION
For some reason this was causing stubtest to crash (after applying the changes from #10515):

```python-traceback
Traceback (most recent call last):
  File "/home/joren/Workspace/numba/.venv/bin/stubtest", line 10, in <module>
    sys.exit(main())
  File "/home/joren/Workspace/numba/.venv/lib/python3.10/site-packages/mypy/stubtest.py", line 2587, in main
    return test_stubs(parse_options(sys.argv[1:]))
  File "/home/joren/Workspace/numba/.venv/lib/python3.10/site-packages/mypy/stubtest.py", line 2428, in test_stubs
    for error in test_module(module):
  File "/home/joren/Workspace/numba/.venv/lib/python3.10/site-packages/mypy/stubtest.py", line 263, in test_module
    yield from verify(stub, runtime, [module_name])
  File "/home/joren/Workspace/numba/.venv/lib/python3.10/site-packages/mypy/stubtest.py", line 459, in verify_mypyfile
    yield from verify(stub_entry, runtime_entry, object_path + [entry])
  File "/home/joren/Workspace/numba/.venv/lib/python3.10/site-packages/mypy/stubtest.py", line 749, in verify_typeinfo
    yield from verify(stub_to_verify, runtime_attr, object_path + [entry])
  File "/home/joren/Workspace/numba/.venv/lib/python3.10/site-packages/mypy/stubtest.py", line 1668, in verify_decorator
    func = _resolve_funcitem_from_decorator(stub)
  File "/home/joren/Workspace/numba/.venv/lib/python3.10/site-packages/mypy/stubtest.py", line 1575, in _resolve_funcitem_from_decorator
    resulting_func = apply_decorator_to_funcitem(decorator, func)
  File "/home/joren/Workspace/numba/.venv/lib/python3.10/site-packages/mypy/stubtest.py", line 1560, in apply_decorator_to_funcitem
    raise StubtestFailure(
mypy.stubtest.StubtestFailure: unexpected class parameter name 'self' in numba.cuda.cudadrv.driver.Device.from_identity
```

I confirmed that with this change and #10515 together, stubtest no longer crashes.