### PR TITLE
Run stubtest and mypy with Python 3.11 in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,8 +46,6 @@ jobs:
         NUMPY: '1.24'
         RUN_COVERAGE: yes
         RUN_FLAKE8: yes
-        RUN_MYPY: yes
-        RUN_STUBTEST: yes
         BUILD_DOC: yes
         CONDA_ENV: azure_ci
         TEST_START_INDEX: 1
@@ -68,9 +66,11 @@ jobs:
         CONDA_ENV: azure_ci
         TEST_START_INDEX: 4
 
-      py311_np124:
+      py311_np124_type_check:
         PYTHON: '3.11'
         NUMPY: '1.24'
+        RUN_MYPY: yes
+        RUN_STUBTEST: yes
         CONDA_ENV: azure_ci
         TEST_START_INDEX: 5
       py311_np125:


### PR DESCRIPTION
In #10555 there are some stubtest issues specific to Python<3.11. And since Python 3.10 is almost EOL, using 3.11 to run stubtest in CI seems to the easiest workaround.

ref: https://github.com/numba/numba/pull/10555#issuecomment-4337616332