### PR TITLE
Fix disk cache crash for exec()'d functions with __module__=None

### DIFF
--- a/numba/core/environment.py
+++ b/numba/core/environment.py
@@ -48,8 +48,13 @@ def _rebuild_env(modname, consts, env_name):
     if env is not None:
         return env
 
-    mod = importlib.import_module(modname)
-    env = Environment(mod.__dict__)
+    if modname is None:
+        mod_dict = {}
+    else:
+        mod = importlib.import_module(modname)
+        mod_dict = mod.__dict__
+
+    env = Environment(mod_dict)
     env.consts[:] = consts
     env.env_name = env_name
     # Cache loaded object

--- a/numba/tests/test_caching.py
+++ b/numba/tests/test_caching.py
@@ -718,6 +718,25 @@ class TestCache(DispatcherCacheUsecasesTest):
         err = execute_with_input()
         self.assertIn("cache hits = 1", err.strip())
 
+    def test_exec_module_none(self):
+        # Issue 10485: caching exec()'d functions with __module__=None
+        from numba import njit
+        
+        @njit
+        def add_one(x):
+            return x + 1
+
+        env = {"_inner": add_one}
+        exec(compile("def wrapper(x): return _inner(x)\n", "<string>", "exec"), env)
+        
+        # This will cache it
+        f1 = njit(cache=True)(env["wrapper"])
+        self.assertEqual(f1(10), 11)
+        
+        # Test loading the cache doesn't crash
+        f2 = njit(cache=True)(env["wrapper"])
+        self.assertEqual(f2(10), 11)
+
 
 class TestCacheZip(DispatcherCacheUsecasesTest):
 


### PR DESCRIPTION
Fixes #10485

When loading an `exec()`'d function from the disk cache, `modname` may be `None` because the function's execution environment lacked a `__name__` or `__module__` attribute. This caused Numba to crash with an `AttributeError` when attempting to import the module inside `_rebuild_env`.

This PR adds a fallback inside `numba/core/environment.py` to supply an empty dictionary to the `Environment` when `modname` is `None`, gracefully handling these dynamically compiled functions.

A regression test has been added to `numba/tests/test_caching.py`.