### PR TITLE
refactor: conda build command on GHA workflows

### DIFF
--- a/.github/workflows/numba_linux-64_conda_builder.yml
+++ b/.github/workflows/numba_linux-64_conda_builder.yml
@@ -110,7 +110,7 @@ jobs:
             extra_args=()
           fi
 
-          conda build --debug -c "${LLVMLITE_CHANNEL}" "${extra_args[@]}" -c defaults  \
+          conda-build --debug -c "${LLVMLITE_CHANNEL}" "${extra_args[@]}" -c defaults  \
             --python=${{ matrix.python-version }} \
             --numpy=${{ matrix.numpy_build }} blas=*=openblas \
             buildscripts/condarecipe.local/ \
@@ -198,7 +198,7 @@ jobs:
             extra_args=()
           fi
 
-          conda build -c "${LLVMLITE_CHANNEL}" "${extra_args[@]}" -c defaults \
+          conda-build -c "${LLVMLITE_CHANNEL}" "${extra_args[@]}" -c defaults \
             --python=${{ matrix.python-version }} \
             --extra-deps numpy=${{ matrix.numpy_test }} blas=*=openblas \
             --test \

--- a/.github/workflows/numba_linux-aarch64_conda_builder.yml
+++ b/.github/workflows/numba_linux-aarch64_conda_builder.yml
@@ -110,7 +110,7 @@ jobs:
             extra_args=()
           fi
 
-          conda build --debug -c $LLVMLITE_CHANNEL "${extra_args[@]}" -c defaults \
+          conda-build --debug -c $LLVMLITE_CHANNEL "${extra_args[@]}" -c defaults \
             --python=${{ matrix.python-version }} \
             --numpy=${{ matrix.numpy_build }} blas=*=openblas \
             buildscripts/condarecipe.local/ \
@@ -213,7 +213,7 @@ jobs:
           echo "Using package: $NUMBA_PKG"
 
           # Run the test with the found package
-          conda build -c $LLVMLITE_CHANNEL "${extra_args[@]}" -c defaults \
+          conda-build -c $LLVMLITE_CHANNEL "${extra_args[@]}" -c defaults \
             --python=${{ matrix.python-version }} \
             --extra-deps numpy=${{ matrix.numpy_test }} blas=*=openblas \
             --test \

--- a/.github/workflows/numba_osx-arm64_conda_builder.yml
+++ b/.github/workflows/numba_osx-arm64_conda_builder.yml
@@ -110,7 +110,7 @@ jobs:
             extra_args=()
           fi
 
-          conda build --debug -c $LLVMLITE_CHANNEL "${extra_args[@]}" -c defaults \
+          conda-build --debug -c $LLVMLITE_CHANNEL "${extra_args[@]}" -c defaults \
             --python=${{ matrix.python-version }} \
             --numpy=${{ matrix.numpy_build }} blas=*=openblas \
             buildscripts/condarecipe.local/ \
@@ -191,7 +191,7 @@ jobs:
             extra_args=()
           fi
 
-          conda build -c $LLVMLITE_CHANNEL "${extra_args[@]}" -c defaults \
+          conda-build -c $LLVMLITE_CHANNEL "${extra_args[@]}" -c defaults \
             --python=${{ matrix.python-version }} \
             --extra-deps numpy=${{ matrix.numpy_test }} blas=*=openblas \
             --test \

--- a/.github/workflows/numba_win-64_conda_builder.yml
+++ b/.github/workflows/numba_win-64_conda_builder.yml
@@ -109,7 +109,7 @@ jobs:
             extra_args=()
           fi
 
-          conda build --debug -c $LLVMLITE_CHANNEL "${extra_args[@]}" -c defaults \
+          conda-build --debug -c $LLVMLITE_CHANNEL "${extra_args[@]}" -c defaults \
             --python=${{ matrix.python-version }} \
             --numpy=${{ matrix.numpy_build }} \
             buildscripts/condarecipe.local/ \
@@ -180,7 +180,7 @@ jobs:
             extra_args=()
           fi
 
-          conda build -c $LLVMLITE_CHANNEL "${extra_args[@]}" -c defaults \
+          conda-build -c $LLVMLITE_CHANNEL "${extra_args[@]}" -c defaults \
             --python=${{ matrix.python-version }} \
             --extra-deps numpy=${{ matrix.numpy_test }} \
             --test \


### PR DESCRIPTION
conda 26.3.1 removed use of conda executable (conda-build) with subcommands (conda build) -

> Conda no longer discovers subcommands by scanning conda-* executables on PATH when building the CLI (prefer the plugin system).

https://conda.org/blog/2026-04-06-march-releases/#changes-in-conda-26302631

This PR corrects the usage on conda builder GHA workflows to use executable directly conda-build.