### PR TITLE
Support native containers `list`, `dict`, `set`, `tuple` as Numba types

### DIFF
--- a/numba/core/typing/asnumbatype.py
+++ b/numba/core/typing/asnumbatype.py
@@ -110,7 +110,7 @@ class AsNumbaTypeRegistry:
 
         if origin is set:
             (element_py,) = args
-            return types.Set(self.infer(element_py))
+            return types.SetType(self.infer(element_py))
 
         if origin is tuple:
             tys = tuple(map(self.infer, args))

--- a/numba/core/typing/asnumbatype.py
+++ b/numba/core/typing/asnumbatype.py
@@ -68,21 +68,28 @@ class AsNumbaTypeRegistry:
             # `typing._GenericAlias`, so that must be keept.
             #
             if not isinstance(py_type, (py_typing.Union,
+                                        py_typing.GenericAlias,
                                         py_typing._GenericAlias)):
                 return
         elif PYVERSION in ((3, 10), (3, 11), (3, 12), (3, 13)):
-            # Use of underscore type `_GenericAlias`.
-            if not isinstance(py_type, py_typing._GenericAlias):
+            # Subscripting a class, e.g. `tuple[int, float]`, creates a
+            # `typing.GenericAlias`. Meanwhile, using deprecated aliases such
+            # as `typing.Tuple[int, float]` creates a `typing._GenericAlias`.
+            if not isinstance(py_type, (py_typing.GenericAlias,
+                                        py_typing._GenericAlias)):
                 return
         else:
             raise NotImplementedError(PYVERSION)
 
-        if getattr(py_type, "__origin__", None) is py_typing.Union:
-            if len(py_type.__args__) != 2:
+        origin = py_typing.get_origin(py_type)
+        args = py_typing.get_args(py_type)
+
+        if origin is py_typing.Union:
+            if len(args) != 2:
                 raise errors.TypingError(
                     "Cannot type Union of more than two types")
 
-            (arg_1_py, arg_2_py) = py_type.__args__
+            (arg_1_py, arg_2_py) = args
 
             if arg_2_py is type(None): # noqa: E721
                 return types.Optional(self.infer(arg_1_py))
@@ -93,20 +100,20 @@ class AsNumbaTypeRegistry:
                     "Cannot type Union that is not an Optional "
                     f"(neither type type {arg_2_py} is not NoneType")
 
-        if getattr(py_type, "__origin__", None) is list:
-            (element_py,) = py_type.__args__
+        if origin is list:
+            (element_py,) = args
             return types.ListType(self.infer(element_py))
 
-        if getattr(py_type, "__origin__", None) is dict:
-            key_py, value_py = py_type.__args__
+        if origin is dict:
+            key_py, value_py = args
             return types.DictType(self.infer(key_py), self.infer(value_py))
 
-        if getattr(py_type, "__origin__", None) is set:
-            (element_py,) = py_type.__args__
+        if origin is set:
+            (element_py,) = args
             return types.Set(self.infer(element_py))
 
-        if getattr(py_type, "__origin__", None) is tuple:
-            tys = tuple(map(self.infer, py_type.__args__))
+        if origin is tuple:
+            tys = tuple(map(self.infer, args))
             return types.BaseTuple.from_types(tys)
 
     def register(self, func_or_py_type, numba_type=None):

--- a/numba/core/typing/asnumbatype.py
+++ b/numba/core/typing/asnumbatype.py
@@ -91,7 +91,8 @@ class AsNumbaTypeRegistry:
         if origin is py_typing.Union:
             if len(args) != 2:
                 raise errors.TypingError(
-                    "Cannot type Union of more than two types")
+                    "Cannot type Union of more than two types. "
+                    f"Attempted to unify '{len(args)}' types.")
 
             (arg_1_py, arg_2_py) = args
 

--- a/numba/core/typing/asnumbatype.py
+++ b/numba/core/typing/asnumbatype.py
@@ -67,6 +67,10 @@ class AsNumbaTypeRegistry:
             # However, other types, such as `typing.List[float]` remain as
             # `typing._GenericAlias`, so that must be keept.
             #
+            # Additionally, using the recommend e.g. `tuple[int, float]`,
+            # creates a `typing.GenericAlias`, so that must be included here
+            # too.
+            #
             if not isinstance(py_type, (py_typing.Union,
                                         py_typing.GenericAlias,
                                         py_typing._GenericAlias)):

--- a/numba/tests/test_asnumbatype.py
+++ b/numba/tests/test_asnumbatype.py
@@ -207,6 +207,24 @@ class TestAsNumbaType(TestCase):
                 str(raises.exception),
             )
 
+    def test_native_no_args_throws(self):
+        # Native container types without arguments are not supported.
+        native_no_args_types = [
+            list,
+            set,
+            dict,
+            tuple,
+            tuple[int, list],
+        ]
+
+        for bad_py_type in native_no_args_types:
+            with self.assertRaises(TypingError) as raises:
+                as_numba_type(bad_py_type)
+            self.assertIn(
+                "Cannot infer Numba type of Python type",
+                str(raises.exception),
+            )
+
     def test_bad_union_throws(self):
         bad_unions = [
             py_typing.Union[str, int],

--- a/numba/tests/test_asnumbatype.py
+++ b/numba/tests/test_asnumbatype.py
@@ -208,7 +208,8 @@ class TestAsNumbaType(TestCase):
             )
 
     def test_native_no_args_throws(self):
-        # Native container types without arguments are not supported.
+        # Non-generic types of native container are not strictly homogeneous,
+        # therefore not supported.
         native_no_args_types = [
             list,
             set,

--- a/numba/tests/test_asnumbatype.py
+++ b/numba/tests/test_asnumbatype.py
@@ -64,7 +64,7 @@ class TestAsNumbaType(TestCase):
         )
         self.assertEqual(
             as_numba_type(set[complex]),
-            types.Set(self.complex_nb_type),
+            types.SetType(self.complex_nb_type),
         )
         self.assertEqual(
             as_numba_type(tuple[float, float]),
@@ -86,7 +86,7 @@ class TestAsNumbaType(TestCase):
         )
         self.assertEqual(
             as_numba_type(py_typing.Set[complex]),
-            types.Set(self.complex_nb_type),
+            types.SetType(self.complex_nb_type),
         )
         self.assertEqual(
             as_numba_type(py_typing.Tuple[float, float]),
@@ -143,7 +143,7 @@ class TestAsNumbaType(TestCase):
         )
         self.assertEqual(
             as_numba_type(set[tuple[py_typing.Optional[int], float]]),
-            types.Set(types.Tuple(
+            types.SetType(types.Tuple(
                 [types.Optional(self.int_nb_type), self.float_nb_type])),
         )
         self.assertEqual(
@@ -155,7 +155,7 @@ class TestAsNumbaType(TestCase):
         self.assertEqual(
             as_numba_type(
                 py_typing.Set[py_typing.Tuple[py_typing.Optional[int], float]]),
-            types.Set(types.Tuple(
+            types.SetType(types.Tuple(
                 [types.Optional(self.int_nb_type), self.float_nb_type])),
         )
 

--- a/numba/tests/test_asnumbatype.py
+++ b/numba/tests/test_asnumbatype.py
@@ -53,6 +53,29 @@ class TestAsNumbaType(TestCase):
             self.assertEqual(as_numba_type(ty), ty)
 
     def test_single_containers(self):
+        # Native container types
+        self.assertEqual(
+            as_numba_type(list[float]),
+            types.ListType(self.float_nb_type),
+        )
+        self.assertEqual(
+            as_numba_type(dict[float, str]),
+            types.DictType(self.float_nb_type, self.str_nb_type),
+        )
+        self.assertEqual(
+            as_numba_type(set[complex]),
+            types.Set(self.complex_nb_type),
+        )
+        self.assertEqual(
+            as_numba_type(tuple[float, float]),
+            types.Tuple([self.float_nb_type, self.float_nb_type]),
+        )
+        self.assertEqual(
+            as_numba_type(tuple[float, complex]),
+            types.Tuple([self.float_nb_type, self.complex_nb_type]),
+        )
+
+        # Corresponding deprecated aliases
         self.assertEqual(
             as_numba_type(py_typing.List[float]),
             types.ListType(self.float_nb_type),
@@ -96,10 +119,32 @@ class TestAsNumbaType(TestCase):
                       str(raises.exception))
 
     def test_nested_containers(self):
-        IntList = py_typing.List[int]
         self.assertEqual(
-            as_numba_type(py_typing.List[IntList]),
+            as_numba_type(list[list[int]]),
             types.ListType(types.ListType(self.int_nb_type)),
+        )
+        self.assertEqual(
+            as_numba_type(list[py_typing.List[int]]),
+            types.ListType(types.ListType(self.int_nb_type)),
+        )
+        self.assertEqual(
+            as_numba_type(py_typing.List[list[int]]),
+            types.ListType(types.ListType(self.int_nb_type)),
+        )
+        self.assertEqual(
+            as_numba_type(py_typing.List[py_typing.List[int]]),
+            types.ListType(types.ListType(self.int_nb_type)),
+        )
+        self.assertEqual(
+            as_numba_type(list[dict[float, bool]]),
+            types.ListType(
+                types.DictType(self.float_nb_type, self.bool_nb_type)
+            ),
+        )
+        self.assertEqual(
+            as_numba_type(set[tuple[py_typing.Optional[int], float]]),
+            types.Set(types.Tuple(
+                [types.Optional(self.int_nb_type), self.float_nb_type])),
         )
         self.assertEqual(
             as_numba_type(py_typing.List[py_typing.Dict[float, bool]]),

--- a/numba/tests/test_asnumbatype.py
+++ b/numba/tests/test_asnumbatype.py
@@ -18,6 +18,7 @@ from numba.core.extending import (register_model, type_callable, unbox,
 from numba.core.types import Number
 from numba.core.typing.typeof import typeof, typeof_impl
 from numba.core.typing.asnumbatype import as_numba_type, AsNumbaTypeRegistry
+from numba.core.utils import PYVERSION
 from numba.experimental.jitclass import jitclass
 from numba.tests.support import TestCase
 
@@ -118,6 +119,12 @@ class TestAsNumbaType(TestCase):
         self.assertIn("Cannot type Union that is not an Optional",
                       str(raises.exception))
 
+    @unittest.skipUnless(PYVERSION >= (3,14),
+        "Syntax only supported from 3.14 onwards")
+    def test_optional_syntax_OR(self):
+        self.assertEqual(as_numba_type(int | None),
+            types.Optional(self.int_nb_type))
+
     def test_nested_containers(self):
         self.assertEqual(
             as_numba_type(list[list[int]]),
@@ -140,11 +147,6 @@ class TestAsNumbaType(TestCase):
             types.ListType(
                 types.DictType(self.float_nb_type, self.bool_nb_type)
             ),
-        )
-        self.assertEqual(
-            as_numba_type(set[tuple[py_typing.Optional[int], float]]),
-            types.SetType(types.Tuple(
-                [types.Optional(self.int_nb_type), self.float_nb_type])),
         )
         self.assertEqual(
             as_numba_type(set[tuple[int | None, float]]),

--- a/numba/tests/test_asnumbatype.py
+++ b/numba/tests/test_asnumbatype.py
@@ -209,9 +209,10 @@ class TestAsNumbaType(TestCase):
                 str(raises.exception),
             )
 
-    def test_native_no_args_throws(self):
+    def test_non_homogenous_type_throws(self):
         # Non-generic types of native container are not strictly homogeneous,
-        # therefore not supported.
+        # therefore not supported. Also, tuples with inhomogeneous types are
+        # excluded.
         native_no_args_types = [
             list,
             set,

--- a/numba/tests/test_asnumbatype.py
+++ b/numba/tests/test_asnumbatype.py
@@ -147,6 +147,11 @@ class TestAsNumbaType(TestCase):
                 [types.Optional(self.int_nb_type), self.float_nb_type])),
         )
         self.assertEqual(
+            as_numba_type(set[tuple[int | None, float]]),
+            types.SetType(types.Tuple(
+                [types.Optional(self.int_nb_type), self.float_nb_type])),
+        )
+        self.assertEqual(
             as_numba_type(py_typing.List[py_typing.Dict[float, bool]]),
             types.ListType(
                 types.DictType(self.float_nb_type, self.bool_nb_type)

--- a/numba/tests/test_asnumbatype.py
+++ b/numba/tests/test_asnumbatype.py
@@ -149,11 +149,6 @@ class TestAsNumbaType(TestCase):
             ),
         )
         self.assertEqual(
-            as_numba_type(set[tuple[int | None, float]]),
-            types.SetType(types.Tuple(
-                [types.Optional(self.int_nb_type), self.float_nb_type])),
-        )
-        self.assertEqual(
             as_numba_type(py_typing.List[py_typing.Dict[float, bool]]),
             types.ListType(
                 types.DictType(self.float_nb_type, self.bool_nb_type)

--- a/numba/tests/test_asnumbatype.py
+++ b/numba/tests/test_asnumbatype.py
@@ -119,11 +119,11 @@ class TestAsNumbaType(TestCase):
         self.assertIn("Cannot type Union that is not an Optional",
                       str(raises.exception))
 
-    @unittest.skipUnless(PYVERSION >= (3,14),
-        "Syntax only supported from 3.14 onwards")
+    @unittest.skipUnless(PYVERSION >= (3, 14),
+                         "Syntax only supported from 3.14 onwards")
     def test_optional_syntax_OR(self):
         self.assertEqual(as_numba_type(int | None),
-            types.Optional(self.int_nb_type))
+                         types.Optional(self.int_nb_type))
 
     def test_nested_containers(self):
         self.assertEqual(


### PR DESCRIPTION
Closes #9978 

This PR adds support for native containers, namely `list`, `dict`, `set`, and `tuple`, to be inferred successfully when calling `numba.extending.as_numba_type`.

Previously, the four types mentioned are not recognized by the registry, e.g. calling `as_numba_type(list[int])` raises a `numba.core.errors.TypingError`. Meanwhile, calling `as_numba_type(typing.List[int])` works as expected, returning a `ListType(int64)` Numba type. The reason is because they have different types: `list[int]` is a `types.GenericAlias`, while `typing.List[int]` is a `types._GenericAlias`.

Now, calling `as_numba_type` with one or more `list`(s) inside the argument gives the same result as doing the same call but with `typing.List` replacing each instance of `list`. The same goes for the other 3 containers.

Changes made:
- Modifications to method `_builtin_infer` of the class `AsNumbaTypeRegistry`.
- Modifications and additions of new test cases

NOTE: I'm not sure if there is a documentation describing all valid Numba types (if there is then I couldn't find it), so there might be some things I missed. But I think everything seems logical.