### PR TITLE
Fix incorrect docstring for TypeRefAttribute (fixes #8023)

### DIFF
--- a/numba/core/typing/builtins.py
+++ b/numba/core/typing/builtins.py
@@ -845,7 +845,7 @@ class TypeRefAttribute(AttributeTemplate):
 
     def resolve___call__(self, classty):
         """
-        Resolve a core number's constructor (e.g. calling int(...))
+        Resolve a Numba type reference's constructor (e.g. calling DictType(...))
 
         Note:
 
@@ -876,7 +876,6 @@ class TypeRefAttribute(AttributeTemplate):
 
             return types.Function(make_callable_template(key=ty,
                                                          typer=Redirect(self.context)))
-
 
 #------------------------------------------------------------------------------
 


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

This PR fixes an incorrect docstring for `TypeRefAttribute` as reported in #8023. 

The docstring previously described a core number's constructor, but it has been updated to accurately reflect that it resolves a Numba type reference's constructor (e.g., `DictType(...)`).

Fixes #8023

*(Note: No new unit tests were added as this is strictly a documentation/docstring fix).*

