### PR TITLE
Fix cryptic AttributeError when loading cache for exec()-defined functions

### DIFF
--- a/docs/upcoming_changes/10485.bug_fix.rst
+++ b/docs/upcoming_changes/10485.bug_fix.rst
@@ -1,0 +1,7 @@
+Fix cryptic ``AttributeError`` when reloading cache for ``exec()``-defined functions
+------------------------------------------------------------------------------------
+
+Fixed a cryptic ``AttributeError`` raised deep inside importlib when
+reloading a cached JIT function that was defined inside ``exec()`` without a
+``'__name__'`` key in its globals. A ``RuntimeError`` with an actionable
+message is now raised instead.

--- a/numba/core/environment.py
+++ b/numba/core/environment.py
@@ -48,6 +48,14 @@ def _rebuild_env(modname, consts, env_name):
     if env is not None:
         return env
 
+    if modname is None:
+        raise RuntimeError(
+            "Cannot load cached JIT function: the function's globals have no "
+            "'__name__', which usually means it was defined inside exec() or "
+            "eval() without a module name. Either disable caching for this "
+            "function or add '__name__' to the globals passed to exec()."
+        )
+
     mod = importlib.import_module(modname)
     env = Environment(mod.__dict__)
     env.consts[:] = consts

--- a/numba/tests/test_caching.py
+++ b/numba/tests/test_caching.py
@@ -1321,5 +1321,31 @@ class TestInTreeCacheLocatorFsAgnostic(TestCase):
         self.assertEqual(stamp[1], stat_result.st_size)
 
 
+class TestRebuildEnvNoneModule(TestCase):
+    """Tests for _rebuild_env behavior when modname is None (issue #10485).
+
+    Functions defined inside exec() without a '__name__' in their globals
+    produce modname=None when pickled. On cache load this used to crash with
+    a cryptic AttributeError deep inside importlib; now it should raise a
+    clear RuntimeError.
+    """
+
+    def test_rebuild_env_raises_on_none_modname(self):
+        from numba.core.environment import _rebuild_env
+        with self.assertRaises(RuntimeError) as cm:
+            _rebuild_env(None, [], "dummy_env_name")
+        self.assertIn("exec()", str(cm.exception))
+        self.assertIn("__name__", str(cm.exception))
+
+    def test_rebuild_env_error_message_is_actionable(self):
+        from numba.core.environment import _rebuild_env
+        with self.assertRaises(RuntimeError) as cm:
+            _rebuild_env(None, [], "dummy_env_name")
+        msg = str(cm.exception)
+        # Message must tell the user both what went wrong and how to fix it
+        self.assertIn("cache", msg.lower())
+        self.assertIn("__name__", msg)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## What this fixes

Closes #10485.

When a `@njit(cache=True)` function is defined inside `exec()` without a `'__name__'` key in its globals, `Environment.__reduce__` serializes `modname=None`. On cache reload, `_rebuild_env(None, ...)` calls `importlib.import_module(None)`, which crashes deep inside importlib with:

```
AttributeError: 'NoneType' object has no attribute 'startswith'
```

This traceback points into importlib internals and gives the user no indication of what went wrong or how to fix it.

## Change

Added an explicit `None` check at the top of `_rebuild_env` that raises a `RuntimeError` with a message explaining the root cause and how to resolve it:

```
RuntimeError: Cannot load cached JIT function: the function's globals have no
'__name__', which usually means it was defined inside exec() or eval() without
a module name. Either disable caching for this function or add '__name__' to
the globals passed to exec().
```

This matches the fix direction discussed in the issue:
> From the triage discussion: we should fix this by producing a better error message in this case.

## Tests

Added `TestRebuildEnvNoneModule` to `numba/tests/test_caching.py` with two unit tests:
- `test_rebuild_env_raises_on_none_modname` — verifies a `RuntimeError` is raised and mentions `exec()` and `__name__`
- `test_rebuild_env_error_message_is_actionable` — verifies the message contains the word "cache" and `__name__`

## Safety

- Only affects the crash path (`modname is None`), which already produced an error
- All valid calls have `modname` as a proper module name string — unaffected
- No behavioral change, no performance impact, no new code paths for normal usage