### PR TITLE
Fix np.clip type promotion to match NumPy behavior (Fixes #10000)

### DIFF
--- a/docs/upcoming_changes/10594.bug_fix.rst
+++ b/docs/upcoming_changes/10594.bug_fix.rst
@@ -1,0 +1,9 @@
+Fix ``np.clip`` type promotion to match NumPy behavior
+------------------------------------------------------
+
+Fixed ``np.clip`` to follow NumPy's type promotion rules when ``a_min`` or
+``a_max`` are of a different type than the input array ``a``. Previously,
+the output was always allocated using the dtype of ``a`` via
+``np.empty_like(a)``, which could silently produce incorrect results.
+The output dtype is now determined by promoting all operand types together,
+matching NumPy's behavior.

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -2655,6 +2655,21 @@ def np_clip(a, a_min, a_max, out=None):
     a_min_is_none = a_min is None or isinstance(a_min, types.NoneType)
     a_max_is_none = a_max is None or isinstance(a_max, types.NoneType)
 
+    def _get_dtype(t):
+        if isinstance(t, types.Array):
+            return as_dtype(t.dtype)
+        elif isinstance(t, types.Number):
+            return as_dtype(t)
+        return None
+
+    dt_a = _get_dtype(a)
+    dt_min = _get_dtype(a_min) if not a_min_is_none else None
+    dt_max = _get_dtype(a_max) if not a_max_is_none else None
+
+    dts = [dt for dt in (dt_a, dt_min, dt_max) if dt is not None]
+    promoted_dt = np.result_type(*dts)
+    nb_promoted_dt = from_dtype(promoted_dt)
+
     if a_min_is_none and a_max_is_none:
         # Raises value error when both a_min and a_max are None
         def np_clip_nn(a, a_min, a_max, out=None):
@@ -2670,7 +2685,7 @@ def np_clip(a, a_min, a_max, out=None):
             # a_min and a_max are scalars
             # since their shape will be empty
             # so broadcasting is not needed at all
-            ret = np.empty_like(a) if out is None else out
+            ret = np.empty(a.shape, dtype=nb_promoted_dt) if out is None else out
             for index in np.ndindex(a.shape):
                 val_a = a[index]
                 ret[index] = min(max(val_a, a_min), a_max)
@@ -2684,7 +2699,7 @@ def np_clip(a, a_min, a_max, out=None):
                 # a_min is a scalar
                 # since its shape will be empty
                 # so broadcasting is not needed at all
-                ret = np.empty_like(a) if out is None else out
+                ret = np.empty(a.shape, dtype=nb_promoted_dt) if out is None else out
                 for index in np.ndindex(a.shape):
                     val_a = a[index]
                     ret[index] = max(val_a, a_min)
@@ -2699,7 +2714,8 @@ def np_clip(a, a_min, a_max, out=None):
                 # broadcast it to shape of a
                 # by using np.full_like
                 a_min_full = np.full_like(a, a_min)
-                return _np_clip_impl(a, a_min_full, a_max, out)
+                ret = np.empty(a.shape, dtype=nb_promoted_dt) if out is None else out
+                return _np_clip_impl(a, a_min_full, a_max, ret)
 
             return np_clip_sa
     elif not a_min_is_scalar and a_max_is_scalar:
@@ -2708,7 +2724,7 @@ def np_clip(a, a_min, a_max, out=None):
                 # a_max is a scalar
                 # since its shape will be empty
                 # so broadcasting is not needed at all
-                ret = np.empty_like(a) if out is None else out
+                ret = np.empty(a.shape, dtype=nb_promoted_dt) if out is None else out
                 for index in np.ndindex(a.shape):
                     val_a = a[index]
                     ret[index] = min(val_a, a_max)
@@ -2723,7 +2739,8 @@ def np_clip(a, a_min, a_max, out=None):
                 # broadcast it to shape of a
                 # by using np.full_like
                 a_max_full = np.full_like(a, a_max)
-                return _np_clip_impl(a, a_min, a_max_full, out)
+                ret = np.empty(a.shape, dtype=nb_promoted_dt) if out is None else out
+                return _np_clip_impl(a, a_min, a_max_full, ret)
 
             return np_clip_as
     else:
@@ -2731,7 +2748,7 @@ def np_clip(a, a_min, a_max, out=None):
         if a_min_is_none:
             def np_clip_na(a, a_min, a_max, out=None):
                 # a_max is a numpy array but a_min is None
-                ret = np.empty_like(a) if out is None else out
+                ret = np.empty(a.shape, dtype=nb_promoted_dt) if out is None else out
                 a_b, a_max_b = np.broadcast_arrays(a, a_max)
                 return _np_clip_impl_none(a_b, a_max_b, True, ret)
 
@@ -2739,7 +2756,7 @@ def np_clip(a, a_min, a_max, out=None):
         elif a_max_is_none:
             def np_clip_an(a, a_min, a_max, out=None):
                 # a_min is a numpy array but a_max is None
-                ret = np.empty_like(a) if out is None else out
+                ret = np.empty(a.shape, dtype=nb_promoted_dt) if out is None else out
                 a_b, a_min_b = np.broadcast_arrays(a, a_min)
                 return _np_clip_impl_none(a_b, a_min_b, False, ret)
 
@@ -2749,7 +2766,8 @@ def np_clip(a, a_min, a_max, out=None):
                 # Both a_min and a_max are clearly arrays
                 # because none of the above branches
                 # returned
-                return _np_clip_impl(a, a_min, a_max, out)
+                ret = np.empty(a.shape, dtype=nb_promoted_dt) if out is None else out
+                return _np_clip_impl(a, a_min, a_max, ret)
 
             return np_clip_aa
 

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -2683,7 +2683,8 @@ def np_clip(a, a_min, a_max, out=None):
             # a_min and a_max are scalars
             # since their shape will be empty
             # so broadcasting is not needed at all
-            ret = np.empty(a.shape, dtype=nb_promoted_dt) if out is None else out
+            ret = np.empty(a.shape, dtype=nb_promoted_dt) \
+                if out is None else out
             for index in np.ndindex(a.shape):
                 val_a = a[index]
                 ret[index] = min(max(val_a, a_min), a_max)
@@ -2697,7 +2698,9 @@ def np_clip(a, a_min, a_max, out=None):
                 # a_min is a scalar
                 # since its shape will be empty
                 # so broadcasting is not needed at all
-                ret = np.empty(a.shape, dtype=nb_promoted_dt) if out is None else out
+                ret = np.empty(
+                    a.shape, dtype=nb_promoted_dt
+                ) if out is None else out
                 for index in np.ndindex(a.shape):
                     val_a = a[index]
                     ret[index] = max(val_a, a_min)
@@ -2712,7 +2715,9 @@ def np_clip(a, a_min, a_max, out=None):
                 # broadcast it to shape of a
                 # by using np.full_like
                 a_min_full = np.full_like(a, a_min)
-                ret = np.empty(a.shape, dtype=nb_promoted_dt) if out is None else out
+                ret = np.empty(
+                    a.shape, dtype=nb_promoted_dt
+                ) if out is None else out
                 return _np_clip_impl(a, a_min_full, a_max, ret)
 
             return np_clip_sa
@@ -2722,7 +2727,9 @@ def np_clip(a, a_min, a_max, out=None):
                 # a_max is a scalar
                 # since its shape will be empty
                 # so broadcasting is not needed at all
-                ret = np.empty(a.shape, dtype=nb_promoted_dt) if out is None else out
+                ret = np.empty(
+                    a.shape, dtype=nb_promoted_dt
+                ) if out is None else out
                 for index in np.ndindex(a.shape):
                     val_a = a[index]
                     ret[index] = min(val_a, a_max)
@@ -2737,7 +2744,9 @@ def np_clip(a, a_min, a_max, out=None):
                 # broadcast it to shape of a
                 # by using np.full_like
                 a_max_full = np.full_like(a, a_max)
-                ret = np.empty(a.shape, dtype=nb_promoted_dt) if out is None else out
+                ret = np.empty(
+                    a.shape, dtype=nb_promoted_dt
+                ) if out is None else out
                 return _np_clip_impl(a, a_min, a_max_full, ret)
 
             return np_clip_as
@@ -2746,7 +2755,9 @@ def np_clip(a, a_min, a_max, out=None):
         if a_min_is_none:
             def np_clip_na(a, a_min, a_max, out=None):
                 # a_max is a numpy array but a_min is None
-                ret = np.empty(a.shape, dtype=nb_promoted_dt) if out is None else out
+                ret = np.empty(
+                    a.shape, dtype=nb_promoted_dt
+                ) if out is None else out
                 a_b, a_max_b = np.broadcast_arrays(a, a_max)
                 return _np_clip_impl_none(a_b, a_max_b, True, ret)
 
@@ -2754,7 +2765,9 @@ def np_clip(a, a_min, a_max, out=None):
         elif a_max_is_none:
             def np_clip_an(a, a_min, a_max, out=None):
                 # a_min is a numpy array but a_max is None
-                ret = np.empty(a.shape, dtype=nb_promoted_dt) if out is None else out
+                ret = np.empty(
+                    a.shape, dtype=nb_promoted_dt
+                ) if out is None else out
                 a_b, a_min_b = np.broadcast_arrays(a, a_min)
                 return _np_clip_impl_none(a_b, a_min_b, False, ret)
 
@@ -2764,7 +2777,9 @@ def np_clip(a, a_min, a_max, out=None):
                 # Both a_min and a_max are clearly arrays
                 # because none of the above branches
                 # returned
-                ret = np.empty(a.shape, dtype=nb_promoted_dt) if out is None else out
+                ret = np.empty(
+                    a.shape, dtype=nb_promoted_dt
+                ) if out is None else out
                 return _np_clip_impl(a, a_min, a_max, ret)
 
             return np_clip_aa

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -2656,11 +2656,9 @@ def np_clip(a, a_min, a_max, out=None):
     a_max_is_none = a_max is None or isinstance(a_max, types.NoneType)
 
     def _get_dtype(t):
-        if isinstance(t, types.Array):
+        if hasattr(t, 'dtype'):
             return as_dtype(t.dtype)
-        elif isinstance(t, types.Number):
-            return as_dtype(t)
-        return None
+        return as_dtype(t)
 
     dt_a = _get_dtype(a)
     dt_min = _get_dtype(a_min) if not a_min_is_none else None
@@ -2677,8 +2675,8 @@ def np_clip(a, a_min, a_max, out=None):
 
         return np_clip_nn
 
-    a_min_is_scalar = isinstance(a_min, types.Number)
-    a_max_is_scalar = isinstance(a_max, types.Number)
+    a_min_is_scalar = isinstance(a_min, (types.Number, types.Boolean))
+    a_max_is_scalar = isinstance(a_max, (types.Number, types.Boolean))
 
     if a_min_is_scalar and a_max_is_scalar:
         def np_clip_ss(a, a_min, a_max, out=None):

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -1752,6 +1752,21 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
 
                 self._lower_clip_result_test_util(cfunc, a, -5, 5)
 
+    def test_clip_type_promotion(self):
+        # tests fix for issue #10000
+        has_out = (np_clip, np_clip_kwargs, array_clip, array_clip_kwargs)
+        has_no_out = (np_clip_no_out, array_clip_no_out)
+        
+        a = np.array([1, 2], dtype=np.int64)
+        for pyfunc in has_out + has_no_out:
+            cfunc = jit(nopython=True)(pyfunc)
+            
+            expected = pyfunc(a, np.inf, np.inf)
+            got = cfunc(a, np.inf, np.inf)
+            
+            np.testing.assert_equal(expected, got)
+            self.assertEqual(expected.dtype, got.dtype)
+
     def test_clip_errors(self):
         # Disable leak check since we expect an error to be raised
         self.disable_leak_check()


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

**0. Description of changes:**
Currently, Numba allocates the output array for `np.clip` strictly using the type of the input array `a` via `np.empty_like(a)`. This breaks NumPy compatibility when clipping an integer array against float limits (like `np.inf`), resulting in silent integer overflow instead of correctly promoting the return type to float.
This PR updates `numba/np/arrayobj.py` to correctly calculate the promoted return `dtype` using `np.result_type` based on the arguments `a`, `a_min`, and `a_max`. The result is then allocated via `np.empty(..., dtype=nb_promoted_dt)`. 
**1. Unit tests:**
Yes, a unit test has been added: `test_clip_type_promotion` in `numba/tests/test_array_methods.py`.
**2. Closing an issue:**
Fixes #10000