### PR TITLE
docs/numpy: clarify lack of support for in-place operation using `out` kw in `numpy.random.Generator().random()`

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -691,7 +691,8 @@ The following :py:class:`Generator` methods are supported:
 * :func:`numpy.random.Generator().permutation()` (Only accepts NumPy ndarrays and integers.)
 * :func:`numpy.random.Generator().poisson()`
 * :func:`numpy.random.Generator().power()`
-* :func:`numpy.random.Generator().random()`
+* :func:`numpy.random.Generator().random()` (In-place operation using the ``out`` 
+  keyword is not supported.)
 * :func:`numpy.random.Generator().rayleigh()`
 * :func:`numpy.random.Generator().shuffle()` (Only accepts NumPy ndarrays.)
 * :func:`numpy.random.Generator().standard_cauchy()`


### PR DESCRIPTION
This change adds a parenthesis note, in the NumPy compatibility docs section, explaining that in-place operation of the random number generator is not supported. The following snippet depicts the problem:

```python
import numpy as np
import numba

rng = np.random.default_rng()

@numba.jit
def test():
    a = np.empty(10)
    a = rng.random(out=a)

# THIS WORKS
test.py_func()  

# THIS PRINTS AN ERROR:
try:
    test()
except Exception as e:
    for line in e.msg.splitlines():
        if "out" in line:
            print(line)
```
gives:
```
>>> NumPyRandomGeneratorType_random(NumPyRandomGeneratorType, out=array(float64, 1d, C))
        With argument(s): '(NumPyRandomGeneratorType, out=array(float64, 1d, C))':
         TypingError: got an unexpected keyword argument 'out'
```
