### PR TITLE
Refactored int constructor into overload API

### DIFF
--- a/numba/core/typing/builtins.py
+++ b/numba/core/typing/builtins.py
@@ -954,33 +954,6 @@ class Bool(AbstractTemplate):
         # intrinsic.
         return self.context.resolve_function_type(operator.truth, args, kws)
 
-
-@infer_global(int)
-class Int(AbstractTemplate):
-
-    def generic(self, args, kws):
-        # TODO: When we refactor min and max, we should move datetime logic 
-        # to the NumPy module. For now, we special case the datetime-like 
-        # types here.
-        from numba.np.types.datetime import NPTimedelta, NPDatetime
-        if kws:
-            raise errors.NumbaAssertionError('kws not supported')
-
-        [arg] = args
-
-        if isinstance(arg, types.Integer):
-            return signature(arg, arg)
-        if isinstance(arg, (types.Float, types.Boolean)):
-            return signature(types.intp, arg)
-        if isinstance(arg, NPDatetime):
-            if arg.unit == 'ns':
-                return signature(types.int64, arg)
-            else:
-                raise errors.NumbaTypeError(f"Only datetime64[ns] can be converted, but got datetime64[{arg.unit}]")
-        if isinstance(arg, NPTimedelta):
-            return signature(types.int64, arg)
-
-
 @infer_global(float)
 class Float(AbstractTemplate):
 

--- a/numba/core/typing/builtins.py
+++ b/numba/core/typing/builtins.py
@@ -906,33 +906,6 @@ class Bool(AbstractTemplate):
         # intrinsic.
         return self.context.resolve_function_type(operator.truth, args, kws)
 
-
-@infer_global(int)
-class Int(AbstractTemplate):
-
-    def generic(self, args, kws):
-        # TODO: When we refactor min and max, we should move datetime logic 
-        # to the NumPy module. For now, we special case the datetime-like 
-        # types here.
-        from numba.np.types.datetime import NPTimedelta, NPDatetime
-        if kws:
-            raise errors.NumbaAssertionError('kws not supported')
-
-        [arg] = args
-
-        if isinstance(arg, types.Integer):
-            return signature(arg, arg)
-        if isinstance(arg, (types.Float, types.Boolean)):
-            return signature(types.intp, arg)
-        if isinstance(arg, NPDatetime):
-            if arg.unit == 'ns':
-                return signature(types.int64, arg)
-            else:
-                raise errors.NumbaTypeError(f"Only datetime64[ns] can be converted, but got datetime64[{arg.unit}]")
-        if isinstance(arg, NPTimedelta):
-            return signature(types.int64, arg)
-
-
 @infer_global(float)
 class Float(AbstractTemplate):
 

--- a/numba/cpython/builtins.py
+++ b/numba/cpython/builtins.py
@@ -311,14 +311,24 @@ def round_impl_binary(context, builder, sig, args):
 #-------------------------------------------------------------------------------
 # Numeric constructors
 
-@lower_builtin(int, types.Any)
-@lower_builtin(float, types.Any)
-def int_impl(context, builder, sig, args):
-    [ty] = sig.args
-    [val] = args
-    res = context.cast(builder, val, ty, sig.return_type)
-    return impl_ret_untracked(context, builder, sig.return_type, res)
+@intrinsic
+def cast_int(typingctx, x):
+    def impl(context, builder, signature, args):
+        [ty] = signature.args
+        [val] = args
+        res = context.cast(builder, val, ty, sig.return_type)
+        return impl_ret_untracked(context, builder, sig.return_type, res)
 
+    sig = types.intp(x)
+    return sig, impl
+
+@overload(int)
+def ol_int(x):
+    if isinstance(x, (types.Integer, types.Boolean, types.Float)):
+        def impl(x):
+            return cast_int(x)
+
+        return impl
 
 @lower_builtin(float, types.StringLiteral)
 def float_literal_impl(context, builder, sig, args):

--- a/numba/cpython/builtins.py
+++ b/numba/cpython/builtins.py
@@ -311,6 +311,13 @@ def round_impl_binary(context, builder, sig, args):
 #-------------------------------------------------------------------------------
 # Numeric constructors
 
+@lower_builtin(float, types.Any)
+def int_impl(context, builder, sig, args):
+    [ty] = sig.args
+    [val] = args
+    res = context.cast(builder, val, ty, sig.return_type)
+    return impl_ret_untracked(context, builder, sig.return_type, res)
+
 @intrinsic
 def cast_int(typingctx, x):
     def impl(context, builder, signature, args):

--- a/numba/cpython/builtins.py
+++ b/numba/cpython/builtins.py
@@ -289,14 +289,36 @@ def round_impl_binary(context, builder, sig, args):
 #-------------------------------------------------------------------------------
 # Numeric constructors
 
-@lower_builtin(int, types.Any)
 @lower_builtin(float, types.Any)
-def int_impl(context, builder, sig, args):
+def float_impl(context, builder, sig, args):
     [ty] = sig.args
     [val] = args
     res = context.cast(builder, val, ty, sig.return_type)
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
+@intrinsic
+def cast_int(typingctx, x):
+    if isinstance(x, types.Integer):
+        retty = x
+    else:
+        retty = types.intp
+
+    def impl(context, builder, signature, args):
+        [ty] = signature.args
+        [val] = args
+        res = context.cast(builder, val, ty, signature.return_type)
+        return impl_ret_untracked(context, builder, signature.return_type, res)
+
+    sig = signature(retty, x)
+    return sig, impl
+
+@overload(int)
+def ol_int(x):
+    if isinstance(x, (types.Integer, types.Boolean, types.Float)):
+        def impl(x):
+            return cast_int(x)
+
+        return impl
 
 @lower_builtin(float, types.StringLiteral)
 def float_literal_impl(context, builder, sig, args):

--- a/numba/np/types/datetime_registry.py
+++ b/numba/np/types/datetime_registry.py
@@ -32,7 +32,7 @@ def ol_int(x):
     if not isinstance(x, (NPDatetime, NPTimedelta)):
         return
 
-    if not (isinstance(x, NPDatetime) and x.unit == 'ns'):
+    if not (isinstance(x, (NPDatetime, NPTimedelta)) and x.unit == 'ns'):
         raise errors.NumbaTypeError(
             "Only datetime64[ns] can be converted,"
             f" but got datetime64[{x.unit}]"

--- a/numba/np/types/datetime_registry.py
+++ b/numba/np/types/datetime_registry.py
@@ -1,5 +1,8 @@
 from numba.core.pythonapi import box, unbox, NativeValue
 from numba.np.types import NPDatetime, NPTimedelta
+from numba.core.extending import overload
+from numba.cpython.builtins import cast_int
+from numba.core import errors
 
 
 @box(NPDatetime)
@@ -22,3 +25,20 @@ def box_nptimedelta(typ, val, c):
 def unbox_nptimedelta(typ, obj, c):
     val = c.pyapi.extract_np_timedelta(obj)
     return NativeValue(val, is_error=c.pyapi.c_api_error())
+
+
+@overload(int)
+def ol_int(x):
+    if not isinstance(x, (NPDatetime, NPTimedelta)):
+        return
+
+    if not (isinstance(x, NPDatetime) and x.unit == 'ns'):
+        raise errors.NumbaTypeError(
+            "Only datetime64[ns] can be converted,"
+            f" but got datetime64[{x.unit}]"
+        )
+
+    def impl(x):
+        return cast_int(x)
+
+    return impl

--- a/numba/np/types/datetime_registry.py
+++ b/numba/np/types/datetime_registry.py
@@ -2,7 +2,8 @@ from numba.core.pythonapi import box, unbox, NativeValue
 from numba.core.types import UniTuple, BaseTuple, Number, Boolean
 from numba.np.types import NPDatetime, NPTimedelta
 from numba.core.extending import overload
-from numba.cpython.builtins import max_vararg, min_vararg
+from numba.cpython.builtins import max_vararg, min_vararg, cast_int
+from numba.core import errors
 
 
 @box(NPDatetime)
@@ -71,3 +72,20 @@ def ol_min_datetime(*x):
         def impl(*x):
             return min_vararg(x)
         return impl
+
+
+@overload(int)
+def ol_int(x):
+    if not isinstance(x, (NPDatetime, NPTimedelta)):
+        return
+
+    if isinstance(x, NPDatetime) and x.unit != 'ns':
+        raise errors.NumbaTypeError(
+            "Only datetime64[ns] can be converted,"
+            f" but got datetime64[{x.unit}]"
+        )
+
+    def impl(x):
+        return cast_int(x)
+
+    return impl

--- a/numba/tests/test_builtins.py
+++ b/numba/tests/test_builtins.py
@@ -681,6 +681,29 @@ class TestBuiltins(TestCase):
         with self.assertTypingError():
             self.test_int(flags=no_pyobj_flags)
 
+    def test_int_kws(self):
+        cfunc = njit(int_usecase)
+        with self.assertRaises(errors.TypingError):
+            cfunc('1234', base=10)
+
+    def test_int_preserve_type_usecase(self):
+        def pyfunc(x):
+            return int(x)
+
+        cfunc = njit(pyfunc)
+
+        for typ in [types.int32, types.int64, types.uint32, types.uint64]:
+            v = typ(1234)
+            self.assertEqual(cfunc(v), pyfunc(v))
+
+        for i in range(len(cfunc.signatures)):
+            sig = cfunc.signatures[i]
+            ov = cfunc.overloads[sig]
+
+            # Check that the return type is the same as the argument type,
+            # i.e. that int(x) does not widen the type of x.
+            self.assertIs(ov.signature.return_type, ov.signature.args[0])
+
     def test_iter_next(self, flags=forceobj_flags):
         pyfunc = iter_next_usecase
         cfunc = jit((types.UniTuple(types.int32, 3),), **flags)(pyfunc)


### PR DESCRIPTION
As titled,

This PR refactors the `int` builtins implementations to follow the new overload API.

`overload` API allows us to seperate the NumPy `datetime` and `timedelta` dependent implementation during the typing stage from the core implementation in CPython. Hence removing the requirement to import a NumPy datatype into the CPython builtins.

This PR does not have any effect on the actual functionality of the implementation.