### PR TITLE
type annotations for `CFunc`

### DIFF
--- a/buildscripts/azure/azure-linux-macos.yml
+++ b/buildscripts/azure/azure-linux-macos.yml
@@ -46,7 +46,8 @@ jobs:
         set -e
         export PATH=$HOME/miniconda3/bin:$PATH
         # using conda-forge because main only have version < 1.0
-        conda create -n mypy311 -y -c conda-forge python=3.11 mypy 
+        conda create -n mypy311 -y -c conda-forge python=3.11 mypy
+        conda run -n mypy311 pip install types-cffi
         conda run -n mypy311 mypy
       displayName: 'Mypy'
       condition: eq(variables['RUN_MYPY'], 'yes')

--- a/maint/stubtest/requirements_stubtest.txt
+++ b/maint/stubtest/requirements_stubtest.txt
@@ -1,5 +1,6 @@
 mypy >=1.20, <1.21
 scipy-stubs
+types-cffi
 types-psutil
 types-pygments
 types-pyyaml

--- a/numba/core/ccallback.pyi
+++ b/numba/core/ccallback.pyi
@@ -1,0 +1,58 @@
+from _typeshed import Incomplete
+from collections.abc import Callable
+from ctypes import _CFunctionType
+import functools
+from typing import Any, Generic, TypeVar
+
+from _cffi_backend import _CDataBase as CData
+from typing_extensions import ParamSpec
+
+from .compiler import Compiler
+from .types import Type
+
+_SignatureT_co = TypeVar(
+    "_SignatureT_co",
+    bound=Callable[..., object],
+    default=Callable[..., Any],
+    covariant=True,
+)
+_ParamsT = ParamSpec("_ParamsT")
+_ReturnT = TypeVar("_ReturnT")
+
+class CFunc(Generic[_SignatureT_co]):
+    __name__: str
+    __qualname__: str
+    __wrapped__: _SignatureT_co
+
+    def __init__(
+        self,
+        /,
+        pyfunc: _SignatureT_co,
+        sig: tuple[tuple[Type, ...], Type | None],
+        locals: dict[str, Any],
+        options: dict[str, Incomplete],  # TODO
+        pipeline_class: type[Compiler] = Compiler,
+    ) -> None: ...
+    def __call__(
+        self: CFunc[Callable[_ParamsT, _ReturnT]],
+        /,
+        *args: _ParamsT.args,
+        **kwargs: _ParamsT.kwargs,
+    ) -> _ReturnT: ...
+
+    #
+    def enable_caching(self) -> None: ...
+    def compile(self) -> None: ...
+    def inspect_llvm(self) -> str: ...
+
+    #
+    @property
+    def native_name(self) -> str: ...
+    @property
+    def address(self) -> int | None: ...
+    @property
+    def cache_hits(self) -> int: ...
+    @functools.cached_property
+    def cffi(self) -> CData: ...
+    @functools.cached_property
+    def ctypes(self) -> _CFunctionType: ...

--- a/numba/core/decorators.pyi
+++ b/numba/core/decorators.pyi
@@ -12,6 +12,7 @@ from typing import (
 from typing_extensions import Unpack
 
 from . import compiler, ir, types, typing
+from .ccallback import CFunc
 from .typing.templates import _inline_info
 
 ###
@@ -50,8 +51,7 @@ class _JITWrapper(Protocol):
 
 @type_check_only
 class _CFuncWrapper(Protocol):
-    # TODO: Return `CFunc[_FunctionT]` once `CFunc` is annotated and generic.
-    def __call__(self, fn: _FunctionT, /) -> _FunctionT: ...
+    def __call__(self, fn: _FunctionT, /) -> CFunc[_FunctionT]: ...
 
 ###
 # stubs


### PR DESCRIPTION
Dual to #10551, here are the stubs for `CFunc`, so that we can now use to accurately annotate the wrapped `@cfunc` functions as (generic) `CFunc` types.

ref: https://github.com/numba/numba/pull/10505#issuecomment-4164558683