### PR TITLE
Implement hash for datetime and timedelta

### DIFF
--- a/docs/upcoming_changes/10603.improvement.rst
+++ b/docs/upcoming_changes/10603.improvement.rst
@@ -1,6 +1,6 @@
 Implement hash functionality for ``np.timedelta64`` and ``np.datetime64``.
 --------------------------------------------------------------------------
 
-Numba now supports hash functionality for `np.timedelta64` and `np.datetime64`
-types, (e.g. `hash(np.timedelta64(1, 'D'))`) allowing their usage in hash-based
+Numba now supports hash functionality for ``np.timedelta64`` and ``np.datetime64``
+types, (e.g. ``hash(np.timedelta64(1, 'D'))``) allowing their usage in hash-based
 collections like sets and dictionaries.

--- a/docs/upcoming_changes/10603.improvement.rst
+++ b/docs/upcoming_changes/10603.improvement.rst
@@ -1,0 +1,6 @@
+Implement hash functionality for ``np.timedelta64`` and ``np.datetime64``.
+--------------------------------------------------------------------------
+
+Numba now supports hash functionality for `np.timedelta64` and `np.datetime64`
+types, (e.g. `hash(np.timedelta64(1, 'D'))`) allowing their usage in hash-based
+collections like sets and dictionaries.

--- a/numba/np/types/datetime.py
+++ b/numba/np/types/datetime.py
@@ -21,7 +21,7 @@ from numba.core.datamodel.models import PrimitiveModel
 numpy_version = tuple(map(int, np.__version__.split('.')[:2]))
 
 
-class _NPDatetimeBase(types.Type):
+class _NPDatetimeBase(types.Hashable):
     """
     Common base class for np.datetime64 and np.timedelta64.
     """

--- a/numba/np/types/datetime_registry.py
+++ b/numba/np/types/datetime_registry.py
@@ -1,9 +1,10 @@
 from numba.core.pythonapi import box, unbox, NativeValue
-from numba.core.types import UniTuple, BaseTuple, Number, Boolean
+from numba.core.types import UniTuple, BaseTuple, Number, Boolean, int64
 from numba.np.types import NPDatetime, NPTimedelta
 from numba.core.extending import overload
 from numba.cpython.builtins import max_vararg, min_vararg, cast_int
 from numba.core import errors
+from numba.extending import overload_method, intrinsic
 
 
 @box(NPDatetime)
@@ -88,4 +89,28 @@ def ol_int(x):
     def impl(x):
         return cast_int(x)
 
+    return impl
+
+
+################################################################################
+# hash support
+
+@intrinsic
+def hash_datetime(typingctx, inst):
+    if not isinstance(inst, (NPDatetime, NPTimedelta)):
+        return
+
+    def codegen(context, builder, sig, args):
+        val = args[0]
+        return context.cast(builder, val, inst, int64)
+
+    sig = int64(inst)
+    return sig, codegen
+
+
+@overload_method(NPDatetime, '__hash__')
+@overload_method(NPTimedelta, '__hash__')
+def _hash_NPDatetime(inst):
+    def impl(inst):
+        return hash(hash_datetime(inst))
     return impl

--- a/numba/tests/test_hashing.py
+++ b/numba/tests/test_hashing.py
@@ -496,6 +496,39 @@ class TestUnicodeHashing(BaseTest):
         self.assertEqual(a, b)
 
 
+class TestDatetimeHashing(BaseTest):
+    """
+    Test hashing of np.datetime64 and np.timedelta64 types.
+    """
+
+    def test_datetime_hashing(self):
+        cases = [
+            np.datetime64('2000-01-02'),
+            np.datetime64('2000-01-02T12:34:56.789012345'),
+            np.datetime64('1970-01-01'),
+            np.datetime64('2000-01-01'),
+            np.datetime64('2000-01-03'),
+            np.datetime64('2000-01-02T00:00:00'),
+            np.datetime64('2000-01-02T12:34:56')
+        ]
+
+        self.check_hash_values(cases)
+
+
+    def test_timedelta_hashing(self):
+        cases = [
+            np.timedelta64(1, 'D'),
+            np.timedelta64(1, 'ns'),
+            np.timedelta64(-1, 'ns'),
+            np.timedelta64(123456789, 'ns'), 
+            np.timedelta64(-123456789, 'ns'),
+            np.timedelta64(0, 'D'),
+            np.timedelta64(0, 'ns'),
+        ]
+
+        self.check_hash_values(cases)
+
+
 class TestUnhashable(TestCase):
     # Tests that unhashable types behave correctly and raise a TypeError at
     # runtime.


### PR DESCRIPTION
Resolves #4552 

Unblocks #10590 

As titled,

This PR implements hash functionality for the NumPy `datetime` and `timedelta64` types and makes them inherit from the hashable types. 