### PR TITLE
update llvmlite version on numba to `0.49.0dev0`

### DIFF
--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - numpy
     - setuptools
     # On channel https://anaconda.org/numba/
-    - llvmlite >=0.48.0dev0,<0.48
+    - llvmlite >=0.49.0dev0,<0.49
     # TBB devel version is to match TBB libs.
     # NOTE: ppc64le and aarch64 are pending testing so excluded for now.
     - tbb-devel >=2021.6       # [not (aarch64 or ppc64le)]
@@ -41,7 +41,7 @@ requirements:
     - python >=3.10
     - numpy >=1.22.3
     # On channel https://anaconda.org/numba/
-    - llvmlite >=0.48.0dev0,<0.48
+    - llvmlite >=0.49.0dev0,<0.49
   run_constrained:
     # If TBB is present it must be at least version 2021.6
     - tbb >=2021.6    # [not (aarch64 or ppc64le)]

--- a/buildscripts/incremental/setup_conda_environment.cmd
+++ b/buildscripts/incremental/setup_conda_environment.cmd
@@ -22,7 +22,7 @@ call deactivate
 conda list
 @rem Collect all conda packages so the environment is created in a single solve
 @rem CFFI, jinja2 and IPython are optional dependencies, but exercised in the test suite
-set PKGS=python=%PYTHON% numpy=%NUMPY% cffi pip jinja2 gitpython pyyaml psutil llvmlite=0.48 "tbb>=2021.6" "tbb-devel>=2021.6"
+set PKGS=python=%PYTHON% numpy=%NUMPY% cffi pip jinja2 gitpython pyyaml psutil llvmlite=0.49 "tbb>=2021.6" "tbb-devel>=2021.6"
 @rem missing IPython for Python 3.13
 if "%PYTHON%" neq "3.13" set PKGS=%PKGS% ipython
 @rem Install SciPy only if NumPy is not 2.1

--- a/buildscripts/incremental/setup_conda_environment.sh
+++ b/buildscripts/incremental/setup_conda_environment.sh
@@ -88,7 +88,7 @@ elif  [[ $(uname) == Darwin ]]; then
 fi
 
 # Install latest correct build
-$CONDA_INSTALL -c numba/label/dev llvmlite=0.48
+$CONDA_INSTALL -c numba/label/dev llvmlite=0.49
 
 # Install dependencies for building the documentation
 if [ "$BUILD_DOC" == "yes" ]; then $CONDA_INSTALL sphinx docutils sphinx_rtd_theme pygments numpydoc; fi

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -6,7 +6,7 @@ channels:
   - numba/label/dev
 dependencies:
   - python=3.10
-  - llvmlite=0.48
+  - llvmlite=0.49
   - numpy
   - numpydoc
   - setuptools

--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -144,7 +144,7 @@ __all__ += types.__all__
 __all__ += errors.__all__
 
 
-_min_llvmlite_version = (0, 48, 0)
+_min_llvmlite_version = (0, 49, 0)
 _min_llvm_version = (14, 0, 0)
 
 def _ensure_llvm():

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ min_python_version = "3.10"
 max_python_version = "3.15"  # exclusive
 min_numpy_build_version = "1.11"
 min_numpy_run_version = "1.22"
-min_llvmlite_version = "0.48.0dev0"
-max_llvmlite_version = "0.49"
+min_llvmlite_version = "0.49.0dev0"
+max_llvmlite_version = "0.50"
 
 if sys.platform.startswith('linux'):
     # Patch for #2555 to make wheels without libpython


### PR DESCRIPTION
Post release Numba `0.66rc1`, this PR updates llvmlite requirement on Numba to next dev version - `0.49.0dev0`.