### PR TITLE
Global ``py.typed`` (PEP 561)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -411,13 +411,12 @@ metadata = dict(
         "numba.cuda.tests.doc_examples.ffi": ["*.cu"],
         "numba.tests": ["pycc_distutils_usecase/*.py"],
         # Some C files are needed by pycc
-        "numba": ["*.c", "*.h"],
+        "numba": ["*.c", "*.h", "py.typed"],
         "numba.pycc": ["*.c", "*.h"],
         "numba.core.runtime": ["*.cpp", "*.c", "*.h"],
         "numba.cext": ["*.c", "*.h"],
         # numba gdb hook init command language file
         "numba.misc": ["cmdlang.gdb"],
-        "numba.typed": ["py.typed"],
         "numba.cuda" : ["cpp_function_wrappers.cu", "cuda_fp16.h",
                         "cuda_fp16.hpp"]
     },


### PR DESCRIPTION
From PEP 561:

> Package maintainers who wish to support type checking of their code MUST add a marker file named `py.typed` to their package supporting typing. This marker applies recursively: if a top-level package includes it, all its sub-packages MUST support type checking as well.

https://peps.python.org/pep-0561/#packaging-type-information

I'm not sure why there was a `numba/typed/py.typed`, but now that there's a `numba/py.typed` there's no need for it anymore.