### PR TITLE
Add get_or_insert_foreign_function() for consistent ABI compliance on s390x

### DIFF
--- a/docs/upcoming_changes/10517.feature.rst
+++ b/docs/upcoming_changes/10517.feature.rst
@@ -1,0 +1,4 @@
+Add ``get_or_insert_foreign_function`` helper for consistent ABI handling across all foreign function declarations.
+
+This ensures target-specific ABI attributes are applied consistently for non-jitted symbols,
+avoiding discrepancies between call sites and simplifying future maintenance of foreign function handling.

--- a/docs/upcoming_changes/10517.feature.rst
+++ b/docs/upcoming_changes/10517.feature.rst
@@ -1,4 +1,0 @@
-Add ``get_or_insert_foreign_function`` helper for consistent ABI handling across all foreign function declarations.
-
-This ensures target-specific ABI attributes are applied consistently for non-jitted symbols,
-avoiding discrepancies between call sites and simplifying future maintenance of foreign function handling.

--- a/docs/upcoming_changes/10517.improvement.rst
+++ b/docs/upcoming_changes/10517.improvement.rst
@@ -1,0 +1,5 @@
+Add ``get_or_insert_foreign_function`` helper to cgutils to centralize application of
+target-specific ABI attributes for foreign function declarations.
+
+This ensures consistent ABI handling across all non-jitted external symbol calls and
+removes the need for manual application of ``apply_target_attributes`` at individual call sites.

--- a/docs/upcoming_changes/10517.improvement.rst
+++ b/docs/upcoming_changes/10517.improvement.rst
@@ -1,3 +1,6 @@
+Add ``get_or_insert_foreign_function`` helper to cgutils
+---------------------------------------------------------
+
 Add ``get_or_insert_foreign_function`` helper to cgutils to centralize application of
 target-specific ABI attributes for foreign function declarations.
 

--- a/numba/core/base.py
+++ b/numba/core/base.py
@@ -428,6 +428,22 @@ class BaseContext(object):
         """
         pass    
 
+    def get_or_insert_foreign_function(self, module, fnty, name):
+        """
+        Get the function named *name* with type *fnty* from *module*, or insert
+        it if it doesn't exist, then apply target-specific ABI attributes via
+        self.apply_target_attributes().
+
+        Use this instead of cgutils.get_or_insert_function() for every call to
+        a function that is not itself jitted by Numba — e.g. NRT helpers,
+        CPython API, libc, NumPy C helpers, typed container helpers, etc.
+
+        For jitted function declarations use cgutils.get_or_insert_function().
+        """
+        fn = cgutils.get_or_insert_function(module, fnty, name)
+        self.apply_target_attributes(fn)
+        return fn
+
     def declare_external_function(self, module, fndesc):
         fnty = self.get_external_function_type(fndesc)
         fn = cgutils.get_or_insert_function(module, fnty, fndesc.mangled_name)

--- a/numba/core/cgutils.py
+++ b/numba/core/cgutils.py
@@ -415,14 +415,12 @@ def insert_pure_function(module, fnty, name):
     fn.attributes.add("nounwind")
     return fn
 
+
 def get_or_insert_function(module, fnty, name):
     """
     Get the function named *name* with type *fnty* from *module*, or insert it
     if it doesn't exist, then apply target-specific ABI attributes via
     context.apply_target_attributes().
-   
-    Use this instead of get_or_insert_function for **every** call to a
-    function that is not itself jitted by Numba. 
     """
     fn = module.globals.get(name, None)
     if fn is None:

--- a/numba/core/cgutils.py
+++ b/numba/core/cgutils.py
@@ -415,15 +415,6 @@ def insert_pure_function(module, fnty, name):
     fn.attributes.add("nounwind")
     return fn
 
-def get_or_insert_foreign_function(context, module, fnty, name):
-    """
-    Apply target attributes (signext/zeroext) to foreign functions when called.
-    This makes Numba's ABI compliant with consistent with other architectures like s390x.
-    """
-    fn = get_or_insert_function(module, fnty, name)
-    context.apply_target_attributes(fn) 
-    return fn
-
 def get_or_insert_function(module, fnty, name):
     """
     Get the function named *name* with type *fnty* from *module*, or insert it

--- a/numba/core/cgutils.py
+++ b/numba/core/cgutils.py
@@ -415,11 +415,23 @@ def insert_pure_function(module, fnty, name):
     fn.attributes.add("nounwind")
     return fn
 
+def get_or_insert_foreign_function(context, module, fnty, name):
+    """
+    Apply target attributes (signext/zeroext) to foreign functions when called.
+    This makes Numba's ABI compliant with consistent with other architectures like s390x.
+    """
+    fn = get_or_insert_function(module, fnty, name)
+    context.apply_target_attributes(fn) 
+    return fn
 
 def get_or_insert_function(module, fnty, name):
     """
     Get the function named *name* with type *fnty* from *module*, or insert it
-    if it doesn't exist.
+    if it doesn't exist, then apply target-specific ABI attributes via
+    context.apply_target_attributes().
+   
+    Use this instead of get_or_insert_function for **every** call to a
+    function that is not itself jitted by Numba. 
     """
     fn = module.globals.get(name, None)
     if fn is None:

--- a/numba/core/pythonapi.py
+++ b/numba/core/pythonapi.py
@@ -1301,9 +1301,7 @@ class PythonAPI(object):
 
     # ------ utils -----
     def _get_function(self, fnty, name):
-        return cgutils.get_or_insert_foreign_function(
-            self.context, self.module, fnty, name
-        )
+        return self.context.get_or_insert_foreign_function(self.module, fnty, name)
 
     def alloca_obj(self):
         return self.builder.alloca(self.pyobj)

--- a/numba/core/pythonapi.py
+++ b/numba/core/pythonapi.py
@@ -1300,20 +1300,11 @@ class PythonAPI(object):
         return self.builder.call(fn, (buf, ptr))
 
     # ------ utils -----
-    # Simple placeholder to replace existing _get_function() this is to validate get_or_insert_foreign_function() functionality
     def _get_function(self, fnty, name):
         return cgutils.get_or_insert_foreign_function(
             self.context, self.module, fnty, name
         )
 
-    # commenting out - this does the same as get_or_insert_foreign_function()
-    """
-    def _get_function(self, fnty, name):
-        fn = cgutils.get_or_insert_function(self.module, fnty, name)
-        self.context.apply_target_attributes(fn)
-        return fn        
-    """
-    
     def alloca_obj(self):
         return self.builder.alloca(self.pyobj)
 

--- a/numba/core/pythonapi.py
+++ b/numba/core/pythonapi.py
@@ -1300,12 +1300,20 @@ class PythonAPI(object):
         return self.builder.call(fn, (buf, ptr))
 
     # ------ utils -----
+    # Simple placeholder to replace existing _get_function() this is to validate get_or_insert_foreign_function() functionality
+    def _get_function(self, fnty, name):
+        return cgutils.get_or_insert_foreign_function(
+            self.context, self.module, fnty, name
+        )
 
+    # commenting out - this does the same as get_or_insert_foreign_function()
+    """
     def _get_function(self, fnty, name):
         fn = cgutils.get_or_insert_function(self.module, fnty, name)
         self.context.apply_target_attributes(fn)
         return fn        
-
+    """
+    
     def alloca_obj(self):
         return self.builder.alloca(self.pyobj)
 

--- a/numba/core/runtime/context.py
+++ b/numba/core/runtime/context.py
@@ -68,7 +68,7 @@ class NRTContext(object):
 
         mod = builder.module
         fnty = ir.FunctionType(cgutils.voidptr_t, [cgutils.intp_t])
-        fn = cgutils.get_or_insert_foreign_function(self._context, mod, fnty, "NRT_Allocate")
+        fn = self._context.get_or_insert_foreign_function(mod, fnty, "NRT_Allocate")
         fn.return_value.add_attribute("noalias")
         return builder.call(fn, [size])
 
@@ -80,7 +80,7 @@ class NRTContext(object):
 
         mod = builder.module
         fnty = ir.FunctionType(ir.VoidType(), [cgutils.voidptr_t])
-        fn = cgutils.get_or_insert_foreign_function(self._context, mod, fnty, "NRT_Free")
+        fn = self._context.get_or_insert_foreign_function(mod, fnty, "NRT_Free")
         return builder.call(fn, [ptr])
 
     @_check_null_result
@@ -107,7 +107,7 @@ class NRTContext(object):
 
         mod = builder.module
         fnty = ir.FunctionType(cgutils.voidptr_t, [cgutils.intp_t])
-        fn = cgutils.get_or_insert_foreign_function(self._context, mod, fnty,
+        fn = self._context.get_or_insert_foreign_function(mod, fnty,
                                             self._meminfo_api.alloc)
         fn.return_value.add_attribute("noalias")
         return builder.call(fn, [size])
@@ -139,7 +139,7 @@ class NRTContext(object):
         mod = builder.module
         fnty = ir.FunctionType(cgutils.voidptr_t,
                                [cgutils.intp_t, cgutils.voidptr_t])
-        fn = cgutils.get_or_insert_foreign_function(self._context, mod, fnty,
+        fn = self._context.get_or_insert_foreign_function(mod, fnty,
                                             self._meminfo_api.alloc_dtor)
         fn.return_value.add_attribute("noalias")
         return builder.call(fn, [size,
@@ -174,7 +174,7 @@ class NRTContext(object):
         mod = builder.module
         u32 = ir.IntType(32)
         fnty = ir.FunctionType(cgutils.voidptr_t, [cgutils.intp_t, u32])
-        fn = cgutils.get_or_insert_foreign_function(self._context, mod, fnty,
+        fn = self._context.get_or_insert_foreign_function(mod, fnty,
                                             self._meminfo_api.alloc_aligned)
         fn.return_value.add_attribute("noalias")
         if isinstance(align, int):
@@ -211,7 +211,7 @@ class NRTContext(object):
 
         mod = builder.module
         fnty = ir.FunctionType(cgutils.voidptr_t, [cgutils.intp_t])
-        fn = cgutils.get_or_insert_foreign_function(self._context, mod, fnty,
+        fn = self._context.get_or_insert_foreign_function(mod, fnty,
                                             "NRT_MemInfo_new_varsize")
         fn.return_value.add_attribute("noalias")
         return builder.call(fn, [size])
@@ -243,8 +243,8 @@ class NRTContext(object):
         mod = builder.module
         fnty = ir.FunctionType(cgutils.voidptr_t,
                                [cgutils.intp_t, cgutils.voidptr_t])
-        fn = cgutils.get_or_insert_foreign_function(
-            self._context, mod, fnty, "NRT_MemInfo_new_varsize_dtor")
+        fn = self._context.get_or_insert_foreign_function(
+            mod, fnty, "NRT_MemInfo_new_varsize_dtor")
         return builder.call(fn, [size, dtor])
 
     @_check_null_result
@@ -311,7 +311,7 @@ class NRTContext(object):
         mod = builder.module
         fnty = ir.FunctionType(ir.VoidType(),
                                [cgutils.voidptr_t, cgutils.voidptr_t])
-        fn = cgutils.get_or_insert_foreign_function(self._context, mod, fnty,
+        fn = self._context.get_or_insert_foreign_function(mod, fnty,
                                             "NRT_MemInfo_varsize_free")
         return builder.call(fn, (meminfo, ptr))
 
@@ -321,7 +321,7 @@ class NRTContext(object):
         mod = builder.module
         fnty = ir.FunctionType(cgutils.voidptr_t,
                                [cgutils.voidptr_t, cgutils.intp_t])
-        fn = cgutils.get_or_insert_foreign_function(self._context, mod, fnty, funcname)
+        fn = self._context.get_or_insert_foreign_function(mod, fnty, funcname)
         fn.return_value.add_attribute("noalias")
         return builder.call(fn, [meminfo, size])
 
@@ -336,7 +336,7 @@ class NRTContext(object):
         from numba.core.runtime.nrtdynmod import meminfo_data_ty
 
         mod = builder.module
-        fn = cgutils.get_or_insert_foreign_function(self._context, mod, meminfo_data_ty,
+        fn = self._context.get_or_insert_foreign_function(mod, meminfo_data_ty,
                                             "NRT_MemInfo_data_fast")
         return builder.call(fn, [meminfo])
 
@@ -367,7 +367,7 @@ class NRTContext(object):
         meminfos = self.get_meminfos(builder, typ, value)
         for _, mi in meminfos:
             mod = builder.module
-            fn = cgutils.get_or_insert_foreign_function(self._context, mod, incref_decref_ty,
+            fn = self._context.get_or_insert_foreign_function(mod, incref_decref_ty,
                                                 funcname)
             # XXX "nonnull" causes a crash in test_dyn_array: can this
             # function be called with a NULL pointer?
@@ -394,7 +394,7 @@ class NRTContext(object):
 
         fnty = ir.FunctionType(cgutils.voidptr_t, ())
         mod = builder.module
-        fn = cgutils.get_or_insert_foreign_function(self._context, mod, fnty, "NRT_get_api")
+        fn = self._context.get_or_insert_foreign_function(mod, fnty, "NRT_get_api")
         return builder.call(fn, ())
 
     def eh_check(self, builder):

--- a/numba/core/runtime/context.py
+++ b/numba/core/runtime/context.py
@@ -68,7 +68,7 @@ class NRTContext(object):
 
         mod = builder.module
         fnty = ir.FunctionType(cgutils.voidptr_t, [cgutils.intp_t])
-        fn = cgutils.get_or_insert_function(mod, fnty, "NRT_Allocate")
+        fn = cgutils.get_or_insert_foreign_function(self._context, mod, fnty, "NRT_Allocate")
         fn.return_value.add_attribute("noalias")
         return builder.call(fn, [size])
 
@@ -80,7 +80,7 @@ class NRTContext(object):
 
         mod = builder.module
         fnty = ir.FunctionType(ir.VoidType(), [cgutils.voidptr_t])
-        fn = cgutils.get_or_insert_function(mod, fnty, "NRT_Free")
+        fn = cgutils.get_or_insert_foreign_function(self._context, mod, fnty, "NRT_Free")
         return builder.call(fn, [ptr])
 
     @_check_null_result
@@ -107,7 +107,7 @@ class NRTContext(object):
 
         mod = builder.module
         fnty = ir.FunctionType(cgutils.voidptr_t, [cgutils.intp_t])
-        fn = cgutils.get_or_insert_function(mod, fnty,
+        fn = cgutils.get_or_insert_foreign_function(self._context, mod, fnty,
                                             self._meminfo_api.alloc)
         fn.return_value.add_attribute("noalias")
         return builder.call(fn, [size])
@@ -139,7 +139,7 @@ class NRTContext(object):
         mod = builder.module
         fnty = ir.FunctionType(cgutils.voidptr_t,
                                [cgutils.intp_t, cgutils.voidptr_t])
-        fn = cgutils.get_or_insert_function(mod, fnty,
+        fn = cgutils.get_or_insert_foreign_function(self._context, mod, fnty,
                                             self._meminfo_api.alloc_dtor)
         fn.return_value.add_attribute("noalias")
         return builder.call(fn, [size,
@@ -174,7 +174,7 @@ class NRTContext(object):
         mod = builder.module
         u32 = ir.IntType(32)
         fnty = ir.FunctionType(cgutils.voidptr_t, [cgutils.intp_t, u32])
-        fn = cgutils.get_or_insert_function(mod, fnty,
+        fn = cgutils.get_or_insert_foreign_function(self._context, mod, fnty,
                                             self._meminfo_api.alloc_aligned)
         fn.return_value.add_attribute("noalias")
         if isinstance(align, int):
@@ -211,7 +211,7 @@ class NRTContext(object):
 
         mod = builder.module
         fnty = ir.FunctionType(cgutils.voidptr_t, [cgutils.intp_t])
-        fn = cgutils.get_or_insert_function(mod, fnty,
+        fn = cgutils.get_or_insert_foreign_function(self._context, mod, fnty,
                                             "NRT_MemInfo_new_varsize")
         fn.return_value.add_attribute("noalias")
         return builder.call(fn, [size])
@@ -243,8 +243,8 @@ class NRTContext(object):
         mod = builder.module
         fnty = ir.FunctionType(cgutils.voidptr_t,
                                [cgutils.intp_t, cgutils.voidptr_t])
-        fn = cgutils.get_or_insert_function(
-            mod, fnty, "NRT_MemInfo_new_varsize_dtor")
+        fn = cgutils.get_or_insert_foreign_function(
+            self._context, mod, fnty, "NRT_MemInfo_new_varsize_dtor")
         return builder.call(fn, [size, dtor])
 
     @_check_null_result
@@ -311,7 +311,7 @@ class NRTContext(object):
         mod = builder.module
         fnty = ir.FunctionType(ir.VoidType(),
                                [cgutils.voidptr_t, cgutils.voidptr_t])
-        fn = cgutils.get_or_insert_function(mod, fnty,
+        fn = cgutils.get_or_insert_foreign_function(self._context, mod, fnty,
                                             "NRT_MemInfo_varsize_free")
         return builder.call(fn, (meminfo, ptr))
 
@@ -321,7 +321,7 @@ class NRTContext(object):
         mod = builder.module
         fnty = ir.FunctionType(cgutils.voidptr_t,
                                [cgutils.voidptr_t, cgutils.intp_t])
-        fn = cgutils.get_or_insert_function(mod, fnty, funcname)
+        fn = cgutils.get_or_insert_foreign_function(self._context, mod, fnty, funcname)
         fn.return_value.add_attribute("noalias")
         return builder.call(fn, [meminfo, size])
 
@@ -336,7 +336,7 @@ class NRTContext(object):
         from numba.core.runtime.nrtdynmod import meminfo_data_ty
 
         mod = builder.module
-        fn = cgutils.get_or_insert_function(mod, meminfo_data_ty,
+        fn = cgutils.get_or_insert_foreign_function(self._context, mod, meminfo_data_ty,
                                             "NRT_MemInfo_data_fast")
         return builder.call(fn, [meminfo])
 
@@ -367,7 +367,7 @@ class NRTContext(object):
         meminfos = self.get_meminfos(builder, typ, value)
         for _, mi in meminfos:
             mod = builder.module
-            fn = cgutils.get_or_insert_function(mod, incref_decref_ty,
+            fn = cgutils.get_or_insert_foreign_function(self._context, mod, incref_decref_ty,
                                                 funcname)
             # XXX "nonnull" causes a crash in test_dyn_array: can this
             # function be called with a NULL pointer?
@@ -394,7 +394,7 @@ class NRTContext(object):
 
         fnty = ir.FunctionType(cgutils.voidptr_t, ())
         mod = builder.module
-        fn = cgutils.get_or_insert_function(mod, fnty, "NRT_get_api")
+        fn = cgutils.get_or_insert_foreign_function(self._context, mod, fnty, "NRT_get_api")
         return builder.call(fn, ())
 
     def eh_check(self, builder):


### PR DESCRIPTION
# Add get_or_insert_foreign_function() for consistent ABI compliance on s390x

## Motivation

This PR implements `get_or_insert_foreign_function()` in `cgutils` as discussed in the
[Feb 10 Numba dev meeting](https://hackmd.io/3wbf-25pRgibya4uVhXQog?both).

PR #10396 added `apply_target_attributes()` as a hook for targets like s390x to apply
correct ABI calling convention attributes to foreign function declarations. However the
hook needs to be called consistently across every foreign function declaration in Numba -
not just in `pythonapi.py`. This need was validated by `numba/core/runtime/context.py`
in PR #10410 and the `npyufunc` test suite failures in #10504. This PR provides the
systematic fix.

## What this PR does

Adds `get_or_insert_foreign_function(context, module, fnty, name)` to `cgutils` - a
wrapper around `get_or_insert_function()` that additionally calls
`context.apply_target_attributes()` on every foreign function declaration. This means:

- The ABI hook fires consistently for every call to a non-jitted symbol.
- Developers don't need to remember to call `apply_target_attributes()` manually at each call site.
- Any future adjustments to foreign function declarations can be made in one place.

## Migrated so far

| File | What was migrated |
|---|---|
| `numba/core/cgutils.py` | adds `get_or_insert_foreign_function()` |
| `numba/core/pythonapi.py` | `_get_function()` now delegates to the new helper, replacing the manual compensation from #10396 |
| `numba/core/runtime/context.py` | all NRT helpers (`NRT_Allocate`, `NRT_Free`, `NRT_incref`, `NRT_MemInfo_*`, etc.) |

## TODO before ready for review

- [ ] Remaining ~100 call sites across `typed/`, `np/`, `cpython/`, `parfors/`, `misc/`
- [ ] Config stack switch (discussed in meeting notes - open question on where this should live)
- [ ] Confirm deprecation intent for `get_or_insert_function()` - the dev meeting notes
      says the final step is to deprecate the function, but it is still needed for numba jitted declarations. Clarification
      on the intended final state would be helpful before completing the migration.

## Testing

- `pytest numba/tests/doc_examples/` passes with the exception of two `KeyError` failures
  in typed dict tests, expected to be resolved by migrating `typed/dictobject.py`.
- `get_preferred_array_alignment` kept at 32-byte. Confirming the ABI fix is driven by
  `apply_target_attributes()` consistently applied via the new helper, not by changing
  alignment assumptions.
- s390x: `numba/tests/npyufunc/` segfaults confirmed resolved by promoting `numba_ndarray_new` 
  in `wrappers.py`, validated in #10504. Migration of `wrappers.py` is part of the remaining 
  TODO call sites.

## Open questions for maintainers

1. **Config stack switch** - the dev meeting notes mention "add a switch to turn it off"
   but don't specify the mechanism. Where should this live and how should it be toggled?
2. **CUDA** - files like `nvvmutils.py` use `get_or_insert_function`, should this be in scope for this PR or handled
   separately?
3. **Multi-arch (e.g. ppc64le)** - `apply_target_attributes()` is not yet implemented
   for ppc64le. The platform check in `cpu.py` L73 currently covers `s390x`. Should
   this be extended to other architectures requiring type promotion, or left to
   contributors with access to that hardware? The proposed switch from question 1 may
   influence this decision, could it be that a target architecture can opt into these promotions. 
4. **Location of `apply_target_attributes()`** - should it remain in `cpu.py` or move
   to `cgutils` alongside `get_or_insert_foreign_function()`? Currently it lives in
   `cpu.py` as it applies CPU-specific ABI logic, but co-locating it with the new helper
   may make the relationship clearer.

CC: @Andreas-Krebbel