### PR TITLE
Remove gitter

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,9 +3,6 @@ contact_links:
   - name: General Question
     url: https://numba.discourse.group/c/numba/community-support/
     about: "If you have a general question (not a bug report or feature request) then please ask on Numba's discourse instance."
-  - name: Quick Question/Just want to say Hi!
-    url: https://gitter.im/numba/numba
-    about: "If you have a quick question or want chat to users/developers in real time then please use gitter.im/numba/numba"
   - name: Discuss an involved feature
     url: https://numba.discourse.group/c/numba/development/
     about: "If you would like to suggest a more involved feature like *Can a new compiler pass be added to do X* then please start a discussion on Numba's discourse instance."

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,8 +3,7 @@
 Thanks for wanting to contribute to Numba :)
 
 First, if you need some help or want to chat to the core developers, please
-visit https://gitter.im/numba/numba for real time chat or post to the Numba
-forum https://numba.discourse.group/.
+post to the Numba forum https://numba.discourse.group/.
 
 Here's some guidelines to help the review process go smoothly.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,7 @@ Even simple documentation improvements are encouraged.
 
 # Asking questions
 
-Numba has a [discourse forum](https://numba.discourse.group/) for longer/more
-involved questions and an IRC channel on
-[gitter.im](https://gitter.im/numba/numba) for quick questions and interactive
-help.
+Numba has a [discourse forum](https://numba.discourse.group/) for questions.
 
 # Ways to help:
 
@@ -16,8 +13,7 @@ changes, see **contributing patches** below.
 
 ## Quick things:
 
-* Answer a question asked on [discourse](https://numba.discourse.group/) or
-  [gitter.im](https://gitter.im/numba/numba).
+* Answer a question asked on [discourse](https://numba.discourse.group/).
 * Review a page of documentation, check it makes sense, that it's clear and
   still relevant, that the examples are present, good and working. Fix anything
   that needs updating in a pull request.

--- a/README.rst
+++ b/README.rst
@@ -2,10 +2,6 @@
 Numba
 *****
 
-.. image:: https://badges.gitter.im/numba/numba.svg
-   :target: https://gitter.im/numba/numba?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge
-   :alt: Gitter
-
 .. image:: https://img.shields.io/badge/discuss-on%20discourse-blue
    :target: https://numba.discourse.group/
    :alt: Discourse

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -11,7 +11,7 @@ Communication
 -------------
 
 Forum
-.....
+'''''
 
 Numba uses Discourse as a forum for longer running threads such as design
 discussions and roadmap planning. There are various categories available and it

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -10,24 +10,6 @@ questions, don't hesitate to ask them (see below).
 Communication
 -------------
 
-Real-time Chat
-''''''''''''''
-
-Numba uses Gitter for public real-time chat.  To help improve the
-signal-to-noise ratio, we have two channels:
-
-* `numba/numba <https://gitter.im/numba/numba>`_: General Numba discussion,
-  questions, and debugging help.
-* `numba/numba-dev <https://gitter.im/numba/numba-dev>`_: Discussion of PRs,
-  planning, release coordination, etc.
-
-Both channels are public, but we may ask that discussions on numba-dev move to
-the numba channel.  This is simply to ensure that numba-dev is easy for core
-developers to keep up with.
-
-Note that the Github issue tracker is the best place to report bugs.  Bug
-reports in chat are difficult to track and likely to be lost.
-
 Forum
 .....
 
@@ -92,7 +74,7 @@ When working with a source checkout of Numba you will also need a development
 build of llvmlite. These are available from the ``numba/label/dev`` channel on
 `anaconda.org <https://anaconda.org/numba/llvmlite>`_.
 
-To create an environment with the required dependencies, noting the use of the 
+To create an environment with the required dependencies, noting the use of the
 double-colon syntax (``numba/label/dev::llvmlite``) to install the latest
 development version of the llvmlite library::
 
@@ -312,7 +294,7 @@ Release Notes
 '''''''''''''
 
 Pull Requests that add significant user-facing modifications may need to be mentioned in the release notes.
-To add a release note, a short ``.rst`` file needs creating containing a summary of the change and it needs to be placed in 
+To add a release note, a short ``.rst`` file needs creating containing a summary of the change and it needs to be placed in
 ``docs/upcoming_changes``. The file ``docs/upcoming_changes/README.rst`` details the format
 and file naming conventions.
 
@@ -436,8 +418,7 @@ as to free up core developer time. Examples of ways to help:
   which essentially involves debugging the reported problem. Even if you cannot
   get right to the bottom of a problem, leaving notes about what was discovered
   for someone else is also helpful.
-* Answer questions/provide help for users on `discourse <https://numba.discourse.group/>`_
-  and/or `gitter.im <https://gitter.im/numba/numba>`_.
+* Answer questions/provide help for users on `discourse <https://numba.discourse.group/>`_.
 
 The core developers thank everyone for their understanding with the above!
 

--- a/docs/upcoming_changes/10599.doc.rst
+++ b/docs/upcoming_changes/10599.doc.rst
@@ -1,0 +1,6 @@
+Remove Gitter
+-------------
+
+References to the Numba Gitter channels have been removed from the
+documentation and source code. Users seeking help should use the
+`Numba Discourse forum <https://numba.discourse.group/>`_ instead.

--- a/numba/core/errors.py
+++ b/numba/core/errors.py
@@ -407,8 +407,8 @@ feedback_details = """
 Please report the error message and traceback, along with a minimal reproducer
 at: https://github.com/numba/numba/issues/new?template=bug_report.md
 
-If more help is needed please feel free to speak to the Numba core developers
-directly at: https://gitter.im/numba/numba
+If more help is needed please feel free to ask on the Numba discourse forum:
+https://numba.discourse.group/
 
 Thanks in advance for your help in improving Numba!
 """


### PR DESCRIPTION
Removing mentioning of gitter since developers are not actively using it anymore. Direct contributors to discourse instead.

(My editor also decided to trim trailing spaces.)