### PR TITLE
Fix for ABI changes on python 3.14.4

### DIFF
--- a/docs/source/developer/sys_monitoring.rst
+++ b/docs/source/developer/sys_monitoring.rst
@@ -7,11 +7,6 @@ Notes on ``sys.monitoring``
           versions of Python may behave differently. It is however hoped that
           most of the concepts herein will remain relevant.
 
-.. note:: From Python 3.14.4 onward the dispatcher behaviour described below is
-          disabled (`#10538 <https://github.com/numba/numba/issues/10538>`_).
-          ``NUMBA_ENABLE_SYS_MONITORING`` has no effect on those versions and a
-          ``UserWarning`` is emitted if this variable is set to a non-zero value.
-
 Python 3.12 introduced a new monitoring system under ``sys.monitoring``. This
 system lets users monitor a selection of events that may be interesting for e.g.
 performance profiling or debugging purposes. Event monitoring is set "per tool",

--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -194,12 +194,6 @@ These variables influence what is printed out during compilation of
 
    Only available for Python 3.12 and above. Otherwise, it has no effect.
 
-   It also has no effect on Python 3.14.4 and newer: dispatcher support for
-   ``sys.monitoring`` is disabled, see this issue for more details
-   (`#10538 <https://github.com/numba/numba/issues/10538>`_). A
-   ``UserWarning`` is emitted if this variable is set to a
-   non-zero value.
-
 .. envvar:: NUMBA_ENABLE_PROFILING
 
    Enables JIT events of LLVM in order to support profiling of jitted functions.

--- a/docs/upcoming_changes/10547.change.rst
+++ b/docs/upcoming_changes/10547.change.rst
@@ -1,7 +1,0 @@
-Disable JIT ``sys.monitoring`` on Python 3.14.4 and later
----------------------------------------------------------
-
-Python 3.14.4 changed interpreter internals Numba relied on for
-``sys.monitoring`` (`#10538 <https://github.com/numba/numba/issues/10538>`_).
-The feature is disabled from 3.14.4 onward; ``NUMBA_ENABLE_SYS_MONITORING`` has no
-effect and a ``UserWarning`` will be emitted if this variable is set to a non-zero value.

--- a/docs/upcoming_changes/10578.change.rst
+++ b/docs/upcoming_changes/10578.change.rst
@@ -1,0 +1,12 @@
+Use public ``PyMonitoring_*`` C API for ``sys.monitoring`` on Python 3.13+
+--------------------------------------------------------------------------
+
+Numba's dispatcher integration with ``sys.monitoring`` on Python 3.13 and
+later now goes through the public ``PyMonitoring_*`` C API instead of
+CPython internal headers. This restores ``sys.monitoring`` support on
+Python 3.14.4 and newer (`#10538
+<https://github.com/numba/numba/issues/10538>`_), which had been disabled
+due to ABI changes in interpreter internals Numba previously relied on.
+``NUMBA_ENABLE_SYS_MONITORING`` again takes effect on those versions and
+the associated ``UserWarning`` is no longer emitted. The Python 3.12 code
+path is unchanged.

--- a/numba/_dispatcher.cpp
+++ b/numba/_dispatcher.cpp
@@ -812,43 +812,6 @@ static inline int msb(uint8_t bits) {
     return MOST_SIG_BIT[bits];
 }
 
-/*
- * On Python 3.14.4+, skip JIT sys.monitoring (#10538).
- * https://github.com/numba/numba/issues/10538
- */
-static int
-jit_sysmon_supported(void)
-{
-    // support_flag states: -1 unknown, 0 unsupported (warn once), 1 supported
-    static int support_flag = -1;
-    unsigned long v;
-    int major, minor, micro;
-
-    if (support_flag != -1) {
-        return support_flag;
-    }
-
-    v = Py_Version;
-    major = (int)((v >> 24) & 0xFF);
-    minor = (int)((v >> 16) & 0xFF);
-    micro = (int)((v >> 8) & 0xFF);
-
-    // Exclude anything beyond 3.14.3.
-    support_flag = !(major == 3 && (minor > 14 || (minor == 14 && micro > 3)));
-
-    if (!support_flag) {
-        PyErr_WarnEx(PyExc_UserWarning,
-            "Numba: JIT sys.monitoring integration is disabled on "
-            "Python 3.14.4+ (https://github.com/numba/numba/"
-            "issues/10538). "
-            "Unset NUMBA_ENABLE_SYS_MONITORING to suppress this warning.",
-            1
-        );
-    }
-
-    return support_flag;
-}
-
 
 static int invoke_monitoring(PyThreadState * tstate, int event, Dispatcher *self, PyObject* retval)
 {
@@ -939,10 +902,6 @@ static int invoke_monitoring(PyThreadState * tstate, int event, Dispatcher *self
     // https://github.com/python/cpython/blob/0ab2384c5f56625e99bb35417cadddfe24d347e1/Python/instrumentation.c#L945-L1008
     // https://github.com/python/cpython/blob/0ab2384c5f56625e99bb35417cadddfe24d347e1/Python/instrumentation.c#L1010-L1026
     // https://github.com/python/cpython/blob/0ab2384c5f56625e99bb35417cadddfe24d347e1/Python/instrumentation.c#L839-L861
-
-    if (!jit_sysmon_supported()) {
-        return 0;
-    }
 
     // TODO: check this, call_instrumentation_vector has this at the top.
     if (tstate->tracing){

--- a/numba/_dispatcher.cpp
+++ b/numba/_dispatcher.cpp
@@ -50,7 +50,6 @@
 #endif
 #include "internal/pycore_interp.h"
 #include "internal/pycore_pyerrors.h"
-#include "internal/pycore_instruments.h"
 #include "internal/pycore_call.h"
 #include "cpython/code.h"
 
@@ -791,10 +790,13 @@ call_cfunc(Dispatcher *self, PyObject *cfunc, PyObject *args, PyObject *kws, PyO
     }
 }
 
-#elif (PY_MAJOR_VERSION >= 3) && ((PY_MINOR_VERSION == 12) || (PY_MINOR_VERSION == 13) || (PY_MINOR_VERSION == 14))
+#elif (PY_MAJOR_VERSION >= 3) && (PY_MINOR_VERSION == 12)
+// Python 3.12 only: use invoke_monitoring() that reads
+// CPython internal struct fields directly.
+// NOTE: Do NOT extend this block to 3.13+. Use the public
+// PyMonitoring_Fire*Event API below instead.
 
-// Python 3.12 has a completely new approach to tracing and profiling due to
-// the new `sys.monitoring` system.
+#include "internal/pycore_instruments.h"
 
 // From: https://github.com/python/cpython/blob/0ab2384c5f56625e99bb35417cadddfe24d347e1/Python/instrumentation.c#L863-L868
 
@@ -1122,6 +1124,107 @@ call_cfunc(Dispatcher *self, PyObject *cfunc, PyObject *args, PyObject *kws, PyO
     if(enabled_sysmon && invoke_monitoring_PY_RETURN(tstate, self, pyresult) != 0){
         return NULL;
     }
+    return pyresult;
+}
+
+#elif (PY_MAJOR_VERSION >= 3) && (PY_MINOR_VERSION >= 13)
+
+// Monitoring event indices into local mon_states[].
+enum {
+    NUMBA_MON_PY_START   = 0,
+    NUMBA_MON_PY_RETURN  = 1,
+    NUMBA_MON_RAISE      = 2,
+    NUMBA_MON_PY_UNWIND  = 3,
+    NUMBA_MON_COUNT      = 4,
+};
+
+// The event types we care about, in the same order as the enum above.
+static const uint8_t numba_mon_event_types[NUMBA_MON_COUNT] = {
+    PY_MONITORING_EVENT_PY_START,
+    PY_MONITORING_EVENT_PY_RETURN,
+    PY_MONITORING_EVENT_RAISE,
+    PY_MONITORING_EVENT_PY_UNWIND,
+};
+
+// Refresh monitoring state via the public API. This reads the interpreter's
+// monitoring configuration through libpython at runtime.
+static int refresh_monitoring_scope(PyMonitoringState mon_states[],
+                                    uint64_t *mon_version) {
+    return PyMonitoring_EnterScope(
+        mon_states,
+        mon_version,
+        numba_mon_event_types,
+        NUMBA_MON_COUNT);
+}
+
+/* forward declaration */
+static bool is_sysmon_enabled(Dispatcher *self);
+
+static PyObject *
+call_cfunc(Dispatcher *self, PyObject *cfunc, PyObject *args, PyObject *kws, PyObject *locals)
+{
+    PyCFunctionWithKeywords fn = NULL;
+    PyObject *pyresult = NULL;
+    PyObject *codelike = NULL;
+    const bool enabled_sysmon = is_sysmon_enabled(self);
+    int in_scope = 0;
+    PyMonitoringState mon_states[NUMBA_MON_COUNT];
+    uint64_t mon_version = 0;
+
+    assert(PyCFunction_Check(cfunc));
+    assert(PyCFunction_GET_FLAGS(cfunc) == (METH_VARARGS | METH_KEYWORDS));
+    fn = (PyCFunctionWithKeywords) PyCFunction_GET_FUNCTION(cfunc);
+
+    if (enabled_sysmon) {
+        if (refresh_monitoring_scope(mon_states, &mon_version) < 0)
+            return NULL;
+        in_scope = 1;
+
+        codelike = PyObject_GetAttrString((PyObject*)self, "__code__");
+        if (!codelike)
+            goto exit_scope;
+
+        if (PyMonitoring_FirePyStartEvent(
+                &mon_states[NUMBA_MON_PY_START], codelike, 0) < 0)
+            goto exit_scope;
+    }
+
+    pyresult = fn(PyCFunction_GET_SELF(cfunc), args, kws);
+
+    if (enabled_sysmon && pyresult == NULL) {
+        // Exception path. Refresh scope — events may have been toggled
+        // during objmode. Leave the exception on the error indicator;
+        // Fire*Event reads it from tstate->current_exception internally.
+        if (refresh_monitoring_scope(mon_states, &mon_version) < 0)
+            goto exit_scope;
+        if (PyErr_Occurred()) {
+            if (PyMonitoring_FireRaiseEvent(
+                    &mon_states[NUMBA_MON_RAISE], codelike, 0) < 0)
+                goto exit_scope;
+            if (PyMonitoring_FirePyUnwindEvent(
+                    &mon_states[NUMBA_MON_PY_UNWIND], codelike, 0) < 0)
+                goto exit_scope;
+        }
+        goto exit_scope;
+    }
+
+    if (enabled_sysmon) {
+        // Normal return. Refresh scope — events may have been toggled
+        // during objmode.
+        if (refresh_monitoring_scope(mon_states, &mon_version) < 0)
+            goto exit_scope;
+        if (PyMonitoring_FirePyReturnEvent(
+                &mon_states[NUMBA_MON_PY_RETURN], codelike, 0,
+                pyresult) < 0) {
+            Py_CLEAR(pyresult);
+            goto exit_scope;
+        }
+    }
+
+exit_scope:
+    if (in_scope)
+        PyMonitoring_ExitScope();
+    Py_XDECREF(codelike);
     return pyresult;
 }
 #else

--- a/numba/_dispatcher.cpp
+++ b/numba/_dispatcher.cpp
@@ -1168,7 +1168,9 @@ call_cfunc(Dispatcher *self, PyObject *cfunc, PyObject *args, PyObject *kws, PyO
     PyObject *codelike = NULL;
     const bool enabled_sysmon = is_sysmon_enabled(self);
     int in_scope = 0;
-    PyMonitoringState mon_states[NUMBA_MON_COUNT];
+    // initialize mon_states as inactive; refresh_monitoring_scope skips
+    // writing them when the monitoring version is unchanged.
+    PyMonitoringState mon_states[NUMBA_MON_COUNT] = {};
     uint64_t mon_version = 0;
 
     assert(PyCFunction_Check(cfunc));

--- a/numba/_dispatcher.cpp
+++ b/numba/_dispatcher.cpp
@@ -1178,18 +1178,18 @@ call_cfunc(Dispatcher *self, PyObject *cfunc, PyObject *args, PyObject *kws, PyO
     fn = (PyCFunctionWithKeywords) PyCFunction_GET_FUNCTION(cfunc);
 
     if (enabled_sysmon) {
-        if (refresh_monitoring_scope(mon_states, &mon_version) < 0){
+        if (refresh_monitoring_scope(mon_states, &mon_version) < 0) {
             return NULL;
         }
         in_scope = 1;
 
         codelike = PyObject_GetAttrString((PyObject*)self, "__code__");
-        if (!codelike){
+        if (!codelike) {
             goto exit_scope;
         }
 
         if (PyMonitoring_FirePyStartEvent(
-                &mon_states[NUMBA_MON_PY_START], codelike, 0) < 0){
+                &mon_states[NUMBA_MON_PY_START], codelike, 0) < 0) {
             goto exit_scope;
         }
     }
@@ -1200,16 +1200,16 @@ call_cfunc(Dispatcher *self, PyObject *cfunc, PyObject *args, PyObject *kws, PyO
         // Exception path. Refresh scope — events may have been toggled
         // during objmode. Leave the exception on the error indicator;
         // Fire*Event reads it from tstate->current_exception internally.
-        if (refresh_monitoring_scope(mon_states, &mon_version) < 0){
+        if (refresh_monitoring_scope(mon_states, &mon_version) < 0) {
             goto exit_scope;
         }
         if (PyErr_Occurred()) {
             if (PyMonitoring_FireRaiseEvent(
-                    &mon_states[NUMBA_MON_RAISE], codelike, 0) < 0){
+                    &mon_states[NUMBA_MON_RAISE], codelike, 0) < 0) {
                 goto exit_scope;
             }
             if (PyMonitoring_FirePyUnwindEvent(
-                    &mon_states[NUMBA_MON_PY_UNWIND], codelike, 0) < 0){
+                    &mon_states[NUMBA_MON_PY_UNWIND], codelike, 0) < 0) {
                 goto exit_scope;
             }
         }
@@ -1219,7 +1219,7 @@ call_cfunc(Dispatcher *self, PyObject *cfunc, PyObject *args, PyObject *kws, PyO
     if (enabled_sysmon) {
         // Normal return. Refresh scope — events may have been toggled
         // during objmode.
-        if (refresh_monitoring_scope(mon_states, &mon_version) < 0){
+        if (refresh_monitoring_scope(mon_states, &mon_version) < 0) {
             Py_CLEAR(pyresult);
             goto exit_scope;
         }
@@ -1232,7 +1232,7 @@ call_cfunc(Dispatcher *self, PyObject *cfunc, PyObject *args, PyObject *kws, PyO
     }
 
 exit_scope:
-    if (in_scope){
+    if (in_scope) {
         PyMonitoring_ExitScope();
     }
     Py_XDECREF(codelike);

--- a/numba/_dispatcher.cpp
+++ b/numba/_dispatcher.cpp
@@ -1178,17 +1178,20 @@ call_cfunc(Dispatcher *self, PyObject *cfunc, PyObject *args, PyObject *kws, PyO
     fn = (PyCFunctionWithKeywords) PyCFunction_GET_FUNCTION(cfunc);
 
     if (enabled_sysmon) {
-        if (refresh_monitoring_scope(mon_states, &mon_version) < 0)
+        if (refresh_monitoring_scope(mon_states, &mon_version) < 0){
             return NULL;
+        }
         in_scope = 1;
 
         codelike = PyObject_GetAttrString((PyObject*)self, "__code__");
-        if (!codelike)
+        if (!codelike){
             goto exit_scope;
+        }
 
         if (PyMonitoring_FirePyStartEvent(
-                &mon_states[NUMBA_MON_PY_START], codelike, 0) < 0)
+                &mon_states[NUMBA_MON_PY_START], codelike, 0) < 0){
             goto exit_scope;
+        }
     }
 
     pyresult = fn(PyCFunction_GET_SELF(cfunc), args, kws);
@@ -1197,15 +1200,18 @@ call_cfunc(Dispatcher *self, PyObject *cfunc, PyObject *args, PyObject *kws, PyO
         // Exception path. Refresh scope — events may have been toggled
         // during objmode. Leave the exception on the error indicator;
         // Fire*Event reads it from tstate->current_exception internally.
-        if (refresh_monitoring_scope(mon_states, &mon_version) < 0)
+        if (refresh_monitoring_scope(mon_states, &mon_version) < 0){
             goto exit_scope;
+        }
         if (PyErr_Occurred()) {
             if (PyMonitoring_FireRaiseEvent(
-                    &mon_states[NUMBA_MON_RAISE], codelike, 0) < 0)
+                    &mon_states[NUMBA_MON_RAISE], codelike, 0) < 0){
                 goto exit_scope;
+            }
             if (PyMonitoring_FirePyUnwindEvent(
-                    &mon_states[NUMBA_MON_PY_UNWIND], codelike, 0) < 0)
+                    &mon_states[NUMBA_MON_PY_UNWIND], codelike, 0) < 0){
                 goto exit_scope;
+            }
         }
         goto exit_scope;
     }
@@ -1213,8 +1219,9 @@ call_cfunc(Dispatcher *self, PyObject *cfunc, PyObject *args, PyObject *kws, PyO
     if (enabled_sysmon) {
         // Normal return. Refresh scope — events may have been toggled
         // during objmode.
-        if (refresh_monitoring_scope(mon_states, &mon_version) < 0)
+        if (refresh_monitoring_scope(mon_states, &mon_version) < 0){
             goto exit_scope;
+        }
         if (PyMonitoring_FirePyReturnEvent(
                 &mon_states[NUMBA_MON_PY_RETURN], codelike, 0,
                 pyresult) < 0) {
@@ -1224,8 +1231,9 @@ call_cfunc(Dispatcher *self, PyObject *cfunc, PyObject *args, PyObject *kws, PyO
     }
 
 exit_scope:
-    if (in_scope)
+    if (in_scope){
         PyMonitoring_ExitScope();
+    }
     Py_XDECREF(codelike);
     return pyresult;
 }

--- a/numba/_dispatcher.cpp
+++ b/numba/_dispatcher.cpp
@@ -1220,6 +1220,7 @@ call_cfunc(Dispatcher *self, PyObject *cfunc, PyObject *args, PyObject *kws, PyO
         // Normal return. Refresh scope — events may have been toggled
         // during objmode.
         if (refresh_monitoring_scope(mon_states, &mon_version) < 0){
+            Py_CLEAR(pyresult);
             goto exit_scope;
         }
         if (PyMonitoring_FirePyReturnEvent(

--- a/numba/_dispatcher.cpp
+++ b/numba/_dispatcher.cpp
@@ -1181,7 +1181,7 @@ call_cfunc(Dispatcher *self, PyObject *cfunc, PyObject *args, PyObject *kws, PyO
         return fn(PyCFunction_GET_SELF(cfunc), args, kws);
     }
 
-    if (refresh_monitoring_scope(mon_states, &mon_version) < 0) {
+    if (refresh_monitoring_scope(mon_states, &mon_version) != 0) {
         return NULL;
     }
     in_scope = 1;
@@ -1192,7 +1192,7 @@ call_cfunc(Dispatcher *self, PyObject *cfunc, PyObject *args, PyObject *kws, PyO
     }
 
     if (PyMonitoring_FirePyStartEvent(
-                &mon_states[NUMBA_MON_PY_START], codelike, 0) < 0) {
+                &mon_states[NUMBA_MON_PY_START], codelike, 0) != 0) {
         goto exit_scope;
     }
 
@@ -1202,16 +1202,16 @@ call_cfunc(Dispatcher *self, PyObject *cfunc, PyObject *args, PyObject *kws, PyO
         // Exception path. Refresh scope — events may have been toggled
         // during objmode. Leave the exception on the error indicator;
         // Fire*Event reads it from tstate->current_exception internally.
-        if (refresh_monitoring_scope(mon_states, &mon_version) < 0) {
+        if (refresh_monitoring_scope(mon_states, &mon_version) != 0) {
             goto exit_scope;
         }
         if (PyErr_Occurred()) {
             if (PyMonitoring_FireRaiseEvent(
-                    &mon_states[NUMBA_MON_RAISE], codelike, 0) < 0) {
+                    &mon_states[NUMBA_MON_RAISE], codelike, 0) != 0) {
                 goto exit_scope;
             }
             if (PyMonitoring_FirePyUnwindEvent(
-                    &mon_states[NUMBA_MON_PY_UNWIND], codelike, 0) < 0) {
+                    &mon_states[NUMBA_MON_PY_UNWIND], codelike, 0) != 0) {
                 goto exit_scope;
             }
         }
@@ -1220,13 +1220,13 @@ call_cfunc(Dispatcher *self, PyObject *cfunc, PyObject *args, PyObject *kws, PyO
 
     // Normal return. Refresh scope — events may have been toggled
     // during objmode.
-    if (refresh_monitoring_scope(mon_states, &mon_version) < 0) {
+    if (refresh_monitoring_scope(mon_states, &mon_version) != 0) {
         Py_CLEAR(pyresult);
         goto exit_scope;
     }
     if (PyMonitoring_FirePyReturnEvent(
             &mon_states[NUMBA_MON_PY_RETURN], codelike, 0,
-            pyresult) < 0) {
+            pyresult) != 0) {
         Py_CLEAR(pyresult);
         goto exit_scope;
     }

--- a/numba/_dispatcher.cpp
+++ b/numba/_dispatcher.cpp
@@ -1177,26 +1177,28 @@ call_cfunc(Dispatcher *self, PyObject *cfunc, PyObject *args, PyObject *kws, PyO
     assert(PyCFunction_GET_FLAGS(cfunc) == (METH_VARARGS | METH_KEYWORDS));
     fn = (PyCFunctionWithKeywords) PyCFunction_GET_FUNCTION(cfunc);
 
-    if (enabled_sysmon) {
-        if (refresh_monitoring_scope(mon_states, &mon_version) < 0) {
-            return NULL;
-        }
-        in_scope = 1;
+    if (!enabled_sysmon) {
+        return fn(PyCFunction_GET_SELF(cfunc), args, kws);
+    }
 
-        codelike = PyObject_GetAttrString((PyObject*)self, "__code__");
-        if (!codelike) {
-            goto exit_scope;
-        }
+    if (refresh_monitoring_scope(mon_states, &mon_version) < 0) {
+        return NULL;
+    }
+    in_scope = 1;
 
-        if (PyMonitoring_FirePyStartEvent(
+    codelike = PyObject_GetAttrString((PyObject*)self, "__code__");
+    if (codelike == NULL) {
+        goto exit_scope;
+    }
+
+    if (PyMonitoring_FirePyStartEvent(
                 &mon_states[NUMBA_MON_PY_START], codelike, 0) < 0) {
-            goto exit_scope;
-        }
+        goto exit_scope;
     }
 
     pyresult = fn(PyCFunction_GET_SELF(cfunc), args, kws);
 
-    if (enabled_sysmon && pyresult == NULL) {
+    if (pyresult == NULL) {
         // Exception path. Refresh scope — events may have been toggled
         // during objmode. Leave the exception on the error indicator;
         // Fire*Event reads it from tstate->current_exception internally.
@@ -1216,19 +1218,17 @@ call_cfunc(Dispatcher *self, PyObject *cfunc, PyObject *args, PyObject *kws, PyO
         goto exit_scope;
     }
 
-    if (enabled_sysmon) {
-        // Normal return. Refresh scope — events may have been toggled
-        // during objmode.
-        if (refresh_monitoring_scope(mon_states, &mon_version) < 0) {
-            Py_CLEAR(pyresult);
-            goto exit_scope;
-        }
-        if (PyMonitoring_FirePyReturnEvent(
-                &mon_states[NUMBA_MON_PY_RETURN], codelike, 0,
-                pyresult) < 0) {
-            Py_CLEAR(pyresult);
-            goto exit_scope;
-        }
+    // Normal return. Refresh scope — events may have been toggled
+    // during objmode.
+    if (refresh_monitoring_scope(mon_states, &mon_version) < 0) {
+        Py_CLEAR(pyresult);
+        goto exit_scope;
+    }
+    if (PyMonitoring_FirePyReturnEvent(
+            &mon_states[NUMBA_MON_PY_RETURN], codelike, 0,
+            pyresult) < 0) {
+        Py_CLEAR(pyresult);
+        goto exit_scope;
     }
 
 exit_scope:

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -143,11 +143,6 @@ skip_if_freethreading = unittest.skipIf(_free_threading,
                                          "free-threading is enabled."))
 
 
-skip_if_sysmon_unsupported = unittest.skipIf(
-    sys.version_info[:3] >= (3, 14, 4),
-    "JIT sys.monitoring is not supported on Python 3.14.4+")
-
-
 def expected_failure_py311(fn):
     if utils.PYVERSION == (3, 11):
         return unittest.expectedFailure(fn)

--- a/numba/tests/test_profiler.py
+++ b/numba/tests/test_profiler.py
@@ -7,7 +7,7 @@ import sys
 import numpy as np
 
 from numba import jit, types
-from numba.tests.support import needs_blas, skip_if_sysmon_unsupported
+from numba.tests.support import needs_blas
 import unittest
 
 
@@ -86,12 +86,10 @@ class TestProfiler(unittest.TestCase):
         if caller is not cfunc:
             check_stats_for_key(stats, caller.__code__, n_calls)
 
-    @skip_if_sysmon_unsupported
     def test_profiler(self):
         dot, _ = generate_standard_dot_case()
         self.check_profiler_dot(dot, dot)
 
-    @skip_if_sysmon_unsupported
     def test_profiler_for_raising_function(self):
         raising_dot, call_raising_dot = generate_raising_dot_case()
         self.check_profiler_dot(call_raising_dot, raising_dot)

--- a/numba/tests/test_sys_monitoring.py
+++ b/numba/tests/test_sys_monitoring.py
@@ -4,10 +4,9 @@ import sys
 import threading
 import traceback
 import unittest
-import warnings
 from collections import Counter
 from unittest.mock import Mock, call
-from numba.tests.support import TestCase, skip_if_sysmon_unsupported
+from numba.tests.support import TestCase
 from numba import jit, objmode
 from numba.core.utils import PYVERSION
 from numba.core.serialize import _numba_unpickle
@@ -179,7 +178,6 @@ class TestMonitoring(TestCase):
             sys.monitoring.free_tool_id(_tool_id)
         return callbacks
 
-    @skip_if_sysmon_unsupported
     def test_start_event(self):
         # test event PY_START
         cb = self.run_with_events(self.call_foo, (self.arg,), (PY_START,))
@@ -187,7 +185,6 @@ class TestMonitoring(TestCase):
         self.assertEqual(len(cb), 1)
         self.check_py_start_calls(cb)
 
-    @skip_if_sysmon_unsupported
     def test_return_event(self):
         # test event PY_RETURN
         cb = self.run_with_events(self.call_foo, (self.arg,), (PY_RETURN,))
@@ -195,7 +192,6 @@ class TestMonitoring(TestCase):
         self.assertEqual(len(cb), 1)
         self.check_py_return_calls(cb)
 
-    @skip_if_sysmon_unsupported
     def test_call_event_chain(self):
         # test event PY_START and PY_RETURN monitored at the same time
         cb = self.run_with_events(self.call_foo, (self.arg,),
@@ -317,7 +313,6 @@ class TestMonitoring(TestCase):
             sys.monitoring.set_events(tool_id, NO_EVENTS)
             sys.monitoring.free_tool_id(tool_id)
 
-    @skip_if_sysmon_unsupported
     def test_disable_from_callback(self):
         # Event callbacks can disable a _local_ event at a specific location to
         # prevent it triggering in the future by returning
@@ -354,7 +349,6 @@ class TestMonitoring(TestCase):
             sys.monitoring.set_events(tool_id, NO_EVENTS)
             sys.monitoring.free_tool_id(tool_id)
 
-    @skip_if_sysmon_unsupported
     def test_mutation_from_objmode(self):
         try:
             # Check that it's possible to enable an event (mutate the event
@@ -397,7 +391,6 @@ class TestMonitoring(TestCase):
             sys.monitoring.register_callback(tool_id, event, None)
             sys.monitoring.free_tool_id(tool_id)
 
-    @skip_if_sysmon_unsupported
     def test_multiple_tool_id(self):
         # Check that multiple tools will work across different combinations of
         # events that Numba dispatcher supports, namely:
@@ -463,7 +456,6 @@ class TestMonitoring(TestCase):
         self.check_py_start_calls(opt_tool)
         self.check_py_return_calls(opt_tool)
 
-    @skip_if_sysmon_unsupported
     def test_raising_under_monitoring(self):
         # Check that Numba can raise an exception whilst monitoring is running
         # and that 1. `RAISE` is issued 2. `PY_UNWIND` is issued, 3. that
@@ -531,7 +523,6 @@ class TestMonitoring(TestCase):
 
         self.assertIn(msg, str(store_raised))
 
-    @skip_if_sysmon_unsupported
     def test_stop_iteration_under_monitoring(self):
         # Check that Numba can raise an StopIteration exception whilst
         # monitoring is running and that:
@@ -614,7 +605,6 @@ class TestMonitoring(TestCase):
 
         self.assertIn(msg, str(store_raised))
 
-    @skip_if_sysmon_unsupported
     def test_raising_callback_unwinds_from_jit_on_success_path(self):
         # An event callback can legitimately raise an exception, this test
         # makes sure Numba's dispatcher handles it ok on the "successful path",
@@ -642,7 +632,6 @@ class TestMonitoring(TestCase):
         callback.assert_called_once()
         self.assertIn(msg, str(store_raised))
 
-    @skip_if_sysmon_unsupported
     def test_raising_callback_unwinds_from_jit_on_raising_path(self):
         # An event callback can legitimately raise an exception, this test
         # makes sure Numba's dispatcher handles it ok on the
@@ -702,7 +691,6 @@ class TestMonitoring(TestCase):
         # check the stored exception is the expected exception
         self.assertIs(store_raised, callback.side_effect)
 
-    @skip_if_sysmon_unsupported
     def test_raising_callback_unwinds_from_jit_on_unwind_path(self):
         # An event callback can legitimately raise an exception, this test
         # makes sure Numba's dispatcher handles it ok on the
@@ -751,7 +739,6 @@ class TestMonitoring(TestCase):
         # check the stored_raise
         self.assertIs(store_raised, callback.side_effect)
 
-    @skip_if_sysmon_unsupported
     def test_monitoring_multiple_threads(self):
         # Two threads, different tools and events registered on each thread.
         # Each test creates a global event capturing. The threads use barriers
@@ -853,31 +840,6 @@ class TestMonitoringEnvVarControl(TestCase):
             return x + 1
 
         self.assertTrue(foo._enable_sysmon)
-
-    @unittest.skipUnless(
-        sys.version_info[:3] >= (3, 14, 4),
-        "needs Python 3.14.4+",
-    )
-    @TestCase.run_test_in_subprocess(
-        envvars={"NUMBA_ENABLE_SYS_MONITORING": '1'})
-    def test_userwarning_when_jit_sysmon_unavailable(self):
-        # C dispatcher warns once when hooks are off on 3.14.4+ (#10538).
-        from numba import jit
-
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always", UserWarning)
-
-            @jit(nopython=True)
-            def foo(x):
-                return x + 1
-
-            self.assertTrue(foo._enable_sysmon)
-            self.assertEqual(foo(1), 2)
-            self.assertEqual(foo(2), 3)
-
-        self.assertEqual(len(w), 1)
-        msg = str(w[0].message)
-        self.assertIn("sys.monitoring", msg)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes: https://github.com/numba/numba/issues/10538

This PR reverts previous patch that disabled sys monitoring for py3.14.4+ and proposes to fix problem using public C API than relying on internal monitoring state sensitive to internal struct changes. The public API was introduced 3.13 onwards and hence public API path will be used for Python 3.13+, the older Python versions will still use existing path.

Co-authored by: Claude Opus 4.6