### PR TITLE
Refactored min/max functionality into overloads

### DIFF
--- a/numba/core/typing/builtins.py
+++ b/numba/core/typing/builtins.py
@@ -880,54 +880,6 @@ class TypeRefAttribute(AttributeTemplate):
 
 #------------------------------------------------------------------------------
 
-
-class MinMaxBase(AbstractTemplate):
-
-    def _unify_minmax(self, tys):
-        # TODO: When we refactor min and max, we should move datetime logic 
-        # to the NumPy module. For now, we special case the datetime-like 
-        # types here.
-        from numba.np.types.datetime import NPTimedelta, NPDatetime
-        for ty in tys:
-            if not isinstance(ty, (types.Number, NPDatetime, NPTimedelta)):
-                return
-        return self.context.unify_types(*tys)
-
-    def generic(self, args, kws):
-        """
-        Resolve a min() or max() call.
-        """
-        assert not kws
-
-        if not args:
-            return
-        if len(args) == 1:
-            # max(arg) only supported if arg is an iterable
-            if isinstance(args[0], types.BaseTuple):
-                tys = list(args[0])
-                if not tys:
-                    raise errors.TypingError("%s() argument is an empty tuple"
-                                             % (self.key.__name__,))
-            else:
-                return
-        else:
-            # max(*args)
-            tys = args
-        retty = self._unify_minmax(tys)
-        if retty is not None:
-            return signature(retty, *args)
-
-
-@infer_global(max)
-class Max(MinMaxBase):
-    pass
-
-
-@infer_global(min)
-class Min(MinMaxBase):
-    pass
-
-
 @infer_global(round)
 class Round(ConcreteTemplate):
     cases = [

--- a/numba/cpython/builtins.py
+++ b/numba/cpython/builtins.py
@@ -564,26 +564,45 @@ def boolval_max(val1, val2):
 
 @overload(max)
 def ol_max(*x):
-    for ty in x:
-        if not isinstance(ty, types.Number):
-            return None
+    if len(x) == 1 and (
+        (isinstance(x[0], types.UniTuple) and isinstance(x[0].dtype, types.Number))
+        or (isinstance(x[0], types.BaseTuple) and all(isinstance(ty, types.Number) for ty in x[0].types))
+    ):
+        def impl(*x):
+            return max_vararg(x[0])
+        return impl
+    else:
+        for ty in x:
+            if not isinstance(ty, types.Number):
+                return None
 
-    def impl(*x):
-        return max_vararg(x)
-    return impl
+        def impl(*x):
+            return max_vararg(x)
+        return impl
 
 @overload(min)
 def ol_min(*x):
-    for ty in x:
-        if not isinstance(ty, types.Number):
-            return None
+    if len(x) == 1 and (
+        (isinstance(x[0], types.UniTuple) and isinstance(x[0].dtype, types.Number))
+        or (isinstance(x[0], types.BaseTuple) and all(isinstance(ty, types.Number) for ty in x[0].types))
+    ):
+        def impl(*x):
+            return min_vararg(x[0])
+        return impl
+    else:
+        for ty in x:
+            if not isinstance(ty, types.Number):
+                return None
 
-    def impl(*x):
-        return min_vararg(x)
-    return impl
+        def impl(*x):
+            return min_vararg(x)
+        return impl
 
 @intrinsic
 def max_vararg(context, x):
+    if len(x) == 0:
+        raise TypingError("max() argument is an empty tuple")
+
     def impl(context, builder, sig, args):
         argtys = list(sig.args[0])
         args = cgutils.unpack_tuple(builder, args[0])
@@ -599,6 +618,9 @@ def max_vararg(context, x):
 
 @intrinsic
 def min_vararg(context, x):
+    if len(x) == 0:
+        raise TypingError("min() argument is an empty tuple")
+
     def impl(context, builder, sig, args):
         argtys = list(sig.args[0])
         args = cgutils.unpack_tuple(builder, args[0])

--- a/numba/cpython/builtins.py
+++ b/numba/cpython/builtins.py
@@ -609,7 +609,6 @@ def max_vararg(context, x):
         return do_minmax(context, builder, argtys, args, operator.gt)
 
     retty = context.unify_types(*x)
-
     if retty is not None:
         sig = signature(retty, x)
         return sig, impl
@@ -628,7 +627,7 @@ def min_vararg(context, x):
 
     retty = context.unify_types(*x)
     if retty is not None:
-        sig = retty(x)
+        sig = signature(x)
         return sig, impl
     else:
         raise ValueError("Given types cannot be unified")

--- a/numba/cpython/builtins.py
+++ b/numba/cpython/builtins.py
@@ -567,10 +567,10 @@ def ol_max(*x):
     if len(x) == 1 and (
         (
             isinstance(x[0], types.UniTuple) and
-            isinstance(x[0].dtype, types.Number)
+            isinstance(x[0].dtype, (types.Number, types.Boolean))
         ) or (
             isinstance(x[0], types.BaseTuple) and
-            all(isinstance(ty, types.Number) for ty in x[0].types)
+            all(isinstance(ty, (types.Number, types.Boolean)) for ty in x[0].types)
         )
     ):
         def impl(*x):
@@ -578,7 +578,7 @@ def ol_max(*x):
         return impl
     else:
         for ty in x:
-            if not isinstance(ty, types.Number):
+            if not isinstance(ty, (types.Number, types.Boolean)):
                 return None
 
         def impl(*x):
@@ -591,10 +591,10 @@ def ol_min(*x):
     if len(x) == 1 and (
         (
             isinstance(x[0], types.UniTuple) and
-            isinstance(x[0].dtype, types.Number)
+            isinstance(x[0].dtype, (types.Number, types.Boolean))
         ) or (
             isinstance(x[0], types.BaseTuple) and
-            all(isinstance(ty, types.Number) for ty in x[0].types)
+            all(isinstance(ty, (types.Number, types.Boolean)) for ty in x[0].types)
         )
     ):
         def impl(*x):
@@ -602,7 +602,7 @@ def ol_min(*x):
         return impl
     else:
         for ty in x:
-            if not isinstance(ty, types.Number):
+            if not isinstance(ty, (types.Number, types.Boolean)):
                 return None
 
         def impl(*x):

--- a/numba/cpython/builtins.py
+++ b/numba/cpython/builtins.py
@@ -625,7 +625,7 @@ def max_vararg(context, x):
         sig = signature(retty, x)
         return sig, impl
     else:
-        raise ValueError("Given types cannot be unified")
+        raise TypingError("Given types cannot be unified")
 
 
 @intrinsic
@@ -643,7 +643,7 @@ def min_vararg(context, x):
         sig = signature(retty, x)
         return sig, impl
     else:
-        raise ValueError("Given types cannot be unified")
+        raise TypingError("Given types cannot be unified")
 
 
 # -----------------------------------------------------------------------------

--- a/numba/cpython/builtins.py
+++ b/numba/cpython/builtins.py
@@ -235,28 +235,6 @@ def do_minmax(context, builder, argtys, args, cmpop):
     resty, resval = reduce(binary_minmax, typvals)
     return resval
 
-
-@lower_builtin(max, types.BaseTuple)
-def max_iterable(context, builder, sig, args):
-    argtys = list(sig.args[0])
-    args = cgutils.unpack_tuple(builder, args[0])
-    return do_minmax(context, builder, argtys, args, operator.gt)
-
-@lower_builtin(max, types.VarArg(types.Any))
-def max_vararg(context, builder, sig, args):
-    return do_minmax(context, builder, sig.args, args, operator.gt)
-
-@lower_builtin(min, types.BaseTuple)
-def min_iterable(context, builder, sig, args):
-    argtys = list(sig.args[0])
-    args = cgutils.unpack_tuple(builder, args[0])
-    return do_minmax(context, builder, argtys, args, operator.lt)
-
-@lower_builtin(min, types.VarArg(types.Any))
-def min_vararg(context, builder, sig, args):
-    return do_minmax(context, builder, sig.args, args, operator.lt)
-
-
 def _round_intrinsic(tp):
     # round() rounds half to even
     return "llvm.rint.f%d" % (tp.bitwidth,)
@@ -581,6 +559,60 @@ def boolval_max(val1, val2):
         def bool_max_impl(val1, val2):
             return val1 or val2
         return bool_max_impl
+
+# -----------------------------------------------------------------------------
+
+@overload(max)
+def ol_max(*x):
+    for ty in x:
+        if not isinstance(ty, types.Number):
+            return None
+
+    def impl(*x):
+        return max_vararg(x)
+    return impl
+
+@overload(min)
+def ol_min(*x):
+    for ty in x:
+        if not isinstance(ty, types.Number):
+            return None
+
+    def impl(*x):
+        return min_vararg(x)
+    return impl
+
+@intrinsic
+def max_vararg(context, x):
+    def impl(context, builder, sig, args):
+        argtys = list(sig.args[0])
+        args = cgutils.unpack_tuple(builder, args[0])
+        return do_minmax(context, builder, argtys, args, operator.gt)
+
+    retty = context.unify_types(*x)
+
+    if retty is not None:
+        sig = signature(retty, x)
+        return sig, impl
+    else:
+        raise ValueError("Given types cannot be unified")
+
+@intrinsic
+def min_vararg(context, x):
+    def impl(context, builder, sig, args):
+        argtys = list(sig.args[0])
+        args = cgutils.unpack_tuple(builder, args[0])
+        return do_minmax(context, builder, argtys, args, operator.lt)
+
+    retty = context.unify_types(*x)
+    if retty is not None:
+        sig = retty(x)
+        return sig, impl
+    else:
+        raise ValueError("Given types cannot be unified")
+
+
+# -----------------------------------------------------------------------------
 
 
 greater_than = register_jitable(lambda a, b: a > b)

--- a/numba/cpython/builtins.py
+++ b/numba/cpython/builtins.py
@@ -565,8 +565,13 @@ def boolval_max(val1, val2):
 @overload(max)
 def ol_max(*x):
     if len(x) == 1 and (
-        (isinstance(x[0], types.UniTuple) and isinstance(x[0].dtype, types.Number))
-        or (isinstance(x[0], types.BaseTuple) and all(isinstance(ty, types.Number) for ty in x[0].types))
+        (
+            isinstance(x[0], types.UniTuple) and
+            isinstance(x[0].dtype, types.Number)
+        ) or (
+            isinstance(x[0], types.BaseTuple) and
+            all(isinstance(ty, types.Number) for ty in x[0].types)
+        )
     ):
         def impl(*x):
             return max_vararg(x[0])
@@ -580,11 +585,17 @@ def ol_max(*x):
             return max_vararg(x)
         return impl
 
+
 @overload(min)
 def ol_min(*x):
     if len(x) == 1 and (
-        (isinstance(x[0], types.UniTuple) and isinstance(x[0].dtype, types.Number))
-        or (isinstance(x[0], types.BaseTuple) and all(isinstance(ty, types.Number) for ty in x[0].types))
+        (
+            isinstance(x[0], types.UniTuple) and
+            isinstance(x[0].dtype, types.Number)
+        ) or (
+            isinstance(x[0], types.BaseTuple) and
+            all(isinstance(ty, types.Number) for ty in x[0].types)
+        )
     ):
         def impl(*x):
             return min_vararg(x[0])
@@ -597,6 +608,7 @@ def ol_min(*x):
         def impl(*x):
             return min_vararg(x)
         return impl
+
 
 @intrinsic
 def max_vararg(context, x):
@@ -614,6 +626,7 @@ def max_vararg(context, x):
         return sig, impl
     else:
         raise ValueError("Given types cannot be unified")
+
 
 @intrinsic
 def min_vararg(context, x):

--- a/numba/cpython/builtins.py
+++ b/numba/cpython/builtins.py
@@ -627,7 +627,7 @@ def min_vararg(context, x):
 
     retty = context.unify_types(*x)
     if retty is not None:
-        sig = signature(x)
+        sig = signature(retty, x)
         return sig, impl
     else:
         raise ValueError("Given types cannot be unified")

--- a/numba/cpython/builtins.py
+++ b/numba/cpython/builtins.py
@@ -625,7 +625,7 @@ def max_vararg(context, x):
         sig = signature(retty, x)
         return sig, impl
     else:
-        raise TypingError("Given types cannot be unified")
+        raise TypingError(f"Given types cannot be unified: {[ty for ty in x]}")
 
 
 @intrinsic
@@ -643,7 +643,7 @@ def min_vararg(context, x):
         sig = signature(retty, x)
         return sig, impl
     else:
-        raise TypingError("Given types cannot be unified")
+        raise TypingError(f"Given types cannot be unified: {[ty for ty in x]}")
 
 
 # -----------------------------------------------------------------------------

--- a/numba/np/types/datetime_registry.py
+++ b/numba/np/types/datetime_registry.py
@@ -1,5 +1,5 @@
 from numba.core.pythonapi import box, unbox, NativeValue
-from numba.np.types import NPDatetime, NPTimedelta
+from numba.np.types import NPDatetime, NPTimedelta, UniTuple, BaseTuple
 from numba.core.extending import overload
 from numba.cpython.builtins import max_vararg, min_vararg
 
@@ -28,25 +28,43 @@ def unbox_nptimedelta(typ, obj, c):
 
 @overload(max)
 def ol_max(*x):
-    for ty in x:
-        if not isinstance(ty, (
-            NPDatetime, NPTimedelta
-        )):
-            return None
+    if len(x) == 1 and (
+        (isinstance(x[0], UniTuple) and isinstance(
+            x[0].dtype, (NPDatetime, NPTimedelta)))
 
-    def impl(*x):
-        return max_vararg(x)
-    return impl
+        or (isinstance(x[0], BaseTuple) and all(
+            isinstance(ty, (NPDatetime, NPTimedelta)) for ty in x[0].types))
+    ):
+        def impl(*x):
+            return max_vararg(x[0])
+        return impl
+    else:
+        for ty in x:
+            if not isinstance(ty, (NPDatetime, NPTimedelta)):
+                return None
+
+        def impl(*x):
+            return max_vararg(x)
+        return impl
 
 
 @overload(min)
 def ol_min(*x):
-    for ty in x:
-        if not isinstance(ty, (
-            NPDatetime, NPTimedelta
-        )):
-            return None
+    if len(x) == 1 and (
+        (isinstance(x[0], UniTuple) and isinstance(
+            x[0].dtype, (NPDatetime, NPTimedelta)))
 
-    def impl(*x):
-        return min_vararg(x)
-    return impl
+        or (isinstance(x[0], BaseTuple) and all(
+            isinstance(ty, (NPDatetime, NPTimedelta)) for ty in x[0].types))
+    ):
+        def impl(*x):
+            return min_vararg(x[0])
+        return impl
+    else:
+        for ty in x:
+            if not isinstance(ty, (NPDatetime, NPTimedelta)):
+                return None
+
+        def impl(*x):
+            return min_vararg(x)
+        return impl

--- a/numba/np/types/datetime_registry.py
+++ b/numba/np/types/datetime_registry.py
@@ -1,5 +1,5 @@
 from numba.core.pythonapi import box, unbox, NativeValue
-from numba.core.types import UniTuple, BaseTuple
+from numba.core.types import UniTuple, BaseTuple, Number, Boolean
 from numba.np.types import NPDatetime, NPTimedelta
 from numba.core.extending import overload
 from numba.cpython.builtins import max_vararg, min_vararg
@@ -31,17 +31,18 @@ def unbox_nptimedelta(typ, obj, c):
 def ol_max_datetime(*x):
     if len(x) == 1 and (
         (isinstance(x[0], UniTuple) and isinstance(
-            x[0].dtype, (NPDatetime, NPTimedelta)))
+            x[0].dtype, (NPDatetime, NPTimedelta, Number, Boolean)))
 
         or (isinstance(x[0], BaseTuple) and all(
-            isinstance(ty, (NPDatetime, NPTimedelta)) for ty in x[0].types))
+            isinstance(ty, (NPDatetime, NPTimedelta,
+                            Number, Boolean)) for ty in x[0].types))
     ):
         def impl(*x):
             return max_vararg(x[0])
         return impl
     else:
         for ty in x:
-            if not isinstance(ty, (NPDatetime, NPTimedelta)):
+            if not isinstance(ty, (NPDatetime, NPTimedelta, Number, Boolean)):
                 return None
 
         def impl(*x):
@@ -53,17 +54,18 @@ def ol_max_datetime(*x):
 def ol_min_datetime(*x):
     if len(x) == 1 and (
         (isinstance(x[0], UniTuple) and isinstance(
-            x[0].dtype, (NPDatetime, NPTimedelta)))
+            x[0].dtype, (NPDatetime, NPTimedelta, Number, Boolean)))
 
         or (isinstance(x[0], BaseTuple) and all(
-            isinstance(ty, (NPDatetime, NPTimedelta)) for ty in x[0].types))
+            isinstance(ty, (NPDatetime, NPTimedelta,
+                            Number, Boolean)) for ty in x[0].types))
     ):
         def impl(*x):
             return min_vararg(x[0])
         return impl
     else:
         for ty in x:
-            if not isinstance(ty, (NPDatetime, NPTimedelta)):
+            if not isinstance(ty, (NPDatetime, NPTimedelta, Number, Boolean)):
                 return None
 
         def impl(*x):

--- a/numba/np/types/datetime_registry.py
+++ b/numba/np/types/datetime_registry.py
@@ -28,7 +28,7 @@ def unbox_nptimedelta(typ, obj, c):
 
 
 @overload(max)
-def ol_max(*x):
+def ol_max_datetime(*x):
     if len(x) == 1 and (
         (isinstance(x[0], UniTuple) and isinstance(
             x[0].dtype, (NPDatetime, NPTimedelta)))
@@ -50,7 +50,7 @@ def ol_max(*x):
 
 
 @overload(min)
-def ol_min(*x):
+def ol_min_datetime(*x):
     if len(x) == 1 and (
         (isinstance(x[0], UniTuple) and isinstance(
             x[0].dtype, (NPDatetime, NPTimedelta)))

--- a/numba/np/types/datetime_registry.py
+++ b/numba/np/types/datetime_registry.py
@@ -1,5 +1,7 @@
 from numba.core.pythonapi import box, unbox, NativeValue
 from numba.np.types import NPDatetime, NPTimedelta
+from numba.core.extending import overload
+from numba.cpython.builtins import max_vararg, min_vararg
 
 
 @box(NPDatetime)
@@ -22,3 +24,29 @@ def box_nptimedelta(typ, val, c):
 def unbox_nptimedelta(typ, obj, c):
     val = c.pyapi.extract_np_timedelta(obj)
     return NativeValue(val, is_error=c.pyapi.c_api_error())
+
+
+@overload(max)
+def ol_max(*x):
+    for ty in x:
+        if not isinstance(ty, (
+            NPDatetime, NPTimedelta
+        )):
+            return None
+
+    def impl(*x):
+        return max_vararg(x)
+    return impl
+
+
+@overload(min)
+def ol_min(*x):
+    for ty in x:
+        if not isinstance(ty, (
+            NPDatetime, NPTimedelta
+        )):
+            return None
+
+    def impl(*x):
+        return min_vararg(x)
+    return impl

--- a/numba/np/types/datetime_registry.py
+++ b/numba/np/types/datetime_registry.py
@@ -1,5 +1,6 @@
 from numba.core.pythonapi import box, unbox, NativeValue
-from numba.np.types import NPDatetime, NPTimedelta, UniTuple, BaseTuple
+from numba.core.types import UniTuple, BaseTuple
+from numba.np.types import NPDatetime, NPTimedelta
 from numba.core.extending import overload
 from numba.cpython.builtins import max_vararg, min_vararg
 

--- a/numba/tests/test_builtins.py
+++ b/numba/tests/test_builtins.py
@@ -876,7 +876,17 @@ class TestBuiltins(TestCase):
 
     def test_min_empty_tuple(self):
         self.check_min_max_empty_tuple(min_usecase4, "min")
+    
+    def check_min_max_type_unification(self, pyfunc, func_name):
+        with self.assertTypingError() as raises:
+            njit(pyfunc)(np.bool_(True), np.datetime64('2020', 'Y'))
+        self.assertIn("Given types cannot be unified", str(raises.exception))
+    
+    def test_max_type_unification(self):
+        self.check_min_max_type_unification(max_usecase1, "max")
 
+    def test_min_type_unification(self):
+        self.check_min_max_type_unification(min_usecase1, "min")
 
     def test_oct(self, flags=forceobj_flags):
         pyfunc = oct_usecase

--- a/numba/tests/test_builtins.py
+++ b/numba/tests/test_builtins.py
@@ -880,8 +880,11 @@ class TestBuiltins(TestCase):
     def check_min_max_type_unification(self, pyfunc, func_name):
         with self.assertTypingError() as raises:
             njit(pyfunc)(np.bool_(True), np.datetime64('2020', 'Y'))
-        self.assertIn("Given types cannot be unified", str(raises.exception))
-    
+        self.assertIn(
+            "Given types cannot be unified: [bool, datetime64[Y]]",
+            str(raises.exception)
+        )
+
     def test_max_type_unification(self):
         self.check_min_max_type_unification(max_usecase1, "max")
 


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

As titled, 

This PR refactors the `min` and `max` builtins implementations to follow the new `overload` API. 

`overload` API allows us  to seperate the NumPy `datetime` and `timedelta` dependent implementation during the typing stage from the `core` implementation in CPython. Hence removing the requirement to import  a NumPy datatype into the CPython builtins. 

This PR does not have any effect on the actual functionality of the implementation. 