### PR TITLE
Fix stubtest error on Python 3.12+

### DIFF
--- a/numba/core/pythonapi.py
+++ b/numba/core/pythonapi.py
@@ -12,12 +12,11 @@ from numba import _helperlib
 from numba.core import (
     types, utils, config, lowering, cgutils, imputils, serialize,
 )
-from numba.core.utils import PYVERSION
 
 PY_UNICODE_1BYTE_KIND = _helperlib.py_unicode_1byte_kind
 PY_UNICODE_2BYTE_KIND = _helperlib.py_unicode_2byte_kind
 PY_UNICODE_4BYTE_KIND = _helperlib.py_unicode_4byte_kind
-if PYVERSION in ((3, 10), (3, 11)):
+if sys.version_info < (3, 12):
     PY_UNICODE_WCHAR_KIND = _helperlib.py_unicode_wchar_kind
 
 


### PR DESCRIPTION
Mypy (and all other type-checkers for that matter) weren't able to understand the python version guard in `core.pythonapi`. They follow the Python typing spec, which only requires them to understand simple version checks: https://typing.python.org/en/latest/spec/directives.html#version-and-platform-checking

Because of this, stubtest was reporting a false positive on Python 3.12+:

```
error: numba.core.pythonapi.PY_UNICODE_WCHAR_KIND is not present at runtime
Stub: in file /home/joren/Workspace/numba/numba/core/pythonapi.py:21
Any
Runtime:
MISSING

Found 1 error (checked 748 modules)
```

This wasn't caught in CI because it runs stubtest with Python 3.10 (or 3.11 after #10575).

Anyway, this small and equivalent change ensures that stubtest will also pass on Python 3.12+.