### PR TITLE
`numba.core.types.common` type stubs

### DIFF
--- a/numba/core/types/abstract.pyi
+++ b/numba/core/types/abstract.pyi
@@ -133,6 +133,7 @@ class IteratorType(IterableType[_TypeT_co], Generic[_TypeT_co]):
     @override
     def iterator_type(self) -> Self: ...
 
+# pyrefly: ignore[invalid-inheritance]
 class Container(
     Sized,
     IterableType[_TypeT_co],

--- a/numba/core/types/abstract.pyi
+++ b/numba/core/types/abstract.pyi
@@ -30,7 +30,7 @@ class _CanCastPythonValue(Protocol[_T_contra, _T_co]):
 # the step is `Any` instead of `Literal[1] | None` so we can use it as invariant `list`
 # element type
 _SpecSlice: TypeAlias = slice[None, None, Any]
-_Layout: TypeAlias = _Literal["F", "C", "A"]
+_Layout: TypeAlias = _Literal["C", "F", "CS", "FS", "A"]
 
 ###
 
@@ -41,10 +41,10 @@ class _TypeMetaclass(abc.ABCMeta):
     def __call__(cls, *args: Any, **kwargs: Any) -> Any: ...
 
 class Type(metaclass=_TypeMetaclass):
-    mutable: ClassVar[bool] = False
     reflected: ClassVar[bool] = False
 
     name: str
+    mutable: bool = False
 
     def __init__(self, name: str) -> None: ...
 
@@ -113,10 +113,10 @@ class DTypeSpec(Type):
     @abc.abstractmethod
     def dtype(self) -> Any: ...
 
-class IterableType(Type):
+class IterableType(Type, Generic[_TypeT_co]):
     @property
     @abc.abstractmethod
-    def iterator_type(self) -> Type: ...
+    def iterator_type(self) -> IteratorType[_TypeT_co]: ...
 
 class Sized(Type): ...
 
@@ -124,20 +124,25 @@ class ConstSized(Sized):
     @abc.abstractmethod
     def __len__(self) -> int: ...
 
-class IteratorType(IterableType):
+class IteratorType(IterableType[_TypeT_co], Generic[_TypeT_co]):
     def __init__(self, name: str, **kwargs: Never) -> None: ...
     @property
     @abc.abstractmethod
-    def yield_type(self) -> Type: ...
+    def yield_type(self) -> _TypeT_co: ...
     @property
     @override
     def iterator_type(self) -> Self: ...
 
-class Container(Sized, IterableType): ...
-class Sequence(Container): ...
+class Container(
+    Sized,
+    IterableType[_TypeT_co],
+    Generic[_TypeT_co],
+    metaclass=abc.ABCMeta,
+): ...
+class Sequence(Container[_TypeT_co], Generic[_TypeT_co], metaclass=abc.ABCMeta): ...
 
-class MutableSequence(Sequence):
-    mutable: ClassVar[bool] = True
+class MutableSequence(Sequence[_TypeT_co], Generic[_TypeT_co], metaclass=abc.ABCMeta):
+    mutable: bool = True
 
 class ArrayCompatible(Type):
     array_priority: ClassVar[float] = 0.0

--- a/numba/core/types/common.pyi
+++ b/numba/core/types/common.pyi
@@ -1,4 +1,3 @@
-import functools
 from typing import ClassVar, Literal, TypeAlias
 
 from typing_extensions import Generic, Self, TypeVar, override
@@ -14,14 +13,14 @@ _Layout: TypeAlias = Literal["C", "F", "CS", "FS", "A"]
 
 class Opaque(Dummy): ...
 
-class SimpleIterableType(IterableType, Generic[_TypeT_co]):
+class SimpleIterableType(IterableType[_TypeT_co], Generic[_TypeT_co]):
     @override
-    def __init__(self, name: str, iterator_type: _TypeT_co): ...
+    def __init__(self, name: str, iterator_type: IteratorType[_TypeT_co]): ...
     @property
     @override
-    def iterator_type(self) -> _TypeT_co: ...
+    def iterator_type(self) -> IteratorType[_TypeT_co]: ...
 
-class SimpleIteratorType(IteratorType, Generic[_TypeT_co]):
+class SimpleIteratorType(IteratorType[_TypeT_co], Generic[_TypeT_co]):
     @override
     def __init__(self, name: str, yield_type: _TypeT_co): ...
     @property
@@ -29,7 +28,7 @@ class SimpleIteratorType(IteratorType, Generic[_TypeT_co]):
     def yield_type(self) -> _TypeT_co: ...
 
 class Buffer(IterableType, ArrayCompatible):
-    LAYOUTS: ClassVar[frozenset[str]] = ...
+    LAYOUTS: ClassVar[frozenset[_Layout]] = ...
 
     slice_is_copy: ClassVar[bool] = False
     aligned: ClassVar[bool] = True
@@ -54,9 +53,6 @@ class Buffer(IterableType, ArrayCompatible):
     @property
     @override
     def key(self) -> tuple[Type, int, _Layout, bool]: ...
-    @functools.cached_property
-    @override
-    def layout(self) -> _Layout: ...
 
     #
     @property

--- a/numba/core/types/common.pyi
+++ b/numba/core/types/common.pyi
@@ -1,0 +1,75 @@
+import functools
+from typing import ClassVar, Literal, TypeAlias
+
+from typing_extensions import Generic, Self, TypeVar, override
+
+from .abstract import ArrayCompatible, Dummy, IterableType, IteratorType, Type
+from .iterators import ArrayIterator
+
+_TypeT_co = TypeVar("_TypeT_co", bound=Type, default=Type, covariant=True)
+
+_Layout: TypeAlias = Literal["C", "F", "CS", "FS", "A"]
+
+###
+
+class Opaque(Dummy): ...
+
+class SimpleIterableType(IterableType, Generic[_TypeT_co]):
+    @override
+    def __init__(self, name: str, iterator_type: _TypeT_co): ...
+    @property
+    @override
+    def iterator_type(self) -> _TypeT_co: ...
+
+class SimpleIteratorType(IteratorType, Generic[_TypeT_co]):
+    @override
+    def __init__(self, name: str, yield_type: _TypeT_co): ...
+    @property
+    @override
+    def yield_type(self) -> _TypeT_co: ...
+
+class Buffer(IterableType, ArrayCompatible):
+    LAYOUTS: ClassVar[frozenset[str]] = ...
+
+    slice_is_copy: ClassVar[bool] = False
+    aligned: ClassVar[bool] = True
+
+    mutable: bool = True
+
+    @override
+    def __init__(
+        self,
+        dtype: Type,
+        ndim: int,
+        layout: _Layout,
+        readonly: bool = False,
+        name: str | None = None,
+    ) -> None: ...
+    @property  # TODO: Use generic `ArrayIterator` once we have `iterators.pyi`
+    @override
+    def iterator_type(self) -> ArrayIterator: ...
+    @property
+    @override
+    def as_array(self) -> Self: ...
+    @property
+    @override
+    def key(self) -> tuple[Type, int, _Layout, bool]: ...
+    @functools.cached_property
+    @override
+    def layout(self) -> _Layout: ...
+
+    #
+    @property
+    def is_c_contig(self) -> bool: ...
+    @property
+    def is_f_contig(self) -> bool: ...
+    @property
+    def is_contig(self) -> bool: ...
+
+    #
+    def copy(
+        self,
+        dtype: Type | None = None,
+        ndim: int | None = None,
+        layout: _Layout | None = None,
+    ) -> Self: ...

--- a/numba/core/types/common.pyi
+++ b/numba/core/types/common.pyi
@@ -14,15 +14,13 @@ _Layout: TypeAlias = Literal["C", "F", "CS", "FS", "A"]
 class Opaque(Dummy): ...
 
 class SimpleIterableType(IterableType[_TypeT_co], Generic[_TypeT_co]):
-    @override
-    def __init__(self, name: str, iterator_type: IteratorType[_TypeT_co]): ...
+    def __init__(self, name: str, iterator_type: IteratorType[_TypeT_co]) -> None: ...
     @property
     @override
     def iterator_type(self) -> IteratorType[_TypeT_co]: ...
 
 class SimpleIteratorType(IteratorType[_TypeT_co], Generic[_TypeT_co]):
-    @override
-    def __init__(self, name: str, yield_type: _TypeT_co): ...
+    def __init__(self, name: str, yield_type: _TypeT_co) -> None: ...
     @property
     @override
     def yield_type(self) -> _TypeT_co: ...
@@ -35,7 +33,6 @@ class Buffer(IterableType, ArrayCompatible):
 
     mutable: bool = True
 
-    @override
     def __init__(
         self,
         dtype: Type,


### PR DESCRIPTION
This builds upon #10513 in the same way as #10555. These are needed when writing the stubs for other types, such as the `numba.core.types.containers`.

This also improves some of the interable abstract base types in `core.types.abstract` by making them (optionally) generic types with parametric yield type. There, I also fixed some minor issues that mypy was complaining about, such as the missing `metaclass=abc.ABCMeta`.