### PR TITLE
Avoid catching and re-emitting warnings

### DIFF
--- a/numba/core/errors.py
+++ b/numba/core/errors.py
@@ -533,21 +533,16 @@ class WarningsFixer(object):
         """
         Store warnings and optionally fix their filename and lineno.
         """
-        with warnings.catch_warnings(record=True) as wlist:
-            warnings.simplefilter('always', self._category)
+        with warnings.catch_warnings(record=True, action='always',
+                                     category=self._category) as wlist:
             yield
 
         for w in wlist:
-            msg = str(w.message)
-            if issubclass(w.category, self._category):
-                # Store warnings of this category for deduplication
-                filename = filename or w.filename
-                lineno = lineno or w.lineno
-                self._warnings[filename, lineno, w.category].add(msg)
-            else:
-                # Simply emit other warnings again
-                warnings.warn_explicit(msg, w.category,
-                                       w.filename, w.lineno)
+            msg = str(w.message)  # stringify in order to deduplicate
+            # Store warnings of this category for deduplication
+            filename = filename or w.filename
+            lineno = lineno or w.lineno
+            self._warnings[filename, lineno, w.category].add(msg)
 
     def flush(self):
         """


### PR DESCRIPTION
`warnings.catch_warnings` already knows how to filter the warnings in Python 3.11 onwards, there is no need to do so ourselves

This avoids needlessly stringifying warnings that we don't care about.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
