### PR TITLE
add tier 1.5 description as per #10406

### DIFF
--- a/.github/workflows/towncrier.yml
+++ b/.github/workflows/towncrier.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: '3.14'
       - name: Install towncrier
         run: |
-          python3 -m pip install towncrier==23.6 "importlib_resources<6" rstcheck
+          python3 -m pip install towncrier==23.6 "importlib_resources<6" "rstcheck[sphinx]"
       - name: Run towncrier
         run: |
           git fetch --no-tags origin +refs/heads/${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}

--- a/docs/source/reference/support_tiers.rst
+++ b/docs/source/reference/support_tiers.rst
@@ -123,6 +123,42 @@ maintainers either maintain or help to maintain these releases.
   * ``linux-aarch64`` (Linux on ``aarch64``)
   * ``win-64`` (Windows on ``x86_64``)
 
+Tier 1.5: Experimental releases for emerging platforms
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Tier 1.5 covers platforms that have limited usage today but, in the view of the
+maintainers, are likely to grow in importance and benefit from early binary
+package availability (for example, so that downstream projects can test against
+them). Tier 1.5 packages are considered experimental and may have significant
+bugs.  The expectation is that Tier 1.5 platforms will eventually graduate to
+Tier 1.
+
+Expectations for Tier 1.5:
+
+* Packages are built for a limited range of Python versions, possibly only the
+  most recent one.
+* The platform must be testable in the GitHub Actions CI system used by Numba
+  and llvmlite.
+* Only wheels *or* conda packages are built, depending on which ecosystem has
+  sufficient support (e.g. NumPy availability) to build Numba.
+* Failure of the ``main`` branch to build on a Tier 1.5 platform is a release 
+  blocker and should be addressed promptly, but maintainers are encouraged to
+  skip tests and document known issues rather than spend significant effort
+  debugging to return ``main`` to a healthy state.
+* Known issues on Tier 1.5 platforms can be resolved as time permits and do
+  not block a Numba release.
+
+Currently supported Tier 1.5 releases for the Numba and llvmlite projects:
+
+* Wheel packages on the PyPI distribution system for the free-threading build
+  of Python 3.14, on all Tier 1 platforms:
+
+  * ``osx-arm64`` (OSX on Apple silicon)
+  * ``linux-64`` (Linux on ``x86_64``)
+  * ``linux-aarch64`` (Linux on ``aarch64``)
+  * ``win-64`` (Windows on ``x86_64``)
+
+
 Tier 2a: Releases that are built by large software distributors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/reference/support_tiers.rst
+++ b/docs/source/reference/support_tiers.rst
@@ -123,35 +123,35 @@ maintainers either maintain or help to maintain these releases.
   * ``linux-aarch64`` (Linux on ``aarch64``)
   * ``win-64`` (Windows on ``x86_64``)
 
-Tier 1.5: Experimental releases for emerging platforms
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Tier 1.5: Experimental releases for emerging release configurations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tier 1.5 covers platforms that have limited usage today but, in the view of the
-maintainers, are likely to grow in importance and benefit from early binary
-package availability (for example, so that downstream projects can test against
-them). Tier 1.5 packages are considered experimental and may have significant
-bugs.  The expectation is that Tier 1.5 platforms will eventually graduate to
-Tier 1.
+Tier 1.5 covers release configurations that have limited usage today but, in
+the view of the maintainers, are likely to grow in importance and benefit from
+early binary package availability (for example, so that downstream projects
+can test against them). Tier 1.5 packages are considered experimental and may
+have significant bugs.  The expectation is that Tier 1.5 release configurations
+will eventually graduate to Tier 1.
 
 Expectations for Tier 1.5:
 
 * Packages are built for a limited range of Python versions, possibly only the
   most recent one.
-* The platform must be testable in the GitHub Actions CI system used by Numba
+* The packages must be testable in the GitHub Actions CI system used by Numba
   and llvmlite.
-* Only wheels *or* conda packages are built, depending on which ecosystem has
-  sufficient support (e.g. NumPy availability) to build Numba.
-* Failure of the ``main`` branch to build on a Tier 1.5 platform is a release 
-  blocker and should be addressed promptly, but maintainers are encouraged to
-  skip tests and document known issues rather than spend significant effort
-  debugging to return ``main`` to a healthy state.
-* Known issues on Tier 1.5 platforms can be resolved as time permits and do
-  not block a Numba release.
+* Wheels *or* conda packages, or both, are built, depending on which ecosystems
+  have sufficient support (e.g. NumPy availability) to build Numba.
+* Failure of the ``main`` branch to build on a Tier 1.5 release configuration
+  is a release blocker and should be addressed promptly, but maintainers are
+  encouraged to skip tests and document known issues rather than spend
+  significant effort debugging to return ``main`` to a healthy state.
+* Known issues on Tier 1.5 release configurations can be resolved as time 
+  permits and do not block a Numba release.
 
 Currently supported Tier 1.5 releases for the Numba and llvmlite projects:
 
 * Wheel packages on the PyPI distribution system for the free-threading build
-  of Python 3.14, on all Tier 1 platforms:
+  of Python 3.14 for these OS/architecture combinations:
 
   * ``osx-arm64`` (OSX on Apple silicon)
   * ``linux-64`` (Linux on ``x86_64``)

--- a/docs/upcoming_changes/10548.doc.rst
+++ b/docs/upcoming_changes/10548.doc.rst
@@ -1,6 +1,6 @@
 Document Tier 1.5 support policy
 --------------------------------
 
-The :ref:`support_tiers` documentation now describes a new "Tier 1.5" category
+The :ref:`Support Tiers <support_tiers>` documentation now describes a new "Tier 1.5" category
 covering experimental releases for emerging platforms.  This support tier
 currently includes the previously released Python 3.14 free-threading builds.

--- a/docs/upcoming_changes/10548.doc.rst
+++ b/docs/upcoming_changes/10548.doc.rst
@@ -1,0 +1,6 @@
+Document Tier 1.5 support policy
+--------------------------------
+
+The :ref:`support_tiers` documentation now describes a new "Tier 1.5" category
+covering experimental releases for emerging platforms.  This support tier
+currently includes the previously released Python 3.14 free-threading builds.

--- a/docs/upcoming_changes/10548.doc.rst
+++ b/docs/upcoming_changes/10548.doc.rst
@@ -2,5 +2,5 @@ Document Tier 1.5 support policy
 --------------------------------
 
 The :ref:`Support Tiers <support_tiers>` documentation now describes a new "Tier 1.5" category
-covering experimental releases for emerging platforms.  This support tier
+covering experimental releases for emerging release configurations.  This support tier
 currently includes the previously released Python 3.14 free-threading builds.


### PR DESCRIPTION
This updates the supported platform docs to include a definition of Tier 1.5 (as per #10406) and adds Python 3.14 free-threading to the list, as we shipped in the previous release.