### PR TITLE
Fixed accidentally excluded dtypes in sum tests and optimized tests for better test suite runtime

### DIFF
--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -1347,58 +1347,56 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
 
         check_err(np.array([1, 2]))
         check_err(np.array([]))
+    
+    def gen_sum_array_cases(self, signed_dtypes, unsigned_dtypes):
+        for arr_dtype in signed_dtypes + unsigned_dtypes:
+            yield np.ones((5, 4, 3), arr_dtype)
+            yield np.ones(1, arr_dtype)
+
+        for arr_dtype in signed_dtypes:
+            yield np.ones((5, 4, 3), arr_dtype) * -5
 
     def test_sum(self):
         """ test sum over a whole range of dtypes, no axis or dtype parameter
         """
         pyfunc = array_sum
         cfunc = jit(nopython=True)(pyfunc)
-        all_dtypes = [np.float64, np.float32, np.int64, np.int32,
-                      np.complex64, np.complex128, np.timedelta64]
-        all_test_arrays = [
-            [np.ones((7, 6, 5, 4, 3), arr_dtype),
-             np.ones(1, arr_dtype),
-             np.ones((7, 3), arr_dtype) * -5]
-            for arr_dtype in all_dtypes]
+        signed_dtypes = [
+            np.float64, np.float32, np.int64, np.int32,
+            np.complex64, np.complex128,
+            #   TODO: Once hashing of timedelta64 is implemented,
+            #   we can add it to the list of tested dtypes in this test.
+            #   np.timedelta64
+        ]
 
         unsigned_dtypes = [np.uint32, np.uint64, np.bool_]
-        all_test_arrays = [
-            [np.ones((7, 6, 5, 4, 3), arr_dtype),
-             np.ones(1, arr_dtype)]
-            for arr_dtype in unsigned_dtypes]
 
-        for arr_list in all_test_arrays:
-            for arr in arr_list:
-                with self.subTest("Test np.sum with {} input ".format(arr.dtype)):
-                    self.assertPreciseEqual(pyfunc(arr), cfunc(arr))
+        for arr in self.gen_sum_array_cases(signed_dtypes, unsigned_dtypes):
+            with self.subTest("Test np.sum with {} input ".format(arr.dtype)):
+                self.assertPreciseEqual(pyfunc(arr), cfunc(arr))
 
     def test_sum_axis_kws1(self):
         """ test sum with axis parameter over a whole range of dtypes  """
         pyfunc = array_sum_axis_kws
         cfunc = jit(nopython=True)(pyfunc)
-        all_dtypes = [np.float64, np.float32, np.int64, np.complex64,
-                      np.complex128, TIMEDELTA_M]
-        all_test_arrays = [
-            [np.ones((7, 6, 5, 4, 3), arr_dtype),
-             np.ones(1, arr_dtype),
-             np.ones((7, 3), arr_dtype) * -5]
-            for arr_dtype in all_dtypes]
+        signed_dtypes_no_int32 = [
+            np.float64, np.float32, np.int64, np.complex64,
+            np.complex128,
+            #   TODO: Once hashing of timedelta64 is implemented,
+            #   we can add it to the list of tested dtypes in this test.
+            #   TIMEDELTA_M
+        ]
 
-        unsigned_dtypes = [np.uint64, np.bool_]
-        all_test_arrays += [
-            [np.ones((7, 6, 5, 4, 3), arr_dtype),
-             np.ones(1, arr_dtype)]
-            for arr_dtype in unsigned_dtypes]
+        unsigned_dtypes_no_uint32 = [np.uint64, np.bool_]
 
-        for arr_list in all_test_arrays:
-            for arr in arr_list:
-                for axis in (0, 1, 2):
-                    if axis > len(arr.shape)-1:
-                        continue
-                    with self.subTest("Testing np.sum(axis) with {} "
-                                      "input ".format(arr.dtype)):
-                        self.assertPreciseEqual(pyfunc(arr, axis=axis),
-                                                cfunc(arr, axis=axis))
+        for arr in self.gen_sum_array_cases(signed_dtypes_no_int32, unsigned_dtypes_no_uint32):
+            for axis in (0, 1, 2):
+                if axis > len(arr.shape)-1:
+                    continue
+                with self.subTest("Testing np.sum(axis) with {} "
+                                    "input ".format(arr.dtype)):
+                    self.assertPreciseEqual(pyfunc(arr, axis=axis),
+                                            cfunc(arr, axis=axis))
 
     def test_sum_axis_kws2(self):
         """  testing uint32 and int32 separately
@@ -1411,57 +1409,38 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         """
         pyfunc = array_sum_axis_kws
         cfunc = jit(nopython=True)(pyfunc)
-        all_dtypes = [np.int32]
+        signed_dtypes_only_int32 = [np.int32]
         # expected return dtypes in Numba
         out_dtypes = {np.dtype('int32'): np.int64, np.dtype('uint32'): np.uint64,
                       np.dtype('int64'): np.int64,
                       np.dtype(TIMEDELTA_M): np.dtype(TIMEDELTA_M)}
-        all_test_arrays = [
-            [np.ones((7, 6, 5, 4, 3), arr_dtype),
-             np.ones(1, arr_dtype),
-             np.ones((7, 3), arr_dtype) * -5]
-            for arr_dtype in all_dtypes]
 
-        unsigned_dtypes = [np.uint32]
-        all_test_arrays += [
-            [np.ones((7, 6, 5, 4, 3), arr_dtype),
-             np.ones(1, arr_dtype)]
-            for arr_dtype in unsigned_dtypes]
+        unsigned_dtypes_only_uint32 = [np.uint32]
 
-        for arr_list in all_test_arrays:
-            for arr in arr_list:
-                for axis in (0, 1, 2):
-                    if axis > len(arr.shape)-1:
-                        continue
-                    with self.subTest("Testing np.sum(axis) with {} "
-                                      "input ".format(arr.dtype)):
-                        npy_res = pyfunc(arr, axis=axis)
-                        numba_res = cfunc(arr, axis=axis)
-                        if isinstance(numba_res, np.ndarray):
-                            self.assertPreciseEqual(
-                                npy_res.astype(out_dtypes[arr.dtype]),
-                                numba_res.astype(out_dtypes[arr.dtype]))
-                        else:
-                            # the results are scalars
-                            self.assertEqual(npy_res, numba_res)
+        for arr in self.gen_sum_array_cases(signed_dtypes_only_int32, unsigned_dtypes_only_uint32):
+            for axis in (0, 1, 2):
+                if axis > len(arr.shape)-1:
+                    continue
+                with self.subTest("Testing np.sum(axis) with {} "
+                                    "input ".format(arr.dtype)):
+                    npy_res = pyfunc(arr, axis=axis)
+                    numba_res = cfunc(arr, axis=axis)
+                    if isinstance(numba_res, np.ndarray):
+                        self.assertPreciseEqual(
+                            npy_res.astype(out_dtypes[arr.dtype]),
+                            numba_res.astype(out_dtypes[arr.dtype]))
+                    else:
+                        # the results are scalars
+                        self.assertEqual(npy_res, numba_res)
 
     def test_sum_dtype_kws(self):
         """ test sum with dtype parameter over a whole range of dtypes """
         pyfunc = array_sum_dtype_kws
         cfunc = jit(nopython=True)(pyfunc)
-        all_dtypes = [np.float64, np.float32, np.int64, np.int32,
+        signed_dtypes = [np.float64, np.float32, np.int64, np.int32,
                       np.complex64, np.complex128]
-        all_test_arrays = [
-            [np.ones((7, 6, 5, 4, 3), arr_dtype),
-             np.ones(1, arr_dtype),
-             np.ones((7, 3), arr_dtype) * -5]
-            for arr_dtype in all_dtypes]
 
         unsigned_dtypes = [np.uint32, np.uint64, np.bool_]
-        all_test_arrays = [
-            [np.ones((7, 6, 5, 4, 3), arr_dtype),
-             np.ones(1, arr_dtype)]
-            for arr_dtype in unsigned_dtypes]
 
         out_dtypes = {np.dtype('float64'): [np.float64],
                       np.dtype('float32'): [np.float64, np.float32],
@@ -1473,32 +1452,22 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
                       np.dtype('complex64'): [np.complex64, np.complex128],
                       np.dtype('complex128'): [np.complex128]}
 
-        for arr_list in all_test_arrays:
-            for arr in arr_list:
-                for out_dtype in out_dtypes[arr.dtype]:
-                    subtest_str = ("Testing np.sum with {} input and {} output"
-                                   .format(arr.dtype, out_dtype))
-                    with self.subTest(subtest_str):
-                            self.assertPreciseEqual(pyfunc(arr, dtype=out_dtype),
-                                                    cfunc(arr, dtype=out_dtype))
+        for arr in self.gen_sum_array_cases(signed_dtypes, unsigned_dtypes):
+            for out_dtype in out_dtypes[arr.dtype]:
+                subtest_str = ("Testing np.sum with {} input and {} output"
+                                .format(arr.dtype, out_dtype))
+                with self.subTest(subtest_str):
+                        self.assertPreciseEqual(pyfunc(arr, dtype=out_dtype),
+                                                cfunc(arr, dtype=out_dtype))
 
     def test_sum_axis_dtype_kws(self):
         """ test sum with axis and dtype parameters over a whole range of dtypes """
         pyfunc = array_sum_axis_dtype_kws
         cfunc = jit(nopython=True)(pyfunc)
-        all_dtypes = [np.float64, np.float32, np.int64, np.int32,
+        signed_dtypes = [np.float64, np.float32, np.int64, np.int32,
                       np.complex64, np.complex128]
-        all_test_arrays = [
-            [np.ones((7, 6, 5, 4, 3), arr_dtype),
-             np.ones(1, arr_dtype),
-             np.ones((7, 3), arr_dtype) * -5]
-            for arr_dtype in all_dtypes]
 
         unsigned_dtypes = [np.uint32, np.uint64, np.bool_]
-        all_test_arrays = [
-            [np.ones((7, 6, 5, 4, 3), arr_dtype),
-             np.ones(1, arr_dtype)]
-            for arr_dtype in unsigned_dtypes]
 
         out_dtypes = {np.dtype('float64'): [np.float64],
                       np.dtype('float32'): [np.float64, np.float32],
@@ -1510,18 +1479,17 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
                       np.dtype('complex64'): [np.complex64, np.complex128],
                       np.dtype('complex128'): [np.complex128]}
 
-        for arr_list in all_test_arrays:
-            for arr in arr_list:
-                for out_dtype in out_dtypes[arr.dtype]:
-                    for axis in (0, 1, 2):
-                        if axis > len(arr.shape) - 1:
-                            continue
-                        subtest_str = ("Testing np.sum with {} input and {} output "
-                                       .format(arr.dtype, out_dtype))
-                        with self.subTest(subtest_str):
-                            py_res = pyfunc(arr, axis=axis, dtype=out_dtype)
-                            nb_res = cfunc(arr, axis=axis, dtype=out_dtype)
-                            self.assertPreciseEqual(py_res, nb_res)
+        for arr in self.gen_sum_array_cases(signed_dtypes, unsigned_dtypes):
+            for out_dtype in out_dtypes[arr.dtype]:
+                for axis in (0, 1, 2):
+                    if axis > len(arr.shape) - 1:
+                        continue
+                    subtest_str = ("Testing np.sum with {} input and {} output "
+                                    .format(arr.dtype, out_dtype))
+                    with self.subTest(subtest_str):
+                        py_res = pyfunc(arr, axis=axis, dtype=out_dtype)
+                        nb_res = cfunc(arr, axis=axis, dtype=out_dtype)
+                        self.assertPreciseEqual(py_res, nb_res)
 
     def test_sum_axis_dtype_pos_arg(self):
         """ testing that axis and dtype inputs work when passed as positional """
@@ -1529,7 +1497,7 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         cfunc = jit(nopython=True)(pyfunc)
         dtype = np.float64
         # OK
-        a = np.ones((7, 6, 5, 4, 3))
+        a = np.ones((2, 3, 4))
         self.assertPreciseEqual(pyfunc(a, 1, dtype),
                                 cfunc(a,  1, dtype))
 
@@ -1563,7 +1531,7 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         pyfunc = array_sum
         cfunc = jit(nopython=True)(pyfunc)
 
-        a = np.ones((7, 6, 5, 4, 3))
+        a = np.ones((2, 3, 4, 5))
         b = np.ones((4, 3))
         # BAD: axis > dimensions
         with self.assertRaises(ValueError):


### PR DESCRIPTION
This PR fixes the tests for `sum` function (which were previously our slowest tests) as follows: 

- Fixes accidentally excluded signed datatypes testing.
- Improves test runtime by nearly ~10-15 mins in total Azure runtime. 