### PR TITLE
Add python script to pull Azure logs for specified PR.

### DIFF
--- a/maint/azure_logs.py
+++ b/maint/azure_logs.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""
+Fetch Azure Pipelines build logs for a numba/numba pull request.
+
+Numba's CI runs on Azure Pipelines at https://dev.azure.com/numba/numba.
+When a PR is opened on GitHub, Azure builds the synthetic branch
+``refs/pull/<PR_NUMBER>/merge``. This script queries the Azure DevOps
+REST API to find those builds and download their per-job logs.
+
+The project is public, so no credentials are required. If you hit
+anonymous rate limits you can set an AZURE_DEVOPS_PAT env var with a
+Personal Access Token (Build: Read scope is sufficient).
+
+Examples:
+    # Download logs for the most recent build of PR 9876
+    python azure_logs.py 9876
+
+    # Download logs for the most recent build of PR 9876 into a custom directory
+    python azure_logs.py 9876 --out-dir my_logs/pr
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Iterator
+
+import requests
+
+ORG = "numba"
+PROJECT = "numba"
+API = f"https://dev.azure.com/{ORG}/{PROJECT}/_apis"
+API_VERSION = "7.1"
+
+# Matches numba's per-test memory profiling lines, e.g.:
+#   2026-04-22T19:31:46.7334303Z Name: numba.tests.test_x.Foo.test_y | PID: 10104
+#   | Start: 19:30:29 | Duration: 0.119s | Start RSS: 245.88 MB
+#   | End RSS: 246.93 MB | RSS delta: +1.04 MB | Avail memory: 6.39 GB
+TEST_MEM_RE = re.compile(
+    r"^(?P<timestamp>\S+)\s+"
+    r"Name:\s+(?P<name>\S+)\s+\|\s+"
+    r"PID:\s+(?P<pid>\d+)\s+\|\s+"
+    r"Start:\s+(?P<start>\d{2}:\d{2}:\d{2})\s+\|\s+"
+    r"Duration:\s+(?P<duration>[\d.]+)s\s+\|\s+"
+    r"Start RSS:\s+(?P<start_rss>[\d.]+)\s+MB\s+\|\s+"
+    r"End RSS:\s+(?P<end_rss>[\d.]+)\s+MB\s+\|\s+"
+    r"RSS delta:\s+(?P<rss_delta>[+-]?[\d.]+)\s+MB\s+\|\s+"
+    r"Avail memory:\s+(?P<avail>[\d.]+)\s+(?P<avail_unit>[KMGT]?B)\s*$"
+)
+
+# Multipliers for converting the "Avail memory" field into MB.
+_UNIT_TO_MB = {"B": 1 / (1024 * 1024), "KB": 1 / 1024, "MB": 1.0,
+               "GB": 1024.0, "TB": 1024.0 * 1024.0}
+
+
+
+def get_builds_for_pr(pr_number: int) -> list[dict]:
+    """Return all Azure builds associated with a GitHub PR, newest first."""
+    url = f"{API}/build/builds"
+    params = {
+        "branchName": f"refs/pull/{pr_number}/merge",
+        "queryOrder": "queueTimeDescending",
+        "api-version": API_VERSION,
+    }
+    r = requests.get(url, params=params, timeout=30)
+    r.raise_for_status()
+    return r.json().get("value", [])
+
+
+def get_timeline(build_id: int) -> list[dict]:
+    """Return the timeline records (jobs, phases, tasks) for a build."""
+    url = f"{API}/build/builds/{build_id}/timeline"
+    params = {"api-version": API_VERSION}
+    r = requests.get(url, params=params, timeout=30)
+    r.raise_for_status()
+    data = r.json() or {}
+    return data.get("records", [])
+
+
+def get_log_text(build_id: int, log_id: int) -> str:
+    """Return the raw text of a log stream."""
+    url = f"{API}/build/builds/{build_id}/logs/{log_id}"
+    params = {"api-version": API_VERSION}
+    r = requests.get(url, params=params, timeout=120)
+    r.raise_for_status()
+    return r.text
+
+
+def parse_test_mem_lines(text: str, OS: str, label: str) -> Iterator[dict]:
+    """Yield a typed dict for every per-test memory line in ``text``."""
+    for line in text.splitlines():
+        m = TEST_MEM_RE.match(line)
+        if not m:
+            continue
+        avail_val = float(m["avail"])
+        avail_unit = m["avail_unit"].upper()
+        test_name = m["name"].split(".")[-1]
+
+        status = "PASS"
+        reason = ""
+        if f"FAIL: {test_name}" in text:
+            status = "FAIL"
+            # Get the line number that contains FAIL: test_name
+            fail_line_number = next((i for i, l in enumerate(text.splitlines()) if f"FAIL: {test_name}" in l), -1)
+            if fail_line_number != -1:
+                # Save the lines until next FAIL: or FAILED (failures=
+                fail_lines = []
+                for l in text.splitlines()[fail_line_number + 1:]:
+                    if (f"FAIL: " in l) or ("FAILED (failures=" in l) or ("FAILED (errors=" in l) or ("ERROR: " in l):
+                        break
+                    fail_lines.append(l)
+                # Add the fail lines to the reason, if any
+                reason += "\n" + "\n".join(fail_lines)
+        
+        if f"ERROR: {test_name}" in text:
+            status = "ERROR"
+            # Get the line number that contains ERROR: test_name
+            error_line_number = next((i for i, l in enumerate(text.splitlines()) if f"ERROR: {test_name}" in l), -1)
+            if error_line_number != -1:
+                # Save the lines until next ERROR: or FAILED (errors=
+                error_lines = []
+                for l in text.splitlines()[error_line_number + 1:]:
+                    if (f"ERROR: " in l) or ("FAILED (errors=" in l) or ("FAILED (failures=" in l) or ("FAIL: " in l):
+                        break
+                    error_lines.append(l)
+                # Add the error lines to the reason, if any
+                reason += "\n" + "\n".join(error_lines)
+    
+        yield {
+            "timestamp": m["timestamp"],
+            "name": m["name"],
+            "test_name": test_name,
+            "pid": int(m["pid"]),
+            "start": m["start"],
+            "duration_s": float(m["duration"]),
+            "start_rss_mb": float(m["start_rss"]),
+            "end_rss_mb": float(m["end_rss"]),
+            "rss_delta_mb": float(m["rss_delta"]),
+            "avail_memory_mb": round(avail_val * _UNIT_TO_MB[avail_unit], 4),
+            "avail_memory_raw": f"{m['avail']} {avail_unit}",
+            "OS": OS,
+            "label": label,
+            "status": status,
+            "reason": reason.strip(),
+        }
+
+
+def summarize(entries: list[dict], top_n: int = 100) -> dict:
+    """Compute top-N rankings and totals over parsed test-mem entries."""
+    if not entries:
+        return {"count": 0}
+
+    def top(key, reverse=True):
+        ranked = sorted(entries, key=lambda e: e[key], reverse=reverse)[:top_n]
+        return [{"name": e["name"], key: e[key]} for e in ranked]
+
+    total_duration = sum(e["duration_s"] for e in entries)
+    return {
+        "count": len(entries),
+        "total_duration_s": round(total_duration, 3),
+        "mean_duration_s": round(total_duration / len(entries), 4),
+        "max_end_rss_mb": max(e["end_rss_mb"] for e in entries),
+        "slowest": top("duration_s"),
+        "largest_rss_growth": top("rss_delta_mb"),
+        "largest_rss_shrink": top("rss_delta_mb", reverse=False),
+        "highest_end_rss": top("end_rss_mb"),
+        "failed_tests": [e for e in entries if e["status"] == "FAIL" or e["status"] == "ERROR"],
+    }
+
+
+def print_summary(summary: dict, label: str = "") -> None:
+    """Print a compact human-readable summary to stdout."""
+    if summary.get("count", 0) == 0:
+        print(f"  {label}(no matching test-mem lines)" if label
+              else "  (no matching test-mem lines)")
+        return
+    header = f"Summary{f' ({label})' if label else ''}:"
+    print(header)
+    print(f"  tests recorded    : {summary['count']}")
+    print(f"  total duration    : {summary['total_duration_s']}s")
+    print(f"  mean duration     : {summary['mean_duration_s']}s")
+    print(f"  peak end RSS      : {summary['max_end_rss_mb']} MB")
+    print("  slowest tests:")
+    for e in summary["slowest"][:50]:
+        print(f"    {e['duration_s']:>8.3f}s  {e['name']}")
+    print("  largest RSS growth:")
+    for e in summary["largest_rss_growth"][:50]:
+        print(f"    {e['rss_delta_mb']:>+8.2f} MB  {e['name']}")
+    print("  failed tests:")
+    for e in summary["failed_tests"]:
+        print(f"    {e['name']}")
+    print()
+
+
+
+def sanitize(name: str) -> str:
+    """Make a string safe for use as a filename component."""
+    return "".join(c if c.isalnum() or c in "._- " else "_" for c in name).strip()
+
+
+def print_builds(pr_number: int, builds: list[dict]) -> None:
+    print(f"Builds for numba/numba PR #{pr_number}:")
+    if not builds:
+        print("  (none found — PR may predate Azure CI, may not have triggered")
+        print("   a build, or may be from a fork still awaiting CI approval.)")
+        return
+    print(f"  {'BuildID':>8}  {'Status':<12}  {'Result':<12}  "
+          f"{'Queued (UTC)':<20}  Definition")
+    print("  " + "-" * 86)
+    for b in builds:
+        print(
+            f"  {b['id']:>8}  "
+            f"{(b.get('status') or '-'):<12}  "
+            f"{(b.get('result') or '-'):<12}  "
+            f"{(b.get('queueTime') or '')[:19]:<20}  "
+            f"{b.get('definition', {}).get('name', '-')}"
+        )
+
+
+def download_logs(build: dict, out_root: Path) -> None:
+    """Download per-job logs for a build into out_root/pr-build-<id>/."""
+    build_id = build["id"]
+    out_dir = out_root / f"pr-build-{build_id}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Drop a small metadata file for context.
+    (out_dir / "build_info.txt").write_text(
+        f"Build        : {build_id}\n"
+        f"Web URL      : {build.get('_links', {}).get('web', {}).get('href', '')}\n"
+        f"Definition   : {build.get('definition', {}).get('name', '')}\n"
+        f"Source branch: {build.get('sourceBranch', '')}\n"
+        f"Source commit: {build.get('sourceVersion', '')}\n"
+        f"Status       : {build.get('status', '')}\n"
+        f"Result       : {build.get('result', '')}\n"
+        f"Queued       : {build.get('queueTime', '')}\n"
+        f"Started      : {build.get('startTime', '')}\n"
+        f"Finished     : {build.get('finishTime', '')}\n"
+    )
+
+    records = get_timeline(build_id)
+    # Job-level records carry the consolidated log most users want.
+    jobs = [r for r in records if r.get("type") == "Job"]
+    if not jobs:
+        kind = ""
+        print(f"  no {kind}jobs with logs found for build {build_id}")
+        return
+
+    print(f"  downloading {len(jobs)} job log(s) -> {out_dir}")
+    all_entries: list[dict] = []
+    for job in jobs:
+        log = job.get("log") or {}
+        log_id = log.get("id")
+        if log_id is None:
+            continue
+        job_name = sanitize(job.get("name") or f"job-{job.get('id', '')}")
+        result = job.get("result") or "unknown"
+        out_path = out_dir / f"{job_name}__{result}.log"
+        try:
+            text = get_log_text(build_id, log_id)
+        except requests.HTTPError as e:
+            print(f"    ! {job_name}: {e}")
+            continue
+        out_path.write_text(text, encoding="utf-8", errors="replace")
+        entries = list(parse_test_mem_lines(text, job_name.split(" ")[0], job_name.split(" ")[1]))
+
+        all_entries.extend(entries)
+        print(f"    - {out_path.name} ({len(text):,} bytes, "
+              f"{len(entries)} test-mem line(s))")
+    
+    # Save all parsed entries across all jobs as JSON for further analysis.
+    (out_dir / "test_logs.json").write_text(
+        json.dumps(all_entries, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    # Build-level roll-up across every job in this build.
+    summary = summarize(all_entries)
+    (out_dir / "summary.json").write_text(
+        json.dumps(summary, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    print_summary(summary, label=f"build {build_id}")
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Fetch Azure Pipelines build logs for a numba/numba PR.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("pr_number", type=int, nargs="?",
+                   help="numba/numba PR number (omit when using --parse).")
+    p.add_argument("--out-dir", default="numba_pr_logs",
+                   help="Output directory (default: numba_pr_logs).")
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    if args.pr_number is None:
+        print("error: pr_number is required unless --parse is used.",
+              file=sys.stderr)
+        return 2
+
+    try:
+        builds = get_builds_for_pr(args.pr_number)
+    except requests.HTTPError as e:
+        print(f"Failed to query builds: {e}", file=sys.stderr)
+        return 1
+
+    if not builds:
+        print(f"No builds found for PR {args.pr_number}; nothing to download.")
+        return 0
+
+    targets = builds[:1]
+    out_root = Path(args.out_dir) / f"pr-{args.pr_number}"
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    for b in targets:
+        print(f"Build {b['id']}  result={b.get('result', 'n/a')}  "
+              f"status={b.get('status', 'n/a')}")
+        download_logs(b, out_root)
+
+    print(f"\nDone. Logs under: {out_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
As titled, 

This PR adds a python script to pull logs and log summary from Azure builds. 

Example Usage: 

```
    # Download logs for the most recent build of PR 10603
    python azure_logs.py 10603

    # Download logs for the most recent build of PR 10590 into a custom directory
    python azure_logs.py 10603 --out-dir my_logs/pr
```

Example Output

```
(numba) kc611@Kaustubhs-MacBook-Pro numba % python maint/azure_logs.py 10603
Build 21281  result=failed  status=completed
  downloading 21 job log(s) -> numba_pr_logs/pr-10603/pr-build-21281
    - Linux py310_np22__failed.log (718,747 bytes, 12 test-mem line(s))
    - Windows py314_np24__failed.log (1,383,398 bytes, 14 test-mem line(s))
    - Windows py313_np23__failed.log (1,375,419 bytes, 14 test-mem line(s))
    - Linux py311_np124_type_check__failed.log (795,782 bytes, 13 test-mem line(s))
    - Linux py310_np125_typeguard__succeeded.log (1,865,843 bytes, 209 test-mem line(s))
    - Linux py310_np123__succeeded.log (1,853,759 bytes, 206 test-mem line(s))
    - Linux py310_np126__succeeded.log (1,854,473 bytes, 158 test-mem line(s))
    - Linux py310_np124_cov_doc__succeeded.log (2,046,186 bytes, 221 test-mem line(s))
    - Windows py312_np20__succeeded.log (1,513,768 bytes, 234 test-mem line(s))
    - Linux py311_np126__succeeded.log (1,871,653 bytes, 219 test-mem line(s))
    - Linux py311_np126_2__succeeded.log (1,861,350 bytes, 199 test-mem line(s))
    - Linux py311_np125__succeeded.log (1,860,435 bytes, 221 test-mem line(s))
    - Linux py311_np125_svml__succeeded.log (1,938,434 bytes, 215 test-mem line(s))
    - Linux py312_np20__succeeded.log (1,854,263 bytes, 229 test-mem line(s))
    - Linux py312_np126__succeeded.log (1,855,424 bytes, 229 test-mem line(s))
    - Linux py312_np22__failed.log (711,933 bytes, 14 test-mem line(s))
    - Windows py310_np124__succeeded.log (1,507,483 bytes, 235 test-mem line(s))
    - Linux py313_np23__failed.log (694,963 bytes, 13 test-mem line(s))
    - Linux py311_np22__failed.log (718,794 bytes, 13 test-mem line(s))
    - Linux py311_np21__succeeded.log (1,867,843 bytes, 228 test-mem line(s))
    - Linux py314_np24__failed.log (703,548 bytes, 14 test-mem line(s))
Summary (build 21281):
  tests recorded    : 2910
  total duration    : 5211.264s
  mean duration     : 1.7908s
  peak end RSS      : 1022.1 MB
  slowest tests:
      83.939s  numba.tests.test_array_methods.TestArrayMethods.test_clip_array_min_max
      81.566s  numba.tests.test_linalg.TestBasics.test_outer
      78.661s  numba.tests.test_fancy_indexing.TestFancyIndexingMultiDim.test_setitem
      71.903s  numba.tests.test_linalg.TestBasics.test_kron
      63.361s  numba.tests.test_sort.TestTimsortArrays.test_merge_lo_hi
      54.488s  numba.tests.test_array_methods.TestArrayMethods.test_sum_exceptions
      46.440s  numba.tests.test_parfors.TestParforsRunner.test_TestPrangeBasic
      45.040s  numba.tests.test_array_methods.TestArrayMethods.test_sum_axis_dtype_pos_arg
      42.435s  numba.tests.test_np_functions.TestNPFunctions.test_interp_float_precision_handled_per_numpy
      40.646s  numba.tests.test_array_reductions.TestArrayReductions.test_nanpercentile_basic
      39.225s  numba.tests.test_np_functions.TestNPFunctions.test_argpartition_fuzz
      38.684s  numba.tests.test_fancy_indexing.TestFancyIndexing.test_setitem
      37.556s  numba.tests.test_array_reductions.TestArrayReductions.test_nanquantile_basic
      37.551s  numba.tests.test_np_functions.TestNPFunctions.test_in1d_3b
      36.352s  numba.tests.test_np_functions.TestNPFunctions.test_repeat
      34.758s  numba.tests.test_np_functions.TestNPFunctions.test_in1d_2
      31.105s  numba.tests.test_fancy_indexing.TestFancyIndexing.test_getitem
      30.797s  numba.tests.test_np_functions.TestNPFunctions.test_in1d_3a
      30.555s  numba.tests.test_array_analysis.TestArrayAnalysis.test_numpy_calls
      30.518s  numba.tests.test_np_functions.TestNPFunctions.test_setdiff1d_2
      30.033s  numba.tests.test_np_functions.TestNPFunctions.test_setdiff1d_3
      27.481s  numba.tests.test_linalg.TestLinalgNorm.test_linalg_norm
      25.605s  numba.tests.test_runtests.TestCase.test_include_exclude_tags
      25.297s  numba.tests.test_fancy_indexing.TestFancyIndexingMultiDim.test_getitem
      24.637s  numba.tests.test_linalg.TestLinalgCond.test_linalg_cond
      22.161s  numba.tests.test_np_functions.TestNPFunctions.test_interp_stress_tests
      21.799s  numba.tests.test_heapq.TestHeapqTypedList.test_nlargest_basic
      21.274s  numba.tests.test_np_functions.TestNPFunctions.test_np_trapezoid_x_dx_basic
      21.220s  numba.tests.test_np_functions.TestNPFunctions.test_cov_explicit_arguments
      21.023s  numba.tests.test_np_randomgen.TestRandomGenerators.test_permutation
      20.909s  numba.tests.test_numberctor.TestArrayNumberCtor.test_2d
      20.848s  numba.tests.test_polynomial.TestPolynomial.test_poly_polyval_basic
      20.484s  numba.tests.test_np_functions.TestNPFunctions.test_triu_basic
      20.159s  numba.tests.test_np_functions.TestNPFunctions.test_cov_basic
      19.595s  numba.tests.npyufunc.test_dufunc.TestDUFuncReduceNumPyTests.test_numpy_identityless_reduction_forder
      19.490s  numba.tests.test_typedlist.TestListSort.test_sort_all_args
      19.409s  numba.tests.npyufunc.test_dufunc.TestDUFuncAt.test_ufunc_at_negative_indexes
      19.153s  numba.tests.npyufunc.test_dufunc.TestDUFuncReduceNumPyTests.test_numpy_identityless_reduction_otherorder
      17.962s  numba.tests.npyufunc.test_dufunc.TestDUFuncReduceAt.test_reduceat_axis_kw
      17.874s  numba.tests.test_sort.TestSortSlashSortedWithKey.test_04
      17.733s  numba.tests.test_array_manipulation.TestArrayManipulation.test_array_transpose_axes
      17.611s  numba.tests.test_array_methods.TestArrayMethods.test_np_where_3
      17.441s  numba.tests.test_array_methods.TestArrayMethods.test_np_where_numpy_basic
      17.435s  numba.tests.test_pycc.TestCC.test_c_extension_usecase
      17.372s  numba.tests.test_polynomial.TestPolynomial.test_polyadd_basic
      17.238s  numba.tests.test_np_functions.TestNPFunctions.test_unwrap_basic
      17.159s  numba.tests.test_array_methods.TestArrayMethods.test_take
      16.354s  numba.tests.npyufunc.test_dufunc.TestDUFuncReduce.test_min_reduce
      16.287s  numba.tests.test_array_methods.TestArrayMethods.test_clip
      16.212s  numba.tests.npyufunc.test_dufunc.TestDUFuncReduce.test_non_associative_reduce
  largest RSS growth:
     +546.27 MB  numba.tests.test_array_methods.TestArrayMethods.test_clip_array_min_max
     +348.04 MB  numba.tests.test_linalg.TestBasics.test_outer
     +342.77 MB  numba.tests.test_fancy_indexing.TestFancyIndexingMultiDim.test_setitem
     +297.69 MB  numba.tests.test_linalg.TestBasics.test_kron
     +292.82 MB  numba.tests.test_sort.TestTimsortArrays.test_merge_lo_hi
     +257.73 MB  numba.tests.test_fancy_indexing.TestFancyIndexing.test_setitem
     +233.49 MB  numba.tests.test_builtins.TestIsinstanceBuiltin.test_combinations
     +230.82 MB  numba.tests.test_fancy_indexing.TestFancyIndexing.test_getitem
     +213.70 MB  numba.tests.test_array_reductions.TestArrayReductions.test_nanpercentile_basic
     +203.11 MB  numba.tests.test_array_reductions.TestArrayReductions.test_nanquantile_basic
     +197.75 MB  numba.tests.test_np_functions.TestNPFunctions.test_argpartition_fuzz
     +179.05 MB  numba.tests.test_np_functions.TestNPFunctions.test_in1d_3b
     +177.45 MB  numba.tests.test_numberctor.TestArrayNumberCtor.test_2d
     +175.04 MB  numba.tests.test_fancy_indexing.TestFancyIndexingMultiDim.test_getitem
     +173.11 MB  numba.tests.test_linalg.TestLinalgNorm.test_linalg_norm
     +172.49 MB  numba.tests.npyufunc.test_dufunc.TestDUFuncAt.test_ufunc_at_negative_indexes
     +168.75 MB  numba.tests.test_np_functions.TestNPFunctions.test_repeat
     +157.99 MB  numba.tests.test_np_functions.TestNPFunctions.test_setdiff1d_2
     +151.30 MB  numba.tests.test_np_functions.TestNPFunctions.test_in1d_2
     +150.12 MB  numba.tests.test_np_functions.TestNPFunctions.test_in1d_3a
     +147.31 MB  numba.tests.test_linalg.TestLinalgCond.test_linalg_cond
     +141.90 MB  numba.tests.test_np_functions.TestNPFunctions.test_setdiff1d_3
     +135.15 MB  numba.tests.test_np_functions.TestNPFunctions.test_cov_basic
     +134.31 MB  numba.tests.test_numberctor.TestArrayNumberCtor.test_1d
     +132.29 MB  numba.tests.test_array_methods.TestArrayMethods.test_np_where_numpy_basic
     +128.34 MB  numba.tests.test_array_analysis.TestArrayAnalysis.test_numpy_calls
     +127.54 MB  numba.tests.test_array_methods.TestArrayMethods.test_sum_exceptions
     +125.87 MB  numba.tests.test_array_methods.TestArrayMethods.test_np_where_3
     +125.43 MB  numba.tests.test_linalg.TestProduct.test_dot_mm
     +125.21 MB  numba.tests.test_np_functions.TestNPFunctions.test_interp_float_precision_handled_per_numpy
     +124.12 MB  numba.tests.test_typedlist.TestListSort.test_sort_all_args
     +122.94 MB  numba.tests.test_pycc.TestCC.test_compile_nrt
     +122.23 MB  numba.tests.test_array_methods.TestArrayMethods.test_sum_axis_dtype_pos_arg
     +121.00 MB  numba.tests.test_random.TestNumPyRandomAPI.test_call_by_name
     +119.14 MB  numba.tests.test_heapq.TestHeapqTypedList.test_nlargest_basic
     +115.77 MB  numba.tests.test_array_manipulation.TestArrayManipulation.test_array_transpose_axes
     +110.28 MB  numba.tests.test_overlap.TestArrayOverlap.test_overlap13
     +109.77 MB  numba.tests.test_array_methods.TestArrayMethods.test_clip
     +108.50 MB  numba.tests.test_np_functions.TestNPFunctions.test_nan_to_num
     +105.97 MB  numba.tests.npyufunc.test_dufunc.TestDUFuncReduceAt.test_reduceat_axis_kw
     +103.91 MB  numba.tests.test_np_functions.TestNPFunctions.test_cov_explicit_arguments
     +103.88 MB  numba.tests.npyufunc.test_dufunc.TestDUFuncReduce.test_non_associative_reduce
     +103.84 MB  numba.tests.test_sort.TestSortSlashSortedWithKey.test_04
     +101.71 MB  numba.tests.test_np_functions.TestNPFunctions.test_triu_basic
     +100.38 MB  numba.tests.test_linalg.TestProduct.test_dot_vm
      +99.69 MB  numba.tests.test_polynomial.TestPolynomial.test_poly_polyval_basic
      +99.21 MB  numba.tests.doc_examples.test_literal_container_usage.DocsLiteralContainerUsageTest.test_ex_initial_value_dict_compile_time_consts
      +98.94 MB  numba.tests.test_np_functions.TestNPFunctions.test_np_trapezoid_x_dx_basic
      +98.61 MB  numba.tests.test_np_functions.TestNPFunctions.test_unwrap_basic
      +98.13 MB  numba.tests.test_random.TestNumPyRandomAPI.test_call_distributions_with_empty_size
  failed tests:
    numba.tests.test_hashing.TestDatetimeHashing.test_datetime_hashing
    numba.tests.test_hashing.TestDatetimeHashing.test_timedelta_hashing
    numba.tests.test_hashing.TestDatetimeHashing.test_datetime_hashing
    numba.tests.test_hashing.TestDatetimeHashing.test_timedelta_hashing
    numba.tests.test_hashing.TestDatetimeHashing.test_datetime_hashing
    numba.tests.test_hashing.TestDatetimeHashing.test_timedelta_hashing
    numba.tests.test_hashing.TestDatetimeHashing.test_datetime_hashing
    numba.tests.test_hashing.TestDatetimeHashing.test_timedelta_hashing
    numba.tests.test_hashing.TestDatetimeHashing.test_datetime_hashing
    numba.tests.test_hashing.TestDatetimeHashing.test_timedelta_hashing
    numba.tests.test_hashing.TestDatetimeHashing.test_datetime_hashing
    numba.tests.test_hashing.TestDatetimeHashing.test_timedelta_hashing
    numba.tests.test_hashing.TestDatetimeHashing.test_datetime_hashing
    numba.tests.test_hashing.TestDatetimeHashing.test_timedelta_hashing
    numba.tests.test_hashing.TestDatetimeHashing.test_datetime_hashing
    numba.tests.test_hashing.TestDatetimeHashing.test_timedelta_hashing


Done. Logs under: numba_pr_logs/pr-10603
```

Outputs:
- Full logs as .txt files for each build
- Test platform, status, duration and resource usage in JSON format
- A summary file stating the failed tests and top 50 longest and most memory intensive tests respectively in test as well as JSON format

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
post to the Numba forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
