### PR TITLE
Fix and complete the type stubs for `core.extending`

### DIFF
--- a/maint/stubtest/allowlist.txt
+++ b/maint/stubtest/allowlist.txt
@@ -1,7 +1,6 @@
 numba\.__main__
 numba\._helperlib\..*
 numba\.cloudpickle\..*
-numba\.core\.extending\..*
 numba\.core\.boxing\..*
 numba\.core\.bytecode\..*
 numba\.core\.byteflow\..*

--- a/maint/stubtest/allowlist.txt
+++ b/maint/stubtest/allowlist.txt
@@ -28,6 +28,7 @@ numba\.misc\..*
 numba\.mviewbuf
 numba\.np\.(arraymath|arrayobj|linalg|npyimpl|random|types|ufunc_db|unsafe)\..*
 numba\.np\.extensions
+numba\.np\.polynomial\.polynomial_core\.type_polynomial
 numba\.np\.ufunc\.parallel\..*
 numba\.np\.ufunc\.(omppool|tbbpool|workqueue)
 numba\.parfors\..*

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,7 +4,7 @@
 warn_unused_configs = True
 follow_imports = silent
 show_error_context = True
-files = **/numba/core/types/*.py, **/numba/core/extending.py, **/numba/core/datamodel/*.py, **/numba/core/rewrites/*.py, **/numba/core/unsafe/*.py, **/numba/np/ufunc/*.pyi
+files = **/numba/core/types/*.py, **/numba/core/extending.pyi, **/numba/core/datamodel/*.py, **/numba/core/rewrites/*.py, **/numba/core/unsafe/*.py, **/numba/np/ufunc/*.pyi
 
 # Per-module options:
 # To classify a given module as Level 0, 1, 2 or 3 it must be added both in files (variable above) and in the lists below.

--- a/numba/core/extending.pyi
+++ b/numba/core/extending.pyi
@@ -48,6 +48,7 @@ register_model = register_default
 ###
 # stubs-only helpers
 
+_T = TypeVar("_T")
 _Pss = ParamSpec("_Pss")
 _ContextT = TypeVar("_ContextT", bound=BaseContext)
 _CallableT = TypeVar("_CallableT", bound=Callable[..., object])
@@ -205,5 +206,6 @@ class BoundLiteralArgs(NamedTuple):
 
     def bind(self, *args: object, **kwargs: object) -> None: ...
 
-# TODO: use generic typevar once https://github.com/numba/numba/pull/10551 is merged
-def is_jitted(function: object) -> TypeIs[Dispatcher]: ...
+def is_jitted(
+    function: Callable[_Pss, _T],
+) -> TypeIs[Dispatcher[Callable[_Pss, _T]]]: ...

--- a/numba/core/extending.pyi
+++ b/numba/core/extending.pyi
@@ -1,128 +1,209 @@
 import collections
-import sys
+import inspect
+import typing
 import weakref
+from collections.abc import Iterable, Mapping, Sequence
+from typing import (
+    Callable,
+    ClassVar,
+    Final,
+    Generic,
+    Literal,
+    ParamSpec,
+    Protocol,
+    TypeAlias,
+    final,
+    type_check_only,
+)
 
-from numba.core.serialize import ReduceMixin
+from _typeshed import Unused
+from typing_extensions import NamedTuple, Never, Self, TypeIs, TypeVar, override
 
+from numba._helperlib import _import_cython_function as _import_cython_function
 
-def type_callable(func):
-    ...
+from .datamodel import models as models
+from .datamodel import register_default
+from .decorators import _FnInline, _JITOptions
+from .dispatcher import Dispatcher
+from .imputils import lower_builtin as lower_builtin
+from .imputils import lower_cast as lower_cast
+from .imputils import lower_getattr as lower_getattr
+from .imputils import lower_getattr_generic as lower_getattr_generic
+from .imputils import lower_setattr as lower_setattr
+from .imputils import lower_setattr_generic as lower_setattr_generic
+from .pythonapi import NativeValue as NativeValue
+from .pythonapi import box as box
+from .pythonapi import reflect as reflect
+from .pythonapi import unbox as unbox
+from .serialize import ReduceMixin as ReduceMixin
+from .types import Type
+from .typing.asnumbatype import as_numba_type as as_numba_type
+from .typing.context import BaseContext
+from .typing.templates import infer as infer
+from .typing.templates import infer_getattr as infer_getattr
+from .typing.typeof import typeof_impl as typeof_impl
 
+register_model = register_default
 
-def overload(func, jit_options={}, strict=True, inline='never',
-             prefer_literal=False, **kwargs):
-    ...
+###
+# stubs-only helpers
 
+_Pss = ParamSpec("_Pss")
+_ContextT = TypeVar("_ContextT", bound=BaseContext)
+_CallableT = TypeVar("_CallableT", bound=Callable[..., object])
+_CallableT_co = TypeVar(
+    "_CallableT_co",
+    bound=Callable[..., object],
+    default=Callable[..., typing.Any],
+    covariant=True,
+)
 
-def register_jitable(*args, **kwargs):
-    ...
+_Target: TypeAlias = Literal["generic", "cpu", "cuda", "npyufunc"] | str
+_Inline: TypeAlias = Literal["never", "always"] | _FnInline
 
+@type_check_only
+class _TypeCallableDecorater(Protocol):
+    def __call__(
+        self,
+        /,
+        # We can't use a single typevar for the entire typing_func callable because
+        # the `BaseContext` input type is in a contravariant position.
+        typing_func: Callable[[_ContextT], _CallableT],
+    ) -> Callable[[_ContextT], _CallableT]: ...
 
-def overload_attribute(typ, attr, **kwargs):
-    ...
+@type_check_only
+class _OverloadDecorater(Protocol):
+    def __call__(self, /, overload_func: _CallableT) -> _CallableT: ...
 
+@type_check_only
+class _RegisterJitableDecorater(Protocol):
+    def __call__(self, /, fn: _CallableT) -> _CallableT: ...
 
-def _overload_method_common(typ, attr, **kwargs):
-    ...
+@type_check_only
+class _IntrinsicDecorator(Protocol):
+    def __call__(self, /, func: _CallableT) -> _Intrinsic[_CallableT]: ...
 
+###
+# stubs
 
-def overload_method(typ, attr, **kwargs):
-    ...
+def type_callable(func: Callable[..., object] | str) -> _TypeCallableDecorater: ...
+def overload(
+    func: Callable[..., object],
+    jit_options: _JITOptions = ...,
+    strict: bool = True,
+    inline: _Inline = "never",
+    prefer_literal: bool = False,
+    *,
+    target: _Target = ...,
+) -> _OverloadDecorater: ...
 
+#
+@typing.overload
+def register_jitable(fn: _CallableT, /) -> _CallableT: ...
+@typing.overload
+# we can't use `**kwargs: Unpack[_JitOptions]` because mypy doesn't support PEP 728 yet
+def register_jitable(**kwargs: object) -> _RegisterJitableDecorater: ...
 
-def overload_classmethod(typ, attr, **kwargs):
-    ...
+#
+def overload_attribute(
+    typ: Type | type[Type],
+    attr: str,
+    *,
+    inline: _Inline = "never",
+    prefer_literal: bool = False,
+    base: type = ...,
+    target: _Target = ...,
+) -> _OverloadDecorater: ...
+def overload_method(
+    typ: Type | type[Type],
+    attr: str,
+    *,
+    inline: _Inline = "never",
+    prefer_literal: bool = False,
+    target: _Target = ...,
+) -> _OverloadDecorater: ...
+def overload_classmethod(
+    typ: Type | type[Type],
+    attr: str,
+    *,
+    inline: _Inline = "never",
+    prefer_literal: bool = False,
+    target: _Target = ...,
+) -> _OverloadDecorater: ...
+def make_attribute_wrapper(
+    typeclass: type[Type], struct_attr: str, python_attr: str
+) -> None: ...
 
+#
+@final
+class _Intrinsic(ReduceMixin, Generic[_CallableT_co]):
+    _memo: ClassVar[weakref.WeakValueDictionary[str, _Intrinsic]] = ...
+    _recent: ClassVar[collections.deque[_Intrinsic]] = ...
 
-def make_attribute_wrapper(typeclass, struct_attr, python_attr):
-    ...
-
-
-class _Intrinsic(ReduceMixin, Generic[P, R]):
-    _memo: weakref.WeakValueDictionary
-    _recent: collections.deque
+    _name: Final[str]
+    _defn: _CallableT_co
+    _prefer_literal: Final[bool]
+    _ctor_kwargs: Final[dict[str, typing.Any]]
 
     def __init__(
         self,
-        name,
-        defn: Callable[Concatenate[object, P], R],
-        prefer_literal=False,
-        **kwargs
-    ):
-        ...
+        name: str,
+        defn: _CallableT_co,
+        prefer_literal: bool = False,
+        **kwargs: object,
+    ) -> None: ...
 
+    #
     @property
-    def _uuid(self):
-        ...
+    def _uuid(self) -> str: ...
+    def _set_uuid(self, u: str) -> None: ...
+    def _register(self) -> None: ...
 
-    def _set_uuid(self, u):
-        ...
+    # always raises `NotImplementedError` on call
+    def __call__(
+        self: _Intrinsic[Callable[_Pss, object]],
+        *args: _Pss.args,
+        **kwargs: _Pss.kwargs,
+    ) -> Never: ...
 
-    def _register(self):
-        ...
-
-    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R:
-        ...
-
-    def __repr__(self):
-        ...
-
-    def __deepcopy__(self, memo):
-        ...
-
-    def _reduce_states(self):
-        ...
-
+    #
+    def __deepcopy__(self, memo: Unused) -> Self: ...
+    def _reduce_states(self) -> dict[str, typing.Any]: ...
     @classmethod
-    def _rebuild(cls, uuid, name, defn):
-        ...
+    @override
+    def _rebuild(  # type:ignore[override]
+        cls, uuid: str, name: str, defn: _CallableT
+    ) -> _Intrinsic[_CallableT]: ...
 
+#
+@typing.overload
+def intrinsic(func: _CallableT, /) -> _Intrinsic[_CallableT]: ...
+@typing.overload
+def intrinsic(
+    *, prefer_literal: bool = False, **kwargs: object
+) -> _IntrinsicDecorator: ...
 
-if sys.version_info >= (3, 10):
-    from typing import Callable, Concatenate, Generic, ParamSpec, TypeVar
+#
+def get_cython_function_address(module_name: str, function_name: str) -> int: ...
+def include_path() -> str: ...
+def sentry_literal_args(
+    pysig: inspect.Signature,
+    literal_args: Sequence[str],
+    args: Iterable[object],
+    kwargs: Mapping[str, object],
+) -> None: ...
 
-    # Type of the parameters of the function being converted to an intrinsic,
-    # excluding the typing context parameter.
-    P = ParamSpec("P")
-    # Return type of the function being converted to an intrinsic
-    R = TypeVar("R")
+class SentryLiteralArgs(NamedTuple):
+    literal_args: Sequence[str]
 
-    def intrinsic(*args, **kwargs) -> Callable[
-        [Callable[Concatenate[object, P], R]],
-        Callable[P, R]
-    ]:
-        ...
-else:
-    def intrinsic(*args, **kwargs):
-        ...
+    def for_function(self, func: Callable[..., object]) -> BoundLiteralArgs: ...
+    def for_pysig(self, pysig: inspect.Signature) -> BoundLiteralArgs: ...
 
+class BoundLiteralArgs(NamedTuple):
+    pysig: inspect.Signature
+    literal_args: Sequence[str]
 
-def get_cython_function_address(module_name, function_name):
-    ...
+    def bind(self, *args: object, **kwargs: object) -> None: ...
 
-
-def include_path():
-    ...
-
-
-def sentry_literal_args(pysig, literal_args, args, kwargs):
-    ...
-
-
-class SentryLiteralArgs(collections.namedtuple(
-        '_SentryLiteralArgs', ['literal_args'])):
-    def for_function(self, func):
-        ...
-
-    def for_pysig(self, pysig):
-        ...
-
-
-class BoundLiteralArgs(collections.namedtuple(
-        'BoundLiteralArgs', ['pysig', 'literal_args'])):
-    def bind(self, *args, **kwargs):
-        ...
-
-
-def is_jitted(function):
-    ...
+# TODO: use generic typevar once https://github.com/numba/numba/pull/10551 is merged
+def is_jitted(function: object) -> TypeIs[Dispatcher]: ...

--- a/numba/core/extending.pyi
+++ b/numba/core/extending.pyi
@@ -73,11 +73,11 @@ class _TypeCallableDecorator(Protocol):
     ) -> Callable[[_ContextT], _CallableT]: ...
 
 @type_check_only
-class _OverloadDecorater(Protocol):
+class _OverloadDecorator(Protocol):
     def __call__(self, /, overload_func: _CallableT) -> _CallableT: ...
 
 @type_check_only
-class _RegisterJitableDecorater(Protocol):
+class _RegisterJitableDecorator(Protocol):
     def __call__(self, /, fn: _CallableT) -> _CallableT: ...
 
 @type_check_only
@@ -96,14 +96,14 @@ def overload(
     prefer_literal: bool = False,
     *,
     target: _Target = ...,
-) -> _OverloadDecorater: ...
+) -> _OverloadDecorator: ...
 
 #
 @typing.overload
 def register_jitable(fn: _CallableT, /) -> _CallableT: ...
 @typing.overload
 # we can't use `**kwargs: Unpack[_JitOptions]` because mypy doesn't support PEP 728 yet
-def register_jitable(**kwargs: object) -> _RegisterJitableDecorater: ...
+def register_jitable(**kwargs: object) -> _RegisterJitableDecorator: ...
 
 #
 def overload_attribute(
@@ -114,7 +114,7 @@ def overload_attribute(
     prefer_literal: bool = False,
     base: type = ...,
     target: _Target = ...,
-) -> _OverloadDecorater: ...
+) -> _OverloadDecorator: ...
 def overload_method(
     typ: Type | type[Type],
     attr: str,
@@ -122,7 +122,7 @@ def overload_method(
     inline: _Inline = "never",
     prefer_literal: bool = False,
     target: _Target = ...,
-) -> _OverloadDecorater: ...
+) -> _OverloadDecorator: ...
 def overload_classmethod(
     typ: Type | type[Type],
     attr: str,
@@ -130,7 +130,7 @@ def overload_classmethod(
     inline: _Inline = "never",
     prefer_literal: bool = False,
     target: _Target = ...,
-) -> _OverloadDecorater: ...
+) -> _OverloadDecorator: ...
 def make_attribute_wrapper(
     typeclass: type[Type], struct_attr: str, python_attr: str
 ) -> None: ...

--- a/numba/core/extending.pyi
+++ b/numba/core/extending.pyi
@@ -63,7 +63,7 @@ _Target: TypeAlias = Literal["generic", "cpu", "cuda", "npyufunc"] | str
 _Inline: TypeAlias = Literal["never", "always"] | _FnInline
 
 @type_check_only
-class _TypeCallableDecorater(Protocol):
+class _TypeCallableDecorator(Protocol):
     def __call__(
         self,
         /,
@@ -87,7 +87,7 @@ class _IntrinsicDecorator(Protocol):
 ###
 # stubs
 
-def type_callable(func: Callable[..., object] | str) -> _TypeCallableDecorater: ...
+def type_callable(func: Callable[..., object] | str) -> _TypeCallableDecorator: ...
 def overload(
     func: Callable[..., object],
     jit_options: _JITOptions = ...,


### PR DESCRIPTION
In #10576 I noticed that the type stubs for `numba.core.extending` were almost fully incomplete and contained several typing errors. This fills in all missing annotations and fixes the typing issues. I verified that this is now indeed correct using stubtest and Claude Opus 4.7.