### PR TITLE
CI: secure github actions workflows

### DIFF
--- a/.github/workflows/numba_linux-64_conda_builder.yml
+++ b/.github/workflows/numba_linux-64_conda_builder.yml
@@ -23,6 +23,10 @@ concurrency:
 env:
   CONDA_CHANNEL_NUMBA: numba/label/dev
 
+permissions:
+  contents: read   # least-privilege default; jobs add more if needed
+  actions: read    # for cross-run artifact download (llvmlite)
+
 jobs:
   load-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/numba_linux-64_conda_builder.yml
+++ b/.github/workflows/numba_linux-64_conda_builder.yml
@@ -35,6 +35,8 @@ jobs:
       test-matrix-json: ${{ steps.parse_matrix.outputs.test-matrix-json }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
       - id: parse_matrix
         name: Parse Workflow Matrix JSON
@@ -65,6 +67,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
@@ -140,6 +143,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1

--- a/.github/workflows/numba_linux-64_conda_builder.yml
+++ b/.github/workflows/numba_linux-64_conda_builder.yml
@@ -91,15 +91,19 @@ jobs:
         run: conda install conda-build "conda-libmamba-solver<25.11"
 
       - name: Build Numba conda package
+        env:
+          INPUTS_LLVMLITE_RUN_ID: ${{ inputs.llvmlite_run_id }}
+          MATRIX_PYTHON_VERSION_FULL: ${{ matrix.python_version_full }}
+          MATRIX_NUMPY_BUILD: ${{ matrix.numpy_build }}
         run: |
           CONDA_CHANNEL_DIR="conda_channel_dir"
           mkdir -p $CONDA_CHANNEL_DIR
 
           # Set channel based on whether llvmlite artifact was downloaded
-          if [ "${{ inputs.llvmlite_run_id }}" != "" ]; then
-            LLVMLITE_CHANNEL="file://${{ github.workspace }}/llvmlite_conda"
+          if [ "${INPUTS_LLVMLITE_RUN_ID}" != "" ]; then
+            LLVMLITE_CHANNEL="file://${GITHUB_WORKSPACE}/llvmlite_conda"
           else
-            LLVMLITE_CHANNEL="${{ env.CONDA_CHANNEL_NUMBA }}"
+            LLVMLITE_CHANNEL="${CONDA_CHANNEL_NUMBA}"
           fi
 
           if [ -n "${EXTRA_CHANNELS}" ]; then
@@ -109,8 +113,8 @@ jobs:
           fi
 
           conda-build --debug -c "${LLVMLITE_CHANNEL}" "${extra_args[@]}" -c defaults  \
-            --python=${{ matrix.python_version_full }} \
-            --numpy=${{ matrix.numpy_build }} blas=*=openblas \
+            --python="${MATRIX_PYTHON_VERSION_FULL}" \
+            --numpy="${MATRIX_NUMPY_BUILD}" blas=*=openblas \
             buildscripts/condarecipe.local/ \
             --output-folder=$CONDA_CHANNEL_DIR \
             --no-test
@@ -183,12 +187,15 @@ jobs:
         env:
           TESTS_TO_RUN: "numba.tests"
           NUMBA_ENABLE_CUDASIM: 1
+          INPUTS_LLVMLITE_RUN_ID: ${{ inputs.llvmlite_run_id }}
+          MATRIX_PYTHON_VERSION_FULL: ${{ matrix.python_version_full }}
+          MATRIX_NUMPY_TEST: ${{ matrix.numpy_test }}
         run: |
           # Set channel based on whether llvmlite artifact was downloaded
-          if [ "${{ inputs.llvmlite_run_id }}" != "" ]; then
-            LLVMLITE_CHANNEL="file://${{ github.workspace }}/llvmlite_conda"
+          if [ "${INPUTS_LLVMLITE_RUN_ID}" != "" ]; then
+            LLVMLITE_CHANNEL="file://${GITHUB_WORKSPACE}/llvmlite_conda"
           else
-            LLVMLITE_CHANNEL="${{ env.CONDA_CHANNEL_NUMBA }}"
+            LLVMLITE_CHANNEL="${CONDA_CHANNEL_NUMBA}"
           fi
 
           if [ -n "${EXTRA_CHANNELS}" ]; then
@@ -198,7 +205,7 @@ jobs:
           fi
 
           conda-build -c "${LLVMLITE_CHANNEL}" "${extra_args[@]}" -c defaults \
-            --python=${{ matrix.python_version_full }} \
-            --extra-deps numpy=${{ matrix.numpy_test }} blas=*=openblas \
+            --python="${MATRIX_PYTHON_VERSION_FULL}" \
+            --extra-deps "numpy=${MATRIX_NUMPY_TEST}" blas=*=openblas \
             --test \
             linux-64/numba*.conda

--- a/.github/workflows/numba_linux-64_wheel_builder.yml
+++ b/.github/workflows/numba_linux-64_wheel_builder.yml
@@ -89,10 +89,13 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build wheel in manylinux docker container
+        env:
+          MATRIX_PYTHON_TAG: ${{ matrix.python_tag }}
+          MATRIX_NUMPY_BUILD: ${{ matrix.numpy_build }}
         run: |
           # Construct the expected Python executable path inside the container
           # For free-threaded builds (e.g. cp314t), the manylinux path is cp314-cp314t
-          TAG="${{ matrix.python_tag }}"
+          TAG="${MATRIX_PYTHON_TAG}"
           VER_TAG="${TAG%t}"
           PYTHON_EXECUTABLE="/opt/python/${VER_TAG}-${TAG}/bin/python"
           echo "Using Python executable: $PYTHON_EXECUTABLE"
@@ -102,12 +105,12 @@ jobs:
 
           # Run the build script inside Docker container
           docker run --rm \
-            -v ${{ github.workspace }}:/io \
+            -v ${GITHUB_WORKSPACE}:/io \
             quay.io/pypa/manylinux2014_x86_64 \
             bash /io/buildscripts/github/build_wheel_linux.sh \
             "${PYTHON_EXECUTABLE}" \
             "${USE_TBB}" \
-            "${{ matrix.numpy_build }}" \
+            "${MATRIX_NUMPY_BUILD}" \
             "/io/llvmlite_wheels" \
             "${WHEELS_INDEX_URL}"
 
@@ -115,17 +118,19 @@ jobs:
           ls -la wheelhouse/
 
       - name: Repair and patch wheel in manylinux docker container
+        env:
+          MATRIX_PYTHON_TAG: ${{ matrix.python_tag }}
         run: |
           # Construct the expected Python executable path inside the container
           # For free-threaded builds (e.g. cp314t), the manylinux path is cp314-cp314t
-          TAG="${{ matrix.python_tag }}"
+          TAG="${MATRIX_PYTHON_TAG}"
           VER_TAG="${TAG%t}"
           PYTHON_EXECUTABLE="/opt/python/${VER_TAG}-${TAG}/bin/python"
           echo "Using Python executable: $PYTHON_EXECUTABLE"
 
           # Run the repair script in Docker
           docker run --rm \
-            -v ${{ github.workspace }}:/io \
+            -v ${GITHUB_WORKSPACE}:/io \
             quay.io/pypa/manylinux2014_x86_64 \
             bash /io/buildscripts/github/repair_wheel_linux.sh \
             "$PYTHON_EXECUTABLE" \
@@ -183,20 +188,24 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Validate and test wheel
+        env:
+          MATRIX_PYTHON_MAJOR_MINOR: ${{ matrix.python_major_minor }}
+          MATRIX_NUMPY_TEST: ${{ matrix.numpy_test }}
+          INPUTS_LLVMLITE_WHEEL_RUNID: ${{ inputs.llvmlite_wheel_runid }}
         run: |
           # Pin to the setup-python interpreter: a login shell (bash -el) can
           # re-source profiles and reorder PATH, so bare `python` is unreliable.
-          PYTHON_PATH=$(which python${{ matrix.python_major_minor }})
+          PYTHON_PATH=$(which "python${MATRIX_PYTHON_MAJOR_MINOR}")
           $PYTHON_PATH -m pip install --upgrade pip twine
           ls -l dist
-          if [ "${{ inputs.llvmlite_wheel_runid }}" != "" ]; then
+          if [ "${INPUTS_LLVMLITE_WHEEL_RUNID}" != "" ]; then
               $PYTHON_PATH -m pip install --no-cache-dir llvmlite_wheels/*.whl
           else
               $PYTHON_PATH -m pip install --no-cache-dir --pre -i $WHEELS_INDEX_URL llvmlite
           fi
           $PYTHON_PATH -m twine check dist/*.whl
 
-          $PYTHON_PATH -m pip install dist/numba*.whl numpy==${{ matrix.numpy_test }} setuptools
+          $PYTHON_PATH -m pip install dist/numba*.whl "numpy==${MATRIX_NUMPY_TEST}" setuptools
 
           if [ "$USE_TBB" = "true" ]; then
             $PYTHON_PATH -m pip install tbb

--- a/.github/workflows/numba_linux-64_wheel_builder.yml
+++ b/.github/workflows/numba_linux-64_wheel_builder.yml
@@ -46,6 +46,8 @@ jobs:
       test-matrix-json: ${{ steps.load_matrix_json.outputs.test-matrix-json }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
       - id: load_matrix_json
         name: Load Workflow Matrix JSON
@@ -74,6 +76,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Download llvmlite wheel
         if: inputs.llvmlite_wheel_runid != ''

--- a/.github/workflows/numba_linux-64_wheel_builder.yml
+++ b/.github/workflows/numba_linux-64_wheel_builder.yml
@@ -34,6 +34,10 @@ env:
   # Set USE_TBB to true by default, only override if explicitly set to false
   USE_TBB: ${{ github.event_name == 'workflow_dispatch' && inputs.use_tbb != false || true }}
 
+permissions:
+  contents: read   # least-privilege default; jobs add more if needed
+  actions: read    # for cross-run artifact download (llvmlite)
+
 jobs:
   load-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/numba_linux-aarch64_conda_builder.yml
+++ b/.github/workflows/numba_linux-aarch64_conda_builder.yml
@@ -23,6 +23,10 @@ concurrency:
 env:
   CONDA_CHANNEL_NUMBA: numba/label/dev
 
+permissions:
+  contents: read   # least-privilege default; jobs add more if needed
+  actions: read    # for cross-run artifact download (llvmlite)
+
 jobs:
   load-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/numba_linux-aarch64_conda_builder.yml
+++ b/.github/workflows/numba_linux-aarch64_conda_builder.yml
@@ -35,6 +35,8 @@ jobs:
       test-matrix-json: ${{ steps.parse_matrix.outputs.test-matrix-json }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
       - id: parse_matrix
         name: Parse Workflow Matrix JSON
@@ -65,6 +67,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
@@ -140,6 +143,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1

--- a/.github/workflows/numba_linux-aarch64_conda_builder.yml
+++ b/.github/workflows/numba_linux-aarch64_conda_builder.yml
@@ -91,15 +91,19 @@ jobs:
         run: conda install conda-build "conda-libmamba-solver<25.11"
 
       - name: Build Numba conda package
+        env:
+          INPUTS_LLVMLITE_RUN_ID: ${{ inputs.llvmlite_run_id }}
+          MATRIX_PYTHON_VERSION_FULL: ${{ matrix.python_version_full }}
+          MATRIX_NUMPY_BUILD: ${{ matrix.numpy_build }}
         run: |
           CONDA_CHANNEL_DIR="conda_channel_dir"
           mkdir -p $CONDA_CHANNEL_DIR
 
           # Set channel based on whether llvmlite artifact was downloaded
-          if [ "${{ inputs.llvmlite_run_id }}" != "" ]; then
-            LLVMLITE_CHANNEL="file://${{ github.workspace }}/llvmlite_conda"
+          if [ "${INPUTS_LLVMLITE_RUN_ID}" != "" ]; then
+            LLVMLITE_CHANNEL="file://${GITHUB_WORKSPACE}/llvmlite_conda"
           else
-            LLVMLITE_CHANNEL="${{ env.CONDA_CHANNEL_NUMBA }}"
+            LLVMLITE_CHANNEL="${CONDA_CHANNEL_NUMBA}"
           fi
 
           if [ -n "${EXTRA_CHANNELS}" ]; then
@@ -109,8 +113,8 @@ jobs:
           fi
 
           conda-build --debug -c $LLVMLITE_CHANNEL "${extra_args[@]}" -c defaults \
-            --python=${{ matrix.python_version_full }} \
-            --numpy=${{ matrix.numpy_build }} blas=*=openblas \
+            --python="${MATRIX_PYTHON_VERSION_FULL}" \
+            --numpy="${MATRIX_NUMPY_BUILD}" blas=*=openblas \
             buildscripts/condarecipe.local/ \
             --output-folder=$CONDA_CHANNEL_DIR \
             --no-test
@@ -183,12 +187,15 @@ jobs:
         env:
           TESTS_TO_RUN: "numba.tests"
           NUMBA_ENABLE_CUDASIM: 1
+          INPUTS_LLVMLITE_RUN_ID: ${{ inputs.llvmlite_run_id }}
+          MATRIX_PYTHON_VERSION_FULL: ${{ matrix.python_version_full }}
+          MATRIX_NUMPY_TEST: ${{ matrix.numpy_test }}
         run: |
           # Set channel based on whether llvmlite artifact was downloaded
-          if [ "${{ inputs.llvmlite_run_id }}" != "" ]; then
-            LLVMLITE_CHANNEL="file://${{ github.workspace }}/llvmlite_conda"
+          if [ "${INPUTS_LLVMLITE_RUN_ID}" != "" ]; then
+            LLVMLITE_CHANNEL="file://${GITHUB_WORKSPACE}/llvmlite_conda"
           else
-            LLVMLITE_CHANNEL="${{ env.CONDA_CHANNEL_NUMBA }}"
+            LLVMLITE_CHANNEL="${CONDA_CHANNEL_NUMBA}"
           fi
 
           if [ -n "${EXTRA_CHANNELS}" ]; then
@@ -213,7 +220,7 @@ jobs:
 
           # Run the test with the found package
           conda-build -c $LLVMLITE_CHANNEL "${extra_args[@]}" -c defaults \
-            --python=${{ matrix.python_version_full }} \
-            --extra-deps numpy=${{ matrix.numpy_test }} blas=*=openblas \
+            --python="${MATRIX_PYTHON_VERSION_FULL}" \
+            --extra-deps "numpy=${MATRIX_NUMPY_TEST}" blas=*=openblas \
             --test \
             "$NUMBA_PKG"

--- a/.github/workflows/numba_linux-aarch64_wheel_builder.yml
+++ b/.github/workflows/numba_linux-aarch64_wheel_builder.yml
@@ -40,6 +40,8 @@ jobs:
       test-matrix-json: ${{ steps.load_matrix_json.outputs.test-matrix-json }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
       - id: load_matrix_json
         name: Load Workflow Matrix JSON
@@ -68,6 +70,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Download llvmlite wheel
         if: inputs.llvmlite_wheel_runid != ''

--- a/.github/workflows/numba_linux-aarch64_wheel_builder.yml
+++ b/.github/workflows/numba_linux-aarch64_wheel_builder.yml
@@ -28,6 +28,10 @@ env:
   CONDA_CHANNEL_NUMBA: numba/label/dev
   MANYLINUX_IMAGE: "manylinux_2_28_aarch64"
 
+permissions:
+  contents: read   # least-privilege default; jobs add more if needed
+  actions: read    # for cross-run artifact download (llvmlite)
+
 jobs:
   load-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/numba_linux-aarch64_wheel_builder.yml
+++ b/.github/workflows/numba_linux-aarch64_wheel_builder.yml
@@ -83,10 +83,13 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build wheel in manylinux docker container
+        env:
+          MATRIX_PYTHON_TAG: ${{ matrix.python_tag }}
+          MATRIX_NUMPY_BUILD: ${{ matrix.numpy_build }}
         run: |
           # Construct the expected Python executable path inside the container
           # For free-threaded builds (e.g. cp314t), the manylinux path is cp314-cp314t
-          TAG="${{ matrix.python_tag }}"
+          TAG="${MATRIX_PYTHON_TAG}"
           VER_TAG="${TAG%t}"
           PYTHON_EXECUTABLE="/opt/python/${VER_TAG}-${TAG}/bin/python"
           echo "Using Python executable: $PYTHON_EXECUTABLE"
@@ -96,12 +99,12 @@ jobs:
 
           # Run the build script inside Docker container
           docker run --rm \
-            -v ${{ github.workspace }}:/io \
-            quay.io/pypa/${{ env.MANYLINUX_IMAGE }} \
+            -v ${GITHUB_WORKSPACE}:/io \
+            quay.io/pypa/${MANYLINUX_IMAGE} \
             bash /io/buildscripts/github/build_wheel_linux.sh \
             "${PYTHON_EXECUTABLE}" \
             "false" \
-            "${{ matrix.numpy_build }}" \
+            "${MATRIX_NUMPY_BUILD}" \
             "/io/llvmlite_wheels" \
             "${WHEELS_INDEX_URL}"
 
@@ -109,18 +112,20 @@ jobs:
           ls -la wheelhouse/
 
       - name: Repair and patch wheel in manylinux docker container
+        env:
+          MATRIX_PYTHON_TAG: ${{ matrix.python_tag }}
         run: |
           # Construct the expected Python executable path inside the container
           # For free-threaded builds (e.g. cp314t), the manylinux path is cp314-cp314t
-          TAG="${{ matrix.python_tag }}"
+          TAG="${MATRIX_PYTHON_TAG}"
           VER_TAG="${TAG%t}"
           PYTHON_EXECUTABLE="/opt/python/${VER_TAG}-${TAG}/bin/python"
           echo "Using Python executable: $PYTHON_EXECUTABLE"
 
           # Run the repair script in Docker
           docker run --rm \
-            -v ${{ github.workspace }}:/io \
-            quay.io/pypa/${{ env.MANYLINUX_IMAGE }} \
+            -v ${GITHUB_WORKSPACE}:/io \
+            quay.io/pypa/${MANYLINUX_IMAGE} \
             bash /io/buildscripts/github/repair_wheel_linux.sh \
             "${PYTHON_EXECUTABLE}" \
             "false" \
@@ -175,19 +180,23 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Validate and test wheel
+        env:
+          MATRIX_PYTHON_MAJOR_MINOR: ${{ matrix.python_major_minor }}
+          MATRIX_NUMPY_TEST: ${{ matrix.numpy_test }}
+          INPUTS_LLVMLITE_WHEEL_RUNID: ${{ inputs.llvmlite_wheel_runid }}
         run: |
           # Pin to the setup-python interpreter: a login shell (bash -el) can
           # re-source profiles and reorder PATH, so bare `python` is unreliable.
-          PYTHON_PATH=$(which python${{ matrix.python_major_minor }})
+          PYTHON_PATH=$(which "python${MATRIX_PYTHON_MAJOR_MINOR}")
           $PYTHON_PATH -m pip install --upgrade pip twine
           ls -l dist
-          if [ "${{ inputs.llvmlite_wheel_runid }}" != "" ]; then
+          if [ "${INPUTS_LLVMLITE_WHEEL_RUNID}" != "" ]; then
               $PYTHON_PATH -m pip install --no-cache-dir llvmlite_wheels/*.whl
           else
               $PYTHON_PATH -m pip install --no-cache-dir --pre -i $WHEELS_INDEX_URL llvmlite
           fi
           $PYTHON_PATH -m twine check dist/*.whl
-          $PYTHON_PATH -m pip install dist/numba*.whl numpy==${{ matrix.numpy_test }} setuptools
+          $PYTHON_PATH -m pip install dist/numba*.whl "numpy==${MATRIX_NUMPY_TEST}" setuptools
 
           # print Numba system information
           $PYTHON_PATH -m numba -s

--- a/.github/workflows/numba_osx-arm64_conda_builder.yml
+++ b/.github/workflows/numba_osx-arm64_conda_builder.yml
@@ -23,6 +23,10 @@ concurrency:
 env:
   CONDA_CHANNEL_NUMBA: numba/label/dev
 
+permissions:
+  contents: read   # least-privilege default; jobs add more if needed
+  actions: read    # for cross-run artifact download (llvmlite)
+
 jobs:
   load-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/numba_osx-arm64_conda_builder.yml
+++ b/.github/workflows/numba_osx-arm64_conda_builder.yml
@@ -35,6 +35,8 @@ jobs:
       test-matrix-json: ${{ steps.parse_matrix.outputs.test-matrix-json }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
       - id: parse_matrix
         name: Parse Workflow Matrix JSON
@@ -65,6 +67,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
@@ -140,6 +143,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1

--- a/.github/workflows/numba_osx-arm64_conda_builder.yml
+++ b/.github/workflows/numba_osx-arm64_conda_builder.yml
@@ -91,15 +91,19 @@ jobs:
         run: conda install conda-build "conda-libmamba-solver<25.11"
 
       - name: Build Numba conda package
+        env:
+          INPUTS_LLVMLITE_RUN_ID: ${{ inputs.llvmlite_run_id }}
+          MATRIX_PYTHON_VERSION_FULL: ${{ matrix.python_version_full }}
+          MATRIX_NUMPY_BUILD: ${{ matrix.numpy_build }}
         run: |
           CONDA_CHANNEL_DIR="conda_channel_dir"
           mkdir -p $CONDA_CHANNEL_DIR
 
           # Set channel based on whether llvmlite artifact was downloaded
-          if [ "${{ inputs.llvmlite_run_id }}" != "" ]; then
-            LLVMLITE_CHANNEL="file://${{ github.workspace }}/llvmlite_conda"
+          if [ "${INPUTS_LLVMLITE_RUN_ID}" != "" ]; then
+            LLVMLITE_CHANNEL="file://${GITHUB_WORKSPACE}/llvmlite_conda"
           else
-            LLVMLITE_CHANNEL="${{ env.CONDA_CHANNEL_NUMBA }}"
+            LLVMLITE_CHANNEL="${CONDA_CHANNEL_NUMBA}"
           fi
 
           if [ -n "${EXTRA_CHANNELS}" ]; then
@@ -109,8 +113,8 @@ jobs:
           fi
 
           conda-build --debug -c $LLVMLITE_CHANNEL "${extra_args[@]}" -c defaults \
-            --python=${{ matrix.python_version_full }} \
-            --numpy=${{ matrix.numpy_build }} blas=*=openblas \
+            --python="${MATRIX_PYTHON_VERSION_FULL}" \
+            --numpy="${MATRIX_NUMPY_BUILD}" blas=*=openblas \
             buildscripts/condarecipe.local/ \
             --output-folder=$CONDA_CHANNEL_DIR \
             --no-test
@@ -176,12 +180,15 @@ jobs:
         env:
           TESTS_TO_RUN: "numba.tests"
           NUMBA_ENABLE_CUDASIM: 1
+          INPUTS_LLVMLITE_RUN_ID: ${{ inputs.llvmlite_run_id }}
+          MATRIX_PYTHON_VERSION_FULL: ${{ matrix.python_version_full }}
+          MATRIX_NUMPY_TEST: ${{ matrix.numpy_test }}
         run: |
           # Set channel based on whether llvmlite artifact was downloaded
-          if [ "${{ inputs.llvmlite_run_id }}" != "" ]; then
-            LLVMLITE_CHANNEL="file://${{ github.workspace }}/llvmlite_conda"
+          if [ "${INPUTS_LLVMLITE_RUN_ID}" != "" ]; then
+            LLVMLITE_CHANNEL="file://${GITHUB_WORKSPACE}/llvmlite_conda"
           else
-            LLVMLITE_CHANNEL="${{ env.CONDA_CHANNEL_NUMBA }}"
+            LLVMLITE_CHANNEL="${CONDA_CHANNEL_NUMBA}"
           fi
 
           if [ -n "${EXTRA_CHANNELS}" ]; then
@@ -191,7 +198,7 @@ jobs:
           fi
 
           conda-build -c $LLVMLITE_CHANNEL "${extra_args[@]}" -c defaults \
-            --python=${{ matrix.python_version_full }} \
-            --extra-deps numpy=${{ matrix.numpy_test }} blas=*=openblas \
+            --python="${MATRIX_PYTHON_VERSION_FULL}" \
+            --extra-deps "numpy=${MATRIX_NUMPY_TEST}" blas=*=openblas \
             --test \
             osx-arm64/numba*.conda

--- a/.github/workflows/numba_osx-arm64_wheel_builder.yml
+++ b/.github/workflows/numba_osx-arm64_wheel_builder.yml
@@ -26,6 +26,10 @@ env:
   ARTIFACT_RETENTION_DAYS: 7
   WHEELS_INDEX_URL: https://pypi.anaconda.org/numba/label/dev/simple
 
+permissions:
+  contents: read   # least-privilege default; jobs add more if needed
+  actions: read    # for cross-run artifact download (llvmlite)
+
 jobs:
   load-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/numba_osx-arm64_wheel_builder.yml
+++ b/.github/workflows/numba_osx-arm64_wheel_builder.yml
@@ -101,13 +101,16 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install build dependencies
+        env:
+          INPUTS_LLVMLITE_WHEEL_RUNID: ${{ inputs.llvmlite_wheel_runid }}
+          MATRIX_NUMPY_BUILD: ${{ matrix.numpy_build }}
         run: |
-          if [ "${{ inputs.llvmlite_wheel_runid }}" != "" ]; then
+          if [ "${INPUTS_LLVMLITE_WHEEL_RUNID}" != "" ]; then
               arch -arm64 python -m pip install llvmlite_wheels/*.whl
           else
-              arch -arm64 python -m pip install -i ${{ env.WHEELS_INDEX_URL }} llvmlite
+              arch -arm64 python -m pip install -i ${WHEELS_INDEX_URL} llvmlite
           fi
-          python -m pip install build numpy==${{ matrix.numpy_build }} setuptools wheel
+          python -m pip install build numpy==${MATRIX_NUMPY_BUILD} setuptools wheel
 
       - name: Setup llvm-openmp for build
         run: |
@@ -117,7 +120,7 @@ jobs:
 
           # Create symlinks for setup.py OpenMP detection
           mkdir -p omp/lib/clang/19/include
-          ln -s ${{ github.workspace }}/omp/include/omp.h omp/lib/clang/19/include/omp.h
+          ln -s ${GITHUB_WORKSPACE}/omp/include/omp.h omp/lib/clang/19/include/omp.h
 
           # Export environment vars for build to detect OpenMP
           echo "PREFIX=$PWD/omp" >> $GITHUB_ENV
@@ -178,8 +181,10 @@ jobs:
 
     steps:
       - name: Set Python versions
+        env:
+          MATRIX_PYTHON_VERSION_FULL: ${{ matrix.python_version_full }}
         run: |
-          FULL_VERSION="${{ matrix.python_version_full }}"
+          FULL_VERSION="${MATRIX_PYTHON_VERSION_FULL}"
           CANONICAL_VERSION=$(echo "$FULL_VERSION" | cut -d. -f1,2)
 
           echo "PYTHON_INSTALL_VERSION=$FULL_VERSION" >> $GITHUB_ENV
@@ -217,20 +222,24 @@ jobs:
           echo "Set DYLD_FALLBACK_LIBRARY_PATH to: $(brew --prefix libomp)/lib"
 
       - name: Validate and test wheel
+        env:
+          INPUTS_LLVMLITE_WHEEL_RUNID: ${{ inputs.llvmlite_wheel_runid }}
+          MATRIX_PYTHON_MAJOR_MINOR: ${{ matrix.python_major_minor }}
+          MATRIX_NUMPY_TEST: ${{ matrix.numpy_test }}
         run: |
           # Pin to the setup-python interpreter: a login shell (bash -el) can
           # re-source profiles and reorder PATH, so bare `python` is unreliable.
-          PYTHON_PATH=$(which python${{ matrix.python_major_minor }})
+          PYTHON_PATH=$(which "python${MATRIX_PYTHON_MAJOR_MINOR}")
           "$PYTHON_PATH" -m venv .venv && source .venv/bin/activate
           arch -arm64 python -m pip install --upgrade pip twine
           ls -l dist
-          if [ "${{ inputs.llvmlite_wheel_runid }}" != "" ]; then
+          if [ "${INPUTS_LLVMLITE_WHEEL_RUNID}" != "" ]; then
               arch -arm64 python -m pip install llvmlite_wheels/*.whl
           else
-              arch -arm64 python -m pip install --pre -i ${{ env.WHEELS_INDEX_URL }} llvmlite
+              arch -arm64 python -m pip install --pre -i ${WHEELS_INDEX_URL} llvmlite
           fi
           arch -arm64 python -m twine check dist/*.whl
-          arch -arm64 python -m pip install dist/numba*.whl numpy==${{ matrix.numpy_test }}
+          arch -arm64 python -m pip install dist/numba*.whl numpy==${MATRIX_NUMPY_TEST}
 
           # print Numba system information
           arch -arm64 python -m numba -s

--- a/.github/workflows/numba_osx-arm64_wheel_builder.yml
+++ b/.github/workflows/numba_osx-arm64_wheel_builder.yml
@@ -38,6 +38,8 @@ jobs:
       test-matrix-json: ${{ steps.load_matrix_json.outputs.test-matrix-json }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
       - id: load_matrix_json
         name: Load Workflow Matrix JSON
@@ -66,6 +68,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Miniconda
         if: ${{ !endsWith(matrix.python_version_full, 't') }}

--- a/.github/workflows/numba_win-64_conda_builder.yml
+++ b/.github/workflows/numba_win-64_conda_builder.yml
@@ -90,15 +90,19 @@ jobs:
         run: conda install conda-build
 
       - name: Build Numba conda package
+        env:
+          INPUTS_LLVMLITE_RUN_ID: ${{ inputs.llvmlite_run_id }}
+          MATRIX_PYTHON_VERSION_FULL: ${{ matrix.python_version_full }}
+          MATRIX_NUMPY_BUILD: ${{ matrix.numpy_build }}
         run: |
           CONDA_CHANNEL_DIR="conda_channel_dir"
           mkdir -p $CONDA_CHANNEL_DIR
 
           # Set channel based on whether llvmlite artifact was downloaded
-          if [ "${{ inputs.llvmlite_run_id }}" != "" ]; then
-            LLVMLITE_CHANNEL="${{ github.workspace }}/llvmlite_conda"
+          if [ "${INPUTS_LLVMLITE_RUN_ID}" != "" ]; then
+            LLVMLITE_CHANNEL="${GITHUB_WORKSPACE}/llvmlite_conda"
           else
-            LLVMLITE_CHANNEL="${{ env.CONDA_CHANNEL_NUMBA }}"
+            LLVMLITE_CHANNEL="${CONDA_CHANNEL_NUMBA}"
           fi
 
           if [ -n "${EXTRA_CHANNELS}" ]; then
@@ -108,8 +112,8 @@ jobs:
           fi
 
           conda-build --debug -c $LLVMLITE_CHANNEL "${extra_args[@]}" -c defaults \
-            --python=${{ matrix.python_version_full }} \
-            --numpy=${{ matrix.numpy_build }} \
+            --python="${MATRIX_PYTHON_VERSION_FULL}" \
+            --numpy="${MATRIX_NUMPY_BUILD}" \
             buildscripts/condarecipe.local/ \
             --output-folder=$CONDA_CHANNEL_DIR \
             --no-test
@@ -164,12 +168,15 @@ jobs:
         env:
           TESTS_TO_RUN: "numba.tests"
           NUMBA_ENABLE_CUDASIM: 1
+          INPUTS_LLVMLITE_RUN_ID: ${{ inputs.llvmlite_run_id }}
+          MATRIX_PYTHON_VERSION_FULL: ${{ matrix.python_version_full }}
+          MATRIX_NUMPY_TEST: ${{ matrix.numpy_test }}
         run: |
           # Set channel based on whether llvmlite artifact was downloaded
-          if [ "${{ inputs.llvmlite_run_id }}" != "" ]; then
-            LLVMLITE_CHANNEL="${{ github.workspace }}/llvmlite_conda"
+          if [ "${INPUTS_LLVMLITE_RUN_ID}" != "" ]; then
+            LLVMLITE_CHANNEL="${GITHUB_WORKSPACE}/llvmlite_conda"
           else
-            LLVMLITE_CHANNEL="${{ env.CONDA_CHANNEL_NUMBA }}"
+            LLVMLITE_CHANNEL="${CONDA_CHANNEL_NUMBA}"
           fi
 
           if [ -n "${EXTRA_CHANNELS}" ]; then
@@ -179,7 +186,7 @@ jobs:
           fi
 
           conda-build -c $LLVMLITE_CHANNEL "${extra_args[@]}" -c defaults \
-            --python=${{ matrix.python_version_full }} \
-            --extra-deps numpy=${{ matrix.numpy_test }} \
+            --python="${MATRIX_PYTHON_VERSION_FULL}" \
+            --extra-deps "numpy=${MATRIX_NUMPY_TEST}" \
             --test \
             win-64/numba*.conda

--- a/.github/workflows/numba_win-64_conda_builder.yml
+++ b/.github/workflows/numba_win-64_conda_builder.yml
@@ -23,6 +23,10 @@ concurrency:
 env:
   CONDA_CHANNEL_NUMBA: numba/label/dev
 
+permissions:
+  contents: read   # least-privilege default; jobs add more if needed
+  actions: read    # for cross-run artifact download (llvmlite)
+
 jobs:
   load-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/numba_win-64_conda_builder.yml
+++ b/.github/workflows/numba_win-64_conda_builder.yml
@@ -35,6 +35,8 @@ jobs:
       test-matrix-json: ${{ steps.parse_matrix.outputs.test-matrix-json }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
       - id: parse_matrix
         name: Parse Workflow Matrix JSON
@@ -65,6 +67,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1

--- a/.github/workflows/numba_win-64_wheel_builder.yml
+++ b/.github/workflows/numba_win-64_wheel_builder.yml
@@ -85,13 +85,16 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install build dependencies
+        env:
+          INPUTS_LLVMLITE_WHEEL_RUNID: ${{ inputs.llvmlite_wheel_runid }}
+          MATRIX_NUMPY_BUILD: ${{ matrix.numpy_build }}
         run: |
-          if [ "${{ inputs.llvmlite_wheel_runid }}" != "" ]; then
+          if [ "${INPUTS_LLVMLITE_WHEEL_RUNID}" != "" ]; then
               python -m pip install llvmlite_wheels/*.whl
           else
-              python -m pip install -i ${{ env.WHEELS_INDEX_URL }} llvmlite
+              python -m pip install -i ${WHEELS_INDEX_URL} llvmlite
           fi
-          python -m pip install build numpy==${{ matrix.numpy_build }} setuptools wheel tbb==2021.6 tbb-devel==2021.6
+          python -m pip install build numpy==${MATRIX_NUMPY_BUILD} setuptools wheel tbb==2021.6 tbb-devel==2021.6
 
       - name: Build wheel
         run: python -m build --wheel --no-isolation
@@ -144,16 +147,18 @@ jobs:
         env:
           NUMBA_CPU_NAME: generic
           _NUMBA_REDUCED_TESTING: 1
+          INPUTS_LLVMLITE_WHEEL_RUNID: ${{ inputs.llvmlite_wheel_runid }}
+          MATRIX_NUMPY_TEST: ${{ matrix.numpy_test }}
         run: |
           # No versioned `which python<ver>` here: Windows setup-python installs
           # only `python.exe` (no python3.14[t]) and it's the sole interpreter,
           # so bare `python` already resolves to the setup-python one.
           python -m pip install --upgrade pip twine
-          python -m pip install numpy==${{ matrix.numpy_test }} tbb==2021.6 tbb-devel==2021.6
-          if [ "${{ inputs.llvmlite_wheel_runid }}" != "" ]; then
+          python -m pip install numpy==${MATRIX_NUMPY_TEST} tbb==2021.6 tbb-devel==2021.6
+          if [ "${INPUTS_LLVMLITE_WHEEL_RUNID}" != "" ]; then
               python -m pip install llvmlite_wheels/*.whl
           else
-              python -m pip install --pre -i ${{ env.WHEELS_INDEX_URL }} llvmlite
+              python -m pip install --pre -i ${WHEELS_INDEX_URL} llvmlite
           fi
           python -m twine check dist/*.whl
           python -m pip install dist/*.whl

--- a/.github/workflows/numba_win-64_wheel_builder.yml
+++ b/.github/workflows/numba_win-64_wheel_builder.yml
@@ -36,6 +36,8 @@ jobs:
       test-matrix-json: ${{ steps.load_matrix_json.outputs.test-matrix-json }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
       - id: load_matrix_json
         name: Load Workflow Matrix JSON
@@ -64,6 +66,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/numba_win-64_wheel_builder.yml
+++ b/.github/workflows/numba_win-64_wheel_builder.yml
@@ -24,6 +24,10 @@ env:
   ARTIFACT_RETENTION_DAYS: 7
   WHEELS_INDEX_URL: https://pypi.anaconda.org/numba/label/dev/simple
 
+permissions:
+  contents: read   # least-privilege default; jobs add more if needed
+  actions: read    # for cross-run artifact download (llvmlite)
+
 jobs:
   load-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/towncrier.yml
+++ b/.github/workflows/towncrier.yml
@@ -7,6 +7,9 @@ on:
 env:
   GITHUB_PR_NUMBER: ${{github.event.pull_request.number}}
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Check release notes
@@ -16,6 +19,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up Python 3.10
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:

--- a/.github/workflows/upload_packages.yml
+++ b/.github/workflows/upload_packages.yml
@@ -27,6 +27,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ inputs.tag || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   find-workflow-runs:
     name: Find Workflow Runs
@@ -37,6 +41,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -47,16 +53,17 @@ jobs:
         id: find-runs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUTS_TAG: ${{ inputs.tag }}
         run: |
-          TAG="${{ inputs.tag }}"
+          TAG="${INPUTS_TAG}"
           if [ -z "$TAG" ]; then
             echo "Error: tag input is required"
             exit 1
           fi
           output=$(./buildscripts/github/find_workflow_runs.py \
             --tag "$TAG" \
-            --repo ${{ github.repository }} \
-            --token "${{ secrets.GITHUB_TOKEN }}" \
+            --repo ${GITHUB_REPOSITORY} \
+            --token "${GH_TOKEN}" \
             --config ./buildscripts/github/workflow_groups.json)
           echo "$output" >> $GITHUB_OUTPUT
 
@@ -68,6 +75,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -77,21 +86,23 @@ jobs:
       - name: Download conda packages
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CONDA_RUN_IDS: ${{ needs.find-workflow-runs.outputs.conda_run_ids }}
         run: |
           ./buildscripts/github/download_artifacts.py \
-            --run-ids ${{ needs.find-workflow-runs.outputs.conda_run_ids }} \
-            --repo ${{ github.repository }} \
-            --token "${{ secrets.GITHUB_TOKEN }}" \
+            --run-ids ${CONDA_RUN_IDS} \
+            --repo ${GITHUB_REPOSITORY} \
+            --token "${GH_TOKEN}" \
             --output-dir conda_packages
 
       - name: Download wheels
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WHEEL_RUN_IDS: ${{ needs.find-workflow-runs.outputs.wheel_run_ids }}
         run: |
           ./buildscripts/github/download_artifacts.py \
-            --run-ids ${{ needs.find-workflow-runs.outputs.wheel_run_ids }} \
-            --repo ${{ github.repository }} \
-            --token "${{ secrets.GITHUB_TOKEN }}" \
+            --run-ids ${WHEEL_RUN_IDS} \
+            --repo ${GITHUB_REPOSITORY} \
+            --token "${GH_TOKEN}" \
             --output-dir dist
 
       - name: List downloaded conda packages
@@ -252,28 +263,30 @@ jobs:
       - name: Publish conda packages to Anaconda.org
         env:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_ORG_GITHUB_NUMBA_UPLOAD }}
+          INPUTS_COPY_CONDA_TO_MAIN: ${{ inputs.copy_conda_to_main }}
         run: |
-          LABELS="-l ${{ env.ANACONDA_LABEL }}"
-          if [ "${{ inputs.copy_conda_to_main }}" = "true" ]; then
+          LABELS="-l ${ANACONDA_LABEL}"
+          if [ "${INPUTS_COPY_CONDA_TO_MAIN}" = "true" ]; then
             LABELS="$LABELS -l main"
           fi
-          echo "Publishing conda packages to: ${{ env.ANACONDA_USER }} with labels: $LABELS"
+          echo "Publishing conda packages to: ${ANACONDA_USER} with labels: $LABELS"
           find conda_packages -name "*.conda" -type f | while read -r pkg; do
             echo "Uploading: $pkg"
-            anaconda -t "$ANACONDA_API_TOKEN" upload --force -u ${{ env.ANACONDA_USER }} $LABELS "$pkg"
+            anaconda -t "$ANACONDA_API_TOKEN" upload --force -u ${ANACONDA_USER} $LABELS "$pkg"
           done
 
       - name: Publish wheels to Anaconda.org
         env:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_ORG_GITHUB_NUMBA_UPLOAD }}
+          INPUTS_COPY_CONDA_TO_MAIN: ${{ inputs.copy_conda_to_main }}
         run: |
-          LABELS="-l ${{ env.ANACONDA_LABEL }}"
-          if [ "${{ inputs.copy_conda_to_main }}" = "true" ]; then
+          LABELS="-l ${ANACONDA_LABEL}"
+          if [ "${INPUTS_COPY_CONDA_TO_MAIN}" = "true" ]; then
             LABELS="$LABELS -l main"
           fi
-          echo "Publishing wheels to: ${{ env.ANACONDA_USER }} with labels: $LABELS"
+          echo "Publishing wheels to: ${ANACONDA_USER} with labels: $LABELS"
           find dist -name "*.whl" -type f | while read -r pkg; do
             echo "Uploading: $pkg"
-            anaconda -t "$ANACONDA_API_TOKEN" upload --force -u ${{ env.ANACONDA_USER }} $LABELS "$pkg"
+            anaconda -t "$ANACONDA_API_TOKEN" upload --force -u ${ANACONDA_USER} $LABELS "$pkg"
           done
 


### PR DESCRIPTION
I had run [zizmor](https://github.com/zizmorcore/zizmor) - static analysis tool that helps find GitHub actions security issues. 
This PR fixes all the flagged issues and makes CI more secure.

These are 3 categories of zizmor findings addressed on this PR:
- excessive-permissions
Added workflow-level permissions: with least-privilege defaults (contents: read; actions: read where jobs download artifacts from other workflow runs). Jobs that need more (e.g. PyPI OIDC) keep explicit job-level permissions.

- artipacked
Set persist-credentials: false on every actions/checkout step so the job token is not left in the git config for later steps or artifacts.

- template-injection
Removed `${{ }}` expansion inside run: shell scripts. Values from inputs, matrix, needs, and job env are passed via step/job env and referenced as shell variables 