### PR TITLE
Fix: add scalar support for `np.argmin`

### DIFF
--- a/docs/upcoming_changes/10521.bug_fix.rst
+++ b/docs/upcoming_changes/10521.bug_fix.rst
@@ -1,0 +1,7 @@
+Fix scalar handling in ``np.argmin``
+------------------------------------
+
+Fixed scalar handling in the ``np.argmin`` function. Previously, this
+function would fail when called with scalar inputs. Now it properly handles
+both scalar and array inputs. The supported scalar types are `types.Number`,
+`types.Boolean`, `types.NPDatetime`, and `types.NPTimedelta`.

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -686,6 +686,15 @@ def array_argmin_impl_generic(arry):
 @overload(np.argmin)
 @overload_method(types.Array, "argmin")
 def array_argmin(a, axis=None):
+    # for scalar
+    if isinstance(a, (types.Number, types.Boolean)):
+        def scalar_argmin(a, axis=None):
+            if axis is not None and axis != 0 and axis != -1:
+                raise ValueError("axis is out of bounds")
+            return np.int64(0)
+        return scalar_argmin
+
+    # for non-scalar
     if isinstance(a.dtype, (types.NPDatetime, types.NPTimedelta)):
         flatten_impl = array_argmin_impl_datetime
     elif isinstance(a.dtype, types.Float):

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -687,7 +687,8 @@ def array_argmin_impl_generic(arry):
 @overload_method(types.Array, "argmin")
 def array_argmin(a, axis=None):
     # for scalar
-    if isinstance(a, (types.Number, types.Boolean, types.NPDatetime, types.NPTimedelta)):
+    if isinstance(a, (types.Number, types.Boolean, types.NPDatetime,
+                      types.NPTimedelta)):
         def scalar_argmin(a, axis=None):
             if axis is not None and axis != 0 and axis != -1:
                 raise ValueError("axis is out of bounds")

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -687,12 +687,15 @@ def array_argmin_impl_generic(arry):
 @overload_method(types.Array, "argmin")
 def array_argmin(a, axis=None):
     # for scalar
-    if isinstance(a, (types.Number, types.Boolean)):
+    if isinstance(a, (types.Number, types.Boolean, types.NPDatetime, types.NPTimedelta)):
         def scalar_argmin(a, axis=None):
             if axis is not None and axis != 0 and axis != -1:
                 raise ValueError("axis is out of bounds")
             return np.int64(0)
         return scalar_argmin
+
+    if not isinstance(a, types.Array):
+        return
 
     # for non-scalar
     if isinstance(a.dtype, (types.NPDatetime, types.NPTimedelta)):

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -457,7 +457,41 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
         self.check_scalar_basic(array_amax)
 
     def test_argmin_basic(self):
-        self.check_reduction_basic(array_argmin)
+        cfunc = jit(nopython=True)(array_argmin_global)
+
+        def check(arg):
+            expected = array_argmin_global(arg)
+            got = cfunc(arg)
+            self.assertPreciseEqual(got, expected)
+
+        # empty array
+        with self.assertRaises(ValueError):
+            check(np.array([]))
+
+        # scalars and special values
+        check(np.float64(1.0))
+        check(np.bool_(True))
+        check(np.nan)
+        check(np.inf)
+        check(-0.0)
+
+        # basic 1D arrays
+        check(np.array([0.0, -1.0, -1.0, 1.0, 1.0, 0.0]))
+        check(np.float64([-1.5, 2.5, 'inf']))
+        check(np.float64([-1.5, 2.5, '-inf']))
+        check(np.float64([-1.5, 2.5, 'inf', '-inf']))
+        check(np.array(['nan']))
+        check(np.array(['nan', 1, 2]))
+        check(np.array(['nan', '-inf']))
+        check(np.array(['nan', 'nan']))
+
+        # types with special treatment
+        check(np.datetime64(0, 'Y'))
+        check(np.timedelta64(10, 's'))
+
+        # invalid type
+        with self.assertTypingError():
+            check('string')
 
     def test_argmax_basic(self):
         self.check_reduction_basic(array_argmax)
@@ -1245,7 +1279,19 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
             for cfunc in c_functions:
                 self.assertPreciseEqual(cfunc.py_func(arr), cfunc(arr))
 
+    def test_argmin_axis_scalar(self):
+        scalar = np.int64(1)
+        axes = [-1, 0]
+
+        py_functions = [lambda a, _axis=axis: np.argmin(a, axis=_axis)
+                        for axis in axes]
+        c_functions = [jit(nopython=True)(pyfunc) for pyfunc in py_functions]
+
+        for cfunc in c_functions:
+            self.assertPreciseEqual(cfunc.py_func(scalar), cfunc(scalar))
+
     def test_argmin_axis_out_of_range(self):
+        scalar = np.int64(1)
         arr1d = np.arange(6)
         arr2d = np.arange(6).reshape(2, 3)
 
@@ -1259,6 +1305,8 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
             with self.assertRaisesRegex(ValueError, "axis.*out of bounds"):
                 jitargmin(arr, axis)
 
+        assert_raises(scalar, 1)
+        assert_raises(scalar, -2)
         assert_raises(arr1d, 1)
         assert_raises(arr1d, -2)
         assert_raises(arr2d, -3)


### PR DESCRIPTION
Partially closes #10408 

This PR adds handling of scalar inputs of type `types.Number`, `types.Boolean`, `types.NPDatetime`, and `types.NPTimedelta`, as well as handling of the `axes` parameter for scalar inputs. Other than these types just mentioned, the implementation expects only inputs of type `types.Array`.