### PR TITLE
chore: improve numba maintenance path

### DIFF
--- a/numba/tests/test_ir.py
+++ b/numba/tests/test_ir.py
@@ -42,7 +42,7 @@ class TestIR(unittest.TestCase):
         more_orange = local.define('orange', loc=ir.Loc(filename=filename,
                                                         line=5))
         self.assertIs(top.get('orange'), orange)
-        self.assertIsNot(local.get('orange'), not orange)
+        self.assertIsNot(local.get('orange'), orange)
         self.assertIs(local.get('orange'), more_orange)
 
         try:


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in numba/tests/test_ir.py, numba/tests/__init__.py related to Python typing, tests, CLI ergonomics, observability; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.