### PR TITLE
Adds a symbol renaming logic in CodeLibrary to ensure symbol name uni…

### DIFF
--- a/numba/core/base.py
+++ b/numba/core/base.py
@@ -409,9 +409,19 @@ class BaseContext(object):
         fnty = llvmir.FunctionType(restype, argtypes)
         return fnty
 
-    def declare_function(self, module, fndesc):
+    def declare_function(self, module, fndesc, libs=()):
+        # If the callee's library has renamed its exported symbols (to avoid
+        # EE-level UID collisions across cached and freshly-compiled code), the
+        # caller must declare the callee under the renamed name. The library
+        # owns the rename; the context just consults its symbol map.
+        name = fndesc.mangled_name
+        for lib in libs:
+            renamed = getattr(lib, '_symbol_map', {}).get(name)
+            if renamed is not None:
+                name = renamed
+                break
         fnty = self.call_conv.get_function_type(fndesc.restype, fndesc.argtypes)
-        fn = cgutils.get_or_insert_function(module, fnty, fndesc.mangled_name)
+        fn = cgutils.get_or_insert_function(module, fnty, name)
         self.apply_target_attributes(fn, fndesc.argtypes, fndesc.restype)
         self.call_conv.decorate_function(fn, fndesc.args, fndesc.argtypes, noalias=fndesc.noalias)
         if fndesc.inline:

--- a/numba/core/codegen.py
+++ b/numba/core/codegen.py
@@ -649,6 +649,7 @@ class CPUCodeLibrary(CodeLibrary):
             str(self._codegen._create_empty_module(self.name)))
         self._final_module.name = cgutils.normalize_ir_text(self.name)
         self._shared_module = None
+        self._symbol_map = {}  # original name -> renamed name in EE
 
     def _optimize_functions(self, ll_module):
         """
@@ -757,7 +758,25 @@ class CPUCodeLibrary(CodeLibrary):
             dump("FUNCTION OPTIMIZED DUMP %s" % self.name,
                  self.get_llvm_str(), 'llvm')
 
-        # Link libraries for shared code
+        # Link libraries for shared code.
+        # Pass 1: rename declarations in this module to match the already-
+        # renamed definitions that linking libraries have published to the EE.
+        # This must happen before link_in so that LLVM can unify call sites
+        # with definitions by name during the actual linking step.
+        seen = set()
+        for library in self._linking_libraries:
+            if library not in seen:
+                seen.add(library)
+                for original, renamed in library._symbol_map.items():
+                    try:
+                        f = self._final_module.get_function(original)
+                    except NameError:
+                        pass
+                    else:
+                        if f.is_declaration:
+                            f.name = renamed
+
+        # Pass 2: link in the modules now that call sites match definitions.
         seen = set()
         for library in self._linking_libraries:
             if library not in seen:
@@ -799,6 +818,8 @@ class CPUCodeLibrary(CodeLibrary):
         # Remember this on the module, for the object cache hooks
         self._final_module.__library = weakref.proxy(self)
 
+        self._pre_add_module()
+
         # It seems add_module() must be done only here and not before
         # linking in other modules, otherwise get_pointer_to_function()
         # could fail.
@@ -826,7 +847,10 @@ class CPUCodeLibrary(CodeLibrary):
                 yield fn
 
     def get_function(self, name):
-        return self._final_module.get_function(name)
+        # If the library renamed its exported symbols, callers may still ask
+        # for the original (unmangled-rename) name; resolve through the map.
+        return self._final_module.get_function(
+            self._symbol_map.get(name, name))
 
     def _sentry_cache_disable_inspection(self):
         if self._disable_inspection:
@@ -920,7 +944,8 @@ class CPUCodeLibrary(CodeLibrary):
         Serialize this library using its bitcode as the cached representation.
         """
         self._ensure_finalized()
-        return (self.name, 'bitcode', self._final_module.as_bitcode())
+        data = (self._final_module.as_bitcode(), self._symbol_map)
+        return (self.name, 'bitcode', data)
 
     def serialize_using_object_code(self):
         """
@@ -930,7 +955,8 @@ class CPUCodeLibrary(CodeLibrary):
         """
         self._ensure_finalized()
         data = (self._get_compiled_object(),
-                self._get_module_for_linking().as_bitcode())
+                self._get_module_for_linking().as_bitcode(),
+                self._symbol_map)
         return (self.name, 'object', data)
 
     @classmethod
@@ -939,18 +965,28 @@ class CPUCodeLibrary(CodeLibrary):
         self = codegen.create_library(name)
         assert isinstance(self, cls)
         if kind == 'bitcode':
-            # No need to re-run optimizations, just make the module ready
-            self._final_module = ll.parse_bitcode(data)
+            # No need to re-run optimizations, just make the module ready.
+            # Restore _symbol_map before _finalize_final_module so that
+            # _pre_add_module skips re-renaming already-renamed symbols.
+            bitcode, symbol_map = data
+            self._final_module = ll.parse_bitcode(bitcode)
+            self._symbol_map = symbol_map
             self._finalize_final_module()
             return self
         elif kind == 'object':
-            object_code, shared_bitcode = data
+            object_code, shared_bitcode, symbol_map = data
             self.enable_object_caching()
             self._set_compiled_object(object_code)
             self._shared_module = ll.parse_bitcode(shared_bitcode)
+            # Restore the symbol map so get_pointer_to_function can translate
+            # Numba-level names to the renamed names baked into the object code.
+            self._symbol_map = symbol_map
             self._finalize_final_module()
-            # Load symbols from cache
-            self._codegen._engine._load_defined_symbols(self._shared_module)
+            # Load renamed symbol names into the EE's defined-symbol set.
+            # _load_defined_symbols reads current names from the module, but
+            # _shared_module still has original names at this point, so
+            # populate directly from the restored symbol_map instead.
+            self._codegen._engine._defined_symbols.update(symbol_map.values())
             return self
         else:
             raise ValueError("unsupported serialization kind %r" % (kind,))
@@ -977,6 +1013,9 @@ class AOTCodeLibrary(CPUCodeLibrary):
         self._ensure_finalized()
         return self._final_module.as_bitcode()
 
+    def _pre_add_module(self):
+        pass
+
     def _finalize_specific(self):
         pass
 
@@ -999,13 +1038,40 @@ class JITCodeLibrary(CPUCodeLibrary):
         """
         self._ensure_finalized()
         ee = self._codegen._engine
-        if not ee.is_symbol_defined(name):
+        resolved = self._symbol_map.get(name, name)
+        if not ee.is_symbol_defined(resolved):
             return 0
         else:
-            return self._codegen._engine.get_function_address(name)
+            return self._codegen._engine.get_function_address(resolved)
+
+    def _pre_add_module(self):
+        # If _symbol_map was restored from cache the module is already renamed;
+        # skip the rename pass but still record the pre-rename bitcode so that
+        # a re-serialization produces consistent output.
+        if self._symbol_map:
+            return
+
+        # Rename all locally-defined symbols to avoid collisions with on-disk
+        # cache entries that share the same uid. Runs after linking and
+        # verification (so the module is sound) but before _add_module hands
+        # the module to the EE (so the EE interns the renamed names).
+        # NRT runtime functions ("NRT_" / "nrt_") are part of the shared
+        # stdlib and must keep their canonical names so that other modules
+        # (and debuginfo) can resolve them.
+        import hashlib
+        m = self._final_module
+        for f in m.functions:
+            if f.is_function and not f.is_declaration:
+                n = f.name
+                if n.startswith(("NRT_", "nrt_")):
+                    continue
+                hashed = hashlib.sha256(str(f).encode()).hexdigest()[:16]
+                f.name = f"{n}_{hashed}"
+                self._symbol_map[n] = f.name
 
     def _finalize_specific(self):
-        self._codegen._scan_and_fix_unresolved_refs(self._final_module)
+        self._codegen._scan_and_fix_unresolved_refs(
+            self._final_module, symbol_map=self._symbol_map)
         with self._recorded_timings.record_legacy("Finalize object"):
             self._codegen._engine.finalize_object()
 
@@ -1019,6 +1085,9 @@ class RuntimeLinker(object):
     def __init__(self):
         self._unresolved = utils.UniqueDict()
         self._defined = set()
+        # Maps an original (pre-rename) mangled name to the renamed name
+        # actually present in _defined. Populated as libraries finalize.
+        self._aliases = {}
         self._resolved = []
 
     def scan_unresolved_symbols(self, module, engine):
@@ -1040,24 +1109,38 @@ class RuntimeLinker(object):
                 engine.add_global_mapping(gv, ctypes.addressof(ptr))
                 self._unresolved[sym] = ptr
 
-    def scan_defined_symbols(self, module):
+    def scan_defined_symbols(self, module, symbol_map=None):
         """
-        Scan and track all defined symbols.
+        Scan and track all defined symbols. *symbol_map*, if given, maps
+        original (pre-rename) names to the renamed names so that unresolved
+        references using the original names can still be matched.
         """
         for fn in module.functions:
             if not fn.is_declaration:
                 self._defined.add(fn.name)
+        if symbol_map:
+            self._aliases.update(symbol_map)
 
     def resolve(self, engine):
         """
         Fix unresolved symbols if they are defined.
         """
-        # An iterator to get all unresolved but available symbols
-        pending = [name for name in self._unresolved if name in self._defined]
+        # An unresolved name resolves either directly or via the rename alias.
+        def lookup(name):
+            if name in self._defined:
+                return name
+            renamed = self._aliases.get(name)
+            if renamed is not None and renamed in self._defined:
+                return renamed
+            return None
+
+        pending = [(name, lookup(name)) for name in self._unresolved]
         # Resolve pending symbols
-        for name in pending:
-            # Get runtime address
-            fnptr = engine.get_function_address(name)
+        for name, defname in pending:
+            if defname is None:
+                continue
+            # Get runtime address (use the actual defined/renamed name)
+            fnptr = engine.get_function_address(defname)
             # Fix all usage
             ptr = self._unresolved[name]
             ptr.value = fnptr
@@ -1302,9 +1385,9 @@ class CPUCodegen(Codegen):
         return (self._llvm_module.triple, self._get_host_cpu_name(),
                 self._tm_features)
 
-    def _scan_and_fix_unresolved_refs(self, module):
+    def _scan_and_fix_unresolved_refs(self, module, symbol_map=None):
         self._rtlinker.scan_unresolved_symbols(module, self._engine)
-        self._rtlinker.scan_defined_symbols(module)
+        self._rtlinker.scan_defined_symbols(module, symbol_map=symbol_map)
         self._rtlinker.resolve(self._engine)
 
     def insert_unresolved_ref(self, builder, fnty, name):

--- a/numba/core/imputils.py
+++ b/numba/core/imputils.py
@@ -190,7 +190,7 @@ def user_function(fndesc, libs):
     """
 
     def imp(context, builder, sig, args):
-        func = context.declare_function(builder.module, fndesc)
+        func = context.declare_function(builder.module, fndesc, libs=libs)
         # env=None assumes this is a nopython function
         status, retval = context.call_conv.call_function(
             builder, func, fndesc.restype, fndesc.argtypes, args)
@@ -217,7 +217,7 @@ def user_generator(gendesc, libs):
     """
 
     def imp(context, builder, sig, args):
-        func = context.declare_function(builder.module, gendesc)
+        func = context.declare_function(builder.module, gendesc, libs=libs)
         # env=None assumes this is a nopython function
         status, retval = context.call_conv.call_function(
             builder, func, gendesc.restype, gendesc.argtypes, args)

--- a/numba/experimental/function_type.py
+++ b/numba/experimental/function_type.py
@@ -311,7 +311,8 @@ def lower_cast_dispatcher_to_function_type(context, builder, fromty, toty, val):
         # Store the cfunc
         sfunc.c_addr = addr
         # Store the jit func
-        fn = context.declare_function(builder.module, cres.fndesc)
+        fn = context.declare_function(builder.module, cres.fndesc,
+                                      libs=(cres.library,))
         sfunc.jit_addr = builder.bitcast(fn, llvoidptr)
         # Link-in the dispatcher library
         context.active_code_library.add_linking_library(cres.library)

--- a/numba/tests/test_codegen.py
+++ b/numba/tests/test_codegen.py
@@ -224,7 +224,9 @@ class TestWrappers(TestCase):
         sig = foo.signatures[0]
 
         ol = foo.overloads[sig]
-        name = ol.fndesc.mangled_name.replace("$", r"\$")
+        name = ol.fndesc.mangled_name
+        name = ol.library._symbol_map.get(name, name)
+        name = name.replace("$", r"\$")
         p1 = r".*call.*{}".format(name)
         p2 = r".*(#[0-9]+).*"
         call_site = re.compile(p1 + p2)

--- a/numba/tests/test_debuginfo.py
+++ b/numba/tests/test_debuginfo.py
@@ -91,7 +91,9 @@ class TestDebugInfo(TestCase):
         # check the LLVM IR has bar marked as 'alwaysinline' and baz as noinline
         full_ir = foo.inspect_llvm(foo.signatures[0])
         module = llvm.parse_assembly(full_ir)
-        name = foo.overloads[foo.signatures[0]].fndesc.mangled_name
+        foo_ol = foo.overloads[foo.signatures[0]]
+        name = foo_ol.fndesc.mangled_name
+        name = foo_ol.library._symbol_map.get(name, name)
         funcs = [x for x in module.functions if x.name == name]
         self.assertEqual(len(funcs), 1)
         func = funcs[0]
@@ -109,7 +111,9 @@ class TestDebugInfo(TestCase):
         # 2. a call to the baz function, this is from the noinline baz
         found_sin = False
         found_baz = False
-        baz_name = baz.overloads[baz.signatures[0]].fndesc.mangled_name
+        baz_ol = baz.overloads[baz.signatures[0]]
+        baz_name = baz_ol.fndesc.mangled_name
+        baz_name = baz_ol.library._symbol_map.get(baz_name, baz_name)
         for x in f_names:
             if not found_sin and re.match('.*llvm.sin.f64.*', x):
                 found_sin = True
@@ -215,7 +219,9 @@ class TestDebugInfoEmission(TestCase):
 
         module = llvm.parse_assembly(full_ir)
 
-        name = foo.overloads[foo.signatures[0]].fndesc.mangled_name
+        foo_ol = foo.overloads[foo.signatures[0]]
+        name = foo_ol.fndesc.mangled_name
+        name = foo_ol.library._symbol_map.get(name, name)
         funcs = [x for x in module.functions if x.name == name]
         self.assertEqual(len(funcs), 1)
         func = funcs[0]
@@ -339,7 +345,9 @@ class TestDebugInfoEmission(TestCase):
         # }
 
         module = llvm.parse_assembly(full_ir)
-        name = foo.overloads[foo.signatures[0]].fndesc.mangled_name
+        foo_ol = foo.overloads[foo.signatures[0]]
+        name = foo_ol.fndesc.mangled_name
+        name = foo_ol.library._symbol_map.get(name, name)
         funcs = [x for x in module.functions if x.name == name]
         self.assertEqual(len(funcs), 1)
         func = funcs[0]
@@ -610,7 +618,7 @@ class TestDebugInfoEmission(TestCase):
         def get_func_attrs(fn):
             cres = fn.overloads[fn.signatures[0]]
             lib = cres.library
-            fn = lib._final_module.get_function(cres.fndesc.mangled_name)
+            fn = lib.get_function(cres.fndesc.mangled_name)
             attrs = set(b' '.join(fn.attributes).split())
             return attrs
 

--- a/numba/tests/test_optimisation_pipelines.py
+++ b/numba/tests/test_optimisation_pipelines.py
@@ -30,7 +30,9 @@ class TestPassManagerOptimization(TestCase):
 
         module = llvm.parse_assembly(full_ir)
 
-        name = foo.overloads[foo.signatures[0]].fndesc.mangled_name
+        foo_ol = foo.overloads[foo.signatures[0]]
+        name = foo_ol.fndesc.mangled_name
+        name = foo_ol.library._symbol_map.get(name, name)
         funcs = [x for x in module.functions if x.name == name]
         self.assertEqual(len(funcs), 1)
         func = funcs[0]


### PR DESCRIPTION
…queness.

By hashing the LLVM-IR content of the function. The hash must embeds the full semantic of the function.

With ODR linkage, combining other name+hash symbol must be semantically the same and interchangeable.

Design and direction by human; implemented with help from Claude Opus, which helped adds comments and see through deep layers of abstraction.

Fixes https://github.com/numba/numba/issues/10486

This is a self-contained, relatively low-effort fix for the symbol collision problem while guaranteeing stable hash. 

TODOs:

- [ ] move the hash into the ABI-tag

---
Update:

The prior alternative implementation via stable-hashing to capture function semantic is at https://github.com/sklam/numba/tree/fix/iss10486_cache_fork. It turns out `typemap` does not capture all information because functions are value-dependent. We need to hash all things in the globals and closure cells and that devolved in how to hash every single thing in Python. 