### PR TITLE
Updated int_ to map to int64 instead of `ctypes.c_long`

### DIFF
--- a/numba/core/types/__init__.py
+++ b/numba/core/types/__init__.py
@@ -155,8 +155,8 @@ char = np_char = _make_signed(ctypes.c_char)
 uchar = np_uchar = byte = _make_unsigned(ctypes.c_ubyte)
 short = np_short = _make_signed(ctypes.c_short)
 ushort = np_ushort = _make_unsigned(ctypes.c_ushort)
-int_ = np_int_ = _make_signed(ctypes.c_long)
-uint = np_uint = _make_unsigned(ctypes.c_long)
+int_ = np_int_ = np_intp
+uint = np_uint = np_uintp
 intc = np_intc = _make_signed(ctypes.c_int) # C-compat int
 uintc = np_uintc = _make_unsigned(ctypes.c_uint) # C-compat uint
 long_ = np_long = _make_signed(ctypes.c_long)  # C-compat long

--- a/numba/tests/test_typenames.py
+++ b/numba/tests/test_typenames.py
@@ -1,16 +1,11 @@
-import numpy as np
-
 from numba.core import types
 import unittest
 
 
 class TestTypeNames(unittest.TestCase):
     def test_numpy_integers(self):
-        expect = getattr(types, "int%d" % (np.dtype("int").itemsize * 8))
-        self.assertEqual(types.int_, expect)
-
-        expect = getattr(types, "uint%d" % (np.dtype("uint").itemsize * 8))
-        self.assertEqual(types.uint, expect)
+        self.assertEqual(types.int_, types.np_intp)
+        self.assertEqual(types.uint, types.np_uintp)
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_typenames.py
+++ b/numba/tests/test_typenames.py
@@ -1,11 +1,13 @@
 from numba.core import types
 import unittest
 
+import numpy as np
+
 
 class TestTypeNames(unittest.TestCase):
     def test_numpy_integers(self):
-        self.assertEqual(types.int_, types.np_intp)
-        self.assertEqual(types.uint, types.np_uintp)
+        self.assertEqual(types.int_.bitwidth, np.dtype(np.intp).itemsize * 8)
+        self.assertEqual(types.uint.bitwidth, np.dtype(np.uintp).itemsize * 8)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Resolves https://github.com/numba/numba/issues/10524

As titled, 

This PR maps the `int_` type to `ctypes.c_int64` instead of `ctypes.c_long` since the NumPy `int_` datatype actually alaises NumPy `int64` datatype