### PR TITLE
`win-arm64` support for Numba

### DIFF
--- a/.github/workflows/numba_win-arm64_conda_builder.yml
+++ b/.github/workflows/numba_win-arm64_conda_builder.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CONDA_CHANNEL_LLVMLITE: swap357
+  CONDA_CHANNEL_LLVMLITE: numba/label/dev
   WIN_ARM64_CONDA_CHANNEL: bootstrap-win-arm64-round-2-native
   PYTHON_VERSION: "3.14"
   NUMPY_VERSION: "2.4"

--- a/.github/workflows/numba_win-arm64_conda_builder.yml
+++ b/.github/workflows/numba_win-arm64_conda_builder.yml
@@ -65,7 +65,7 @@ jobs:
           name: llvmlite-win-arm64-py${{ env.PYTHON_VERSION }}
           path: llvmlite_conda
           run-id: ${{ inputs.llvmlite_run_id }}
-          repository: swap357/llvmlite
+          repository: numba/llvmlite
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Numba conda package
@@ -87,7 +87,7 @@ jobs:
             extra_args=()
           fi
 
-          conda-build --debug -c $LLVMLITE_CHANNEL "${extra_args[@]}" \
+          conda-build -c $LLVMLITE_CHANNEL "${extra_args[@]}" \
             -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c defaults \
             --python=${PYTHON_VERSION} \
             --numpy=${NUMPY_VERSION} \
@@ -147,7 +147,7 @@ jobs:
           name: llvmlite-win-arm64-py${{ env.PYTHON_VERSION }}
           path: llvmlite_conda
           run-id: ${{ inputs.llvmlite_run_id }}
-          repository: swap357/llvmlite
+          repository: numba/llvmlite
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download numba artifact

--- a/.github/workflows/numba_win-arm64_conda_builder.yml
+++ b/.github/workflows/numba_win-arm64_conda_builder.yml
@@ -1,0 +1,188 @@
+name: numba_win-arm64_conda_builder
+
+on:
+  schedule:
+    - cron: '15 8 * * 6'  # Saturday 8:15 AM UTC - win-arm64 conda
+  pull_request:
+    paths:
+      - .github/workflows/numba_win-arm64_conda_builder.yml
+      - buildscripts/condarecipe.local/**
+  workflow_dispatch:
+    inputs:
+      llvmlite_run_id:
+        description: 'llvmlite workflow run ID (optional)'
+        required: false
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+env:
+  CONDA_CHANNEL_LLVMLITE: swap357
+  WIN_ARM64_CONDA_CHANNEL: bootstrap-win-arm64-round-2-native
+  PYTHON_VERSION: "3.14"
+  NUMPY_VERSION: "2.4"
+
+jobs:
+  win-arm64-build-conda:
+    name: win-arm64-build-conda (py 3.14, np 2.4)
+    runs-on: windows-11-arm
+    env:
+      EXTRA_CHANNELS: ''
+    defaults:
+      run:
+        shell: bash -elx {0}
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Set up conda-standalone
+        uses: conda-incubator/setup-conda-standalone@00a34805e93a8b640aee5f8a20e8f481ad77e3b4 # v0.1.0
+        with:
+          channel: ${{ env.WIN_ARM64_CONDA_CHANNEL }}
+          conda-standalone-version: 26.3.2.post1
+          destination-directory: ${{ runner.temp }}/conda-standalone
+
+      - name: Install conda-build
+        run: |
+          export CONDA_PREFIX="${RUNNER_TEMP}/conda-base"
+          "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" \
+            -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c main \
+            --yes conda-build
+          echo "CONDA_PREFIX=${CONDA_PREFIX}" >> "${GITHUB_ENV}"
+          echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
+          echo "${CONDA_PREFIX}/Scripts" >> "${GITHUB_PATH}"
+          echo "${CONDA_PREFIX}/Library/bin" >> "${GITHUB_PATH}"
+
+      - name: Download llvmlite Artifact
+        if: ${{ inputs.llvmlite_run_id != '' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: llvmlite-win-arm64-py${{ env.PYTHON_VERSION }}
+          path: llvmlite_conda
+          run-id: ${{ inputs.llvmlite_run_id }}
+          repository: swap357/llvmlite
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Numba conda package
+        run: |
+          CONDA_CHANNEL_DIR="conda_channel_dir"
+          mkdir -p $CONDA_CHANNEL_DIR
+
+          if [ "${{ inputs.llvmlite_run_id }}" != "" ]; then
+            LLVMLITE_CHANNEL="${{ github.workspace }}/llvmlite_conda"
+          elif [ -d ci_artifacts/llvmlite_channel/win-arm64 ]; then
+            LLVMLITE_CHANNEL="${{ github.workspace }}/ci_artifacts/llvmlite_channel"
+          else
+            LLVMLITE_CHANNEL="${{ env.CONDA_CHANNEL_LLVMLITE }}"
+          fi
+
+          if [ -n "${EXTRA_CHANNELS}" ]; then
+            extra_args=(${EXTRA_CHANNELS})
+          else
+            extra_args=()
+          fi
+
+          conda-build --debug -c $LLVMLITE_CHANNEL "${extra_args[@]}" \
+            -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c defaults \
+            --python=${PYTHON_VERSION} \
+            --numpy=${NUMPY_VERSION} \
+            buildscripts/condarecipe.local/ \
+            --output-folder=$CONDA_CHANNEL_DIR \
+            --no-test
+
+      - name: Upload numba conda package
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: numba_win-arm64_conda_py${{ env.PYTHON_VERSION }}
+          path: conda_channel_dir
+          compression-level: 0
+          retention-days: 7
+          if-no-files-found: error
+
+  win-arm64-test:
+    name: win-arm64-test-conda (py 3.14, np 2.4)
+    needs: win-arm64-build-conda
+    runs-on: windows-11-arm
+    env:
+      EXTRA_CHANNELS: ''
+    defaults:
+      run:
+        shell: bash -elx {0}
+
+    steps:
+      - name: Clone repository (ci_artifacts only)
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # sparse checkout so the numba source tree cannot shadow the
+          # installed package during tests
+          sparse-checkout: ci_artifacts
+
+      - name: Set up conda-standalone
+        uses: conda-incubator/setup-conda-standalone@00a34805e93a8b640aee5f8a20e8f481ad77e3b4 # v0.1.0
+        with:
+          channel: ${{ env.WIN_ARM64_CONDA_CHANNEL }}
+          conda-standalone-version: 26.3.2.post1
+          destination-directory: ${{ runner.temp }}/conda-standalone
+
+      - name: Install conda-build
+        run: |
+          export CONDA_PREFIX="${RUNNER_TEMP}/conda-base"
+          "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" \
+            -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c main \
+            --yes conda-build
+          echo "CONDA_PREFIX=${CONDA_PREFIX}" >> "${GITHUB_ENV}"
+          echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
+          echo "${CONDA_PREFIX}/Scripts" >> "${GITHUB_PATH}"
+          echo "${CONDA_PREFIX}/Library/bin" >> "${GITHUB_PATH}"
+
+      - name: Download llvmlite artifact
+        if: ${{ inputs.llvmlite_run_id != '' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: llvmlite-win-arm64-py${{ env.PYTHON_VERSION }}
+          path: llvmlite_conda
+          run-id: ${{ inputs.llvmlite_run_id }}
+          repository: swap357/llvmlite
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download numba artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: numba_win-arm64_conda_py${{ env.PYTHON_VERSION }}
+
+      - name: Run tests
+        env:
+          TESTS_TO_RUN: "numba.tests"
+          NUMBA_ENABLE_CUDASIM: 1
+        run: |
+          if [ "${{ inputs.llvmlite_run_id }}" != "" ]; then
+            LLVMLITE_CHANNEL="${{ github.workspace }}/llvmlite_conda"
+          elif [ -d ci_artifacts/llvmlite_channel/win-arm64 ]; then
+            LLVMLITE_CHANNEL="${{ github.workspace }}/ci_artifacts/llvmlite_channel"
+          else
+            LLVMLITE_CHANNEL="${{ env.CONDA_CHANNEL_LLVMLITE }}"
+          fi
+
+          if [ -n "${EXTRA_CHANNELS}" ]; then
+            extra_args=(${EXTRA_CHANNELS})
+          else
+            extra_args=()
+          fi
+
+          NUMBA_PKG=$(find . -type f -name "numba*.conda" | head -1)
+          if [ -z "$NUMBA_PKG" ]; then
+            echo "ERROR: Could not find numba conda package"
+            exit 1
+          fi
+
+          conda-build -c $LLVMLITE_CHANNEL "${extra_args[@]}" \
+            -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c defaults \
+            --python=${PYTHON_VERSION} \
+            --extra-deps numpy=${NUMPY_VERSION} \
+            --test \
+            "$NUMBA_PKG"

--- a/.github/workflows/numba_win-arm64_conda_builder.yml
+++ b/.github/workflows/numba_win-arm64_conda_builder.yml
@@ -22,11 +22,11 @@ env:
   CONDA_CHANNEL_LLVMLITE: numba/label/dev
   WIN_ARM64_CONDA_CHANNEL: bootstrap-win-arm64-round-2-native
   PYTHON_VERSION: "3.14"
-  NUMPY_VERSION: "2.4"
+  NUMPY_VERSION: "2.3"
 
 jobs:
   win-arm64-build-conda:
-    name: win-arm64-build-conda (py 3.14, np 2.4)
+    name: win-arm64-build-conda (py 3.14, np 2.3)
     runs-on: windows-11-arm
     env:
       EXTRA_CHANNELS: ''
@@ -105,7 +105,7 @@ jobs:
           if-no-files-found: error
 
   win-arm64-test:
-    name: win-arm64-test-conda (py 3.14, np 2.4)
+    name: win-arm64-test-conda (py 3.14, np 2.3)
     needs: win-arm64-build-conda
     runs-on: windows-11-arm
     env:

--- a/.github/workflows/numba_win-arm64_wheel_builder.yml
+++ b/.github/workflows/numba_win-arm64_wheel_builder.yml
@@ -14,6 +14,7 @@ on:
         required: false
         type: string
 
+# Add concurrency control
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
@@ -53,7 +54,7 @@ jobs:
           name: llvmlite-win-arm64-py${{ env.PYTHON_VERSION }}
           path: llvmlite_wheels
           run-id: ${{ inputs.llvmlite_wheel_runid }}
-          repository: swap357/llvmlite
+          repository: numba/llvmlite
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install build dependencies
@@ -68,11 +69,9 @@ jobs:
           echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
           echo "${CONDA_PREFIX}/Scripts" >> "${GITHUB_PATH}"
           if [ "${{ inputs.llvmlite_wheel_runid }}" != "" ]; then
-            python -m pip install llvmlite_wheels/*.whl
-          elif ls ci_artifacts/wheels/llvmlite-*.whl >/dev/null 2>&1; then
-            python -m pip install ci_artifacts/wheels/llvmlite-*.whl
+              python -m pip install llvmlite_wheels/*.whl
           else
-            python -m pip install -i ${{ env.WHEELS_INDEX_URL }} llvmlite
+              python -m pip install -i ${{ env.WHEELS_INDEX_URL }} llvmlite
           fi
           python -m pip install --pre numpy==${NUMPY_VERSION}
           python -m pip install build setuptools wheel
@@ -89,81 +88,15 @@ jobs:
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
           if-no-files-found: error
 
-  win-arm64-debug-sets:
-    name: win-arm64-debug-unicode-sets
-    needs: win-arm64-build
-    runs-on: windows-11-arm
-    defaults:
-      run:
-        shell: bash -el {0}
-
-    steps:
-      - name: Clone repository (ci dirs only)
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          sparse-checkout: |
-            ci_artifacts
-            ci_debug
-
-      - name: Set up conda-standalone
-        uses: conda-incubator/setup-conda-standalone@00a34805e93a8b640aee5f8a20e8f481ad77e3b4 # v0.1.0
-        with:
-          channel: ${{ env.WIN_ARM64_CONDA_CHANNEL }}
-          conda-standalone-version: 26.3.2.post1
-          destination-directory: ${{ runner.temp }}/conda-standalone
-
-      - name: Download Numba wheel artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: numba_win-arm64_wheel_py${{ env.PYTHON_VERSION }}
-          path: dist
-
-      - name: Install test dependencies
-        run: |
-          export CONDA_PREFIX="${RUNNER_TEMP}/conda-base"
-          "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" \
-            -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c main \
-            --yes "python=${PYTHON_VERSION}" pip wheel tbb
-          echo "CONDA_PREFIX=${CONDA_PREFIX}" >> "${GITHUB_ENV}"
-          export PATH="${CONDA_PREFIX}/Scripts:${CONDA_PREFIX}/Library/bin:${CONDA_PREFIX}:${PATH}"
-          echo "${CONDA_PREFIX}/Library/bin" >> "${GITHUB_PATH}"
-          echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
-          echo "${CONDA_PREFIX}/Scripts" >> "${GITHUB_PATH}"
-
-      - name: Run unicode sets reproducer
-        timeout-minutes: 40
-        env:
-          NUMBA_CPU_NAME: generic
-        run: |
-          python -m pip install --pre numpy==${NUMPY_VERSION}
-          python -m pip install ci_artifacts/wheels/llvmlite-*.whl
-          python -m pip install dist/*.whl
-          python ci_debug/repro_unicode_sets.py
-
   win-arm64-test:
-    name: win-arm64-test-wheel (py 3.14, np 2.4.6, shard ${{ matrix.shard }}/6)
+    name: win-arm64-test-wheel (py 3.14, np 2.4.6)
     needs: win-arm64-build
     runs-on: windows-11-arm
-    strategy:
-      fail-fast: false
-      matrix:
-        # azure-style sharding (buildscripts/azure/azure-windows.yml):
-        # runtests -j "index:count" slices the discovered test list
-        shard: [0, 1, 2, 3, 4, 5]
-    env:
-      SHARD_COUNT: 6
     defaults:
       run:
         shell: bash -el {0}
 
     steps:
-      - name: Clone repository (ci_artifacts only)
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          # sparse checkout so the numba source package dir is absent and
-          # cannot shadow the installed wheel when running python -m numba
-          sparse-checkout: ci_artifacts
-
       - name: Set up conda-standalone
         uses: conda-incubator/setup-conda-standalone@00a34805e93a8b640aee5f8a20e8f481ad77e3b4 # v0.1.0
         with:
@@ -184,7 +117,7 @@ jobs:
           name: llvmlite-win-arm64-py${{ env.PYTHON_VERSION }}
           path: llvmlite_wheels
           run-id: ${{ inputs.llvmlite_wheel_runid }}
-          repository: swap357/llvmlite
+          repository: numba/llvmlite
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install test dependencies
@@ -205,16 +138,17 @@ jobs:
           _NUMBA_REDUCED_TESTING: 1
         run: |
           python -m pip install --upgrade pip twine
-          python -m pip install --pre numpy==${NUMPY_VERSION}
+          python -m pip install numpy==${NUMPY_VERSION}
           if [ "${{ inputs.llvmlite_wheel_runid }}" != "" ]; then
-            python -m pip install llvmlite_wheels/*.whl
-          elif ls ci_artifacts/wheels/llvmlite-*.whl >/dev/null 2>&1; then
-            python -m pip install ci_artifacts/wheels/llvmlite-*.whl
+              python -m pip install llvmlite_wheels/*.whl
           else
-            python -m pip install --pre -i ${{ env.WHEELS_INDEX_URL }} llvmlite
+              python -m pip install --pre -i ${{ env.WHEELS_INDEX_URL }} llvmlite
           fi
           python -m twine check dist/*.whl
           python -m pip install dist/*.whl
 
+          # print Numba system information
           python -m numba -s
-          python -m numba.runtests -b -m 4 -j "${{ matrix.shard }}:${SHARD_COUNT}" -- numba.tests
+
+          # run tests
+          python -m numba.runtests -m 4 -v

--- a/.github/workflows/numba_win-arm64_wheel_builder.yml
+++ b/.github/workflows/numba_win-arm64_wheel_builder.yml
@@ -24,11 +24,11 @@ env:
   WHEELS_INDEX_URL: https://pypi.anaconda.org/numba/label/dev/simple
   WIN_ARM64_CONDA_CHANNEL: bootstrap-win-arm64-round-2-native
   PYTHON_VERSION: "3.14"
-  NUMPY_VERSION: "2.4.6"
+  NUMPY_VERSION: "2.3.0"
 
 jobs:
   win-arm64-build:
-    name: win-arm64-build-wheel (py 3.14, np 2.4.6)
+    name: win-arm64-build-wheel (py 3.14, np 2.3.0)
     runs-on: windows-11-arm
     defaults:
       run:
@@ -89,7 +89,7 @@ jobs:
           if-no-files-found: error
 
   win-arm64-test:
-    name: win-arm64-test-wheel (py 3.14, np 2.4.6)
+    name: win-arm64-test-wheel (py 3.14, np 2.3.0)
     needs: win-arm64-build
     runs-on: windows-11-arm
     defaults:

--- a/.github/workflows/numba_win-arm64_wheel_builder.yml
+++ b/.github/workflows/numba_win-arm64_wheel_builder.yml
@@ -20,7 +20,7 @@ concurrency:
 
 env:
   ARTIFACT_RETENTION_DAYS: 7
-  WHEELS_INDEX_URL: https://pypi.anaconda.org/swap357/simple
+  WHEELS_INDEX_URL: https://pypi.anaconda.org/numba/label/dev/simple
   WIN_ARM64_CONDA_CHANNEL: bootstrap-win-arm64-round-2-native
   PYTHON_VERSION: "3.14"
   NUMPY_VERSION: "2.4.6"

--- a/.github/workflows/numba_win-arm64_wheel_builder.yml
+++ b/.github/workflows/numba_win-arm64_wheel_builder.yml
@@ -24,11 +24,11 @@ env:
   WHEELS_INDEX_URL: https://pypi.anaconda.org/numba/label/dev/simple
   WIN_ARM64_CONDA_CHANNEL: bootstrap-win-arm64-round-2-native
   PYTHON_VERSION: "3.14"
-  NUMPY_VERSION: "2.3.0"
+  NUMPY_VERSION: "2.3.5"
 
 jobs:
   win-arm64-build:
-    name: win-arm64-build-wheel (py 3.14, np 2.3.0)
+    name: win-arm64-build-wheel (py 3.14, np 2.3.5)
     runs-on: windows-11-arm
     defaults:
       run:

--- a/.github/workflows/numba_win-arm64_wheel_builder.yml
+++ b/.github/workflows/numba_win-arm64_wheel_builder.yml
@@ -89,7 +89,7 @@ jobs:
           if-no-files-found: error
 
   win-arm64-test:
-    name: win-arm64-test-wheel (py 3.14, np 2.3.0)
+    name: win-arm64-test-wheel (py 3.14, np 2.3.5)
     needs: win-arm64-build
     runs-on: windows-11-arm
     defaults:

--- a/.github/workflows/numba_win-arm64_wheel_builder.yml
+++ b/.github/workflows/numba_win-arm64_wheel_builder.yml
@@ -1,0 +1,220 @@
+name: numba_win-arm64_wheel_builder
+
+on:
+  schedule:
+    - cron: '30 8 * * 6'  # Saturday 8:30 AM UTC - win-arm64 wheel
+  pull_request:
+    paths:
+      - .github/workflows/numba_win-arm64_wheel_builder.yml
+      - setup.py
+  workflow_dispatch:
+    inputs:
+      llvmlite_wheel_runid:
+        description: 'llvmlite wheel workflow run ID (optional)'
+        required: false
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+env:
+  ARTIFACT_RETENTION_DAYS: 7
+  WHEELS_INDEX_URL: https://pypi.anaconda.org/swap357/simple
+  WIN_ARM64_CONDA_CHANNEL: bootstrap-win-arm64-round-2-native
+  PYTHON_VERSION: "3.14"
+  NUMPY_VERSION: "2.4.6"
+
+jobs:
+  win-arm64-build:
+    name: win-arm64-build-wheel (py 3.14, np 2.4.6)
+    runs-on: windows-11-arm
+    defaults:
+      run:
+        shell: bash -el {0}
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Set up conda-standalone
+        uses: conda-incubator/setup-conda-standalone@00a34805e93a8b640aee5f8a20e8f481ad77e3b4 # v0.1.0
+        with:
+          channel: ${{ env.WIN_ARM64_CONDA_CHANNEL }}
+          conda-standalone-version: 26.3.2.post1
+          destination-directory: ${{ runner.temp }}/conda-standalone
+
+      - name: Download llvmlite wheel
+        if: inputs.llvmlite_wheel_runid != ''
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: llvmlite-win-arm64-py${{ env.PYTHON_VERSION }}
+          path: llvmlite_wheels
+          run-id: ${{ inputs.llvmlite_wheel_runid }}
+          repository: swap357/llvmlite
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install build dependencies
+        run: |
+          export CONDA_PREFIX="${RUNNER_TEMP}/conda-build-env"
+          "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" \
+            -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c main \
+            --yes "python=${PYTHON_VERSION}" pip tbb-devel
+          echo "CONDA_PREFIX=${CONDA_PREFIX}" >> "${GITHUB_ENV}"
+          export PATH="${CONDA_PREFIX}/Scripts:${CONDA_PREFIX}/Library/bin:${CONDA_PREFIX}:${PATH}"
+          echo "${CONDA_PREFIX}/Library/bin" >> "${GITHUB_PATH}"
+          echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
+          echo "${CONDA_PREFIX}/Scripts" >> "${GITHUB_PATH}"
+          if [ "${{ inputs.llvmlite_wheel_runid }}" != "" ]; then
+            python -m pip install llvmlite_wheels/*.whl
+          elif ls ci_artifacts/wheels/llvmlite-*.whl >/dev/null 2>&1; then
+            python -m pip install ci_artifacts/wheels/llvmlite-*.whl
+          else
+            python -m pip install -i ${{ env.WHEELS_INDEX_URL }} llvmlite
+          fi
+          python -m pip install --pre numpy==${NUMPY_VERSION}
+          python -m pip install build setuptools wheel
+
+      - name: Build wheel
+        run: python -m build --wheel --no-isolation
+
+      - name: Upload numba wheel
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: numba_win-arm64_wheel_py${{ env.PYTHON_VERSION }}
+          path: dist/*.whl
+          compression-level: 0
+          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+          if-no-files-found: error
+
+  win-arm64-debug-sets:
+    name: win-arm64-debug-unicode-sets
+    needs: win-arm64-build
+    runs-on: windows-11-arm
+    defaults:
+      run:
+        shell: bash -el {0}
+
+    steps:
+      - name: Clone repository (ci dirs only)
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          sparse-checkout: |
+            ci_artifacts
+            ci_debug
+
+      - name: Set up conda-standalone
+        uses: conda-incubator/setup-conda-standalone@00a34805e93a8b640aee5f8a20e8f481ad77e3b4 # v0.1.0
+        with:
+          channel: ${{ env.WIN_ARM64_CONDA_CHANNEL }}
+          conda-standalone-version: 26.3.2.post1
+          destination-directory: ${{ runner.temp }}/conda-standalone
+
+      - name: Download Numba wheel artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: numba_win-arm64_wheel_py${{ env.PYTHON_VERSION }}
+          path: dist
+
+      - name: Install test dependencies
+        run: |
+          export CONDA_PREFIX="${RUNNER_TEMP}/conda-base"
+          "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" \
+            -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c main \
+            --yes "python=${PYTHON_VERSION}" pip wheel tbb
+          echo "CONDA_PREFIX=${CONDA_PREFIX}" >> "${GITHUB_ENV}"
+          export PATH="${CONDA_PREFIX}/Scripts:${CONDA_PREFIX}/Library/bin:${CONDA_PREFIX}:${PATH}"
+          echo "${CONDA_PREFIX}/Library/bin" >> "${GITHUB_PATH}"
+          echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
+          echo "${CONDA_PREFIX}/Scripts" >> "${GITHUB_PATH}"
+
+      - name: Run unicode sets reproducer
+        timeout-minutes: 40
+        env:
+          NUMBA_CPU_NAME: generic
+        run: |
+          python -m pip install --pre numpy==${NUMPY_VERSION}
+          python -m pip install ci_artifacts/wheels/llvmlite-*.whl
+          python -m pip install dist/*.whl
+          python ci_debug/repro_unicode_sets.py
+
+  win-arm64-test:
+    name: win-arm64-test-wheel (py 3.14, np 2.4.6, shard ${{ matrix.shard }}/6)
+    needs: win-arm64-build
+    runs-on: windows-11-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        # azure-style sharding (buildscripts/azure/azure-windows.yml):
+        # runtests -j "index:count" slices the discovered test list
+        shard: [0, 1, 2, 3, 4, 5]
+    env:
+      SHARD_COUNT: 6
+    defaults:
+      run:
+        shell: bash -el {0}
+
+    steps:
+      - name: Clone repository (ci_artifacts only)
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # sparse checkout so the numba source package dir is absent and
+          # cannot shadow the installed wheel when running python -m numba
+          sparse-checkout: ci_artifacts
+
+      - name: Set up conda-standalone
+        uses: conda-incubator/setup-conda-standalone@00a34805e93a8b640aee5f8a20e8f481ad77e3b4 # v0.1.0
+        with:
+          channel: ${{ env.WIN_ARM64_CONDA_CHANNEL }}
+          conda-standalone-version: 26.3.2.post1
+          destination-directory: ${{ runner.temp }}/conda-standalone
+
+      - name: Download Numba wheel artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: numba_win-arm64_wheel_py${{ env.PYTHON_VERSION }}
+          path: dist
+
+      - name: Download llvmlite wheel
+        if: inputs.llvmlite_wheel_runid != ''
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: llvmlite-win-arm64-py${{ env.PYTHON_VERSION }}
+          path: llvmlite_wheels
+          run-id: ${{ inputs.llvmlite_wheel_runid }}
+          repository: swap357/llvmlite
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install test dependencies
+        run: |
+          export CONDA_PREFIX="${RUNNER_TEMP}/conda-base"
+          "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" \
+            -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c main \
+            --yes "python=${PYTHON_VERSION}" pip wheel tbb
+          echo "CONDA_PREFIX=${CONDA_PREFIX}" >> "${GITHUB_ENV}"
+          export PATH="${CONDA_PREFIX}/Scripts:${CONDA_PREFIX}/Library/bin:${CONDA_PREFIX}:${PATH}"
+          echo "${CONDA_PREFIX}/Library/bin" >> "${GITHUB_PATH}"
+          echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
+          echo "${CONDA_PREFIX}/Scripts" >> "${GITHUB_PATH}"
+
+      - name: Validate and test wheel
+        env:
+          NUMBA_CPU_NAME: generic
+          _NUMBA_REDUCED_TESTING: 1
+        run: |
+          python -m pip install --upgrade pip twine
+          python -m pip install --pre numpy==${NUMPY_VERSION}
+          if [ "${{ inputs.llvmlite_wheel_runid }}" != "" ]; then
+            python -m pip install llvmlite_wheels/*.whl
+          elif ls ci_artifacts/wheels/llvmlite-*.whl >/dev/null 2>&1; then
+            python -m pip install ci_artifacts/wheels/llvmlite-*.whl
+          else
+            python -m pip install --pre -i ${{ env.WHEELS_INDEX_URL }} llvmlite
+          fi
+          python -m twine check dist/*.whl
+          python -m pip install dist/*.whl
+
+          python -m numba -s
+          python -m numba.runtests -b -m 4 -j "${{ matrix.shard }}:${SHARD_COUNT}" -- numba.tests

--- a/buildscripts/condarecipe.local/bld.bat
+++ b/buildscripts/condarecipe.local/bld.bat
@@ -7,7 +7,11 @@ if not exist "%VSINSTALLDIR%" (
   echo "Could not find VS 2022"
   exit /B 1
 )
-call "%VSINSTALLDIR%VC\Auxiliary\Build\vcvarsall.bat" x64
+if "%ARCH%"=="arm64" (
+  call "%VSINSTALLDIR%VC\Auxiliary\Build\vcvarsall.bat" ARM64
+) else (
+  call "%VSINSTALLDIR%VC\Auxiliary\Build\vcvarsall.bat" x64
+)
 
 %PYTHON% setup.py build install --single-version-externally-managed --record=record.txt
 

--- a/buildscripts/condarecipe.local/conda_build_config.yaml
+++ b/buildscripts/condarecipe.local/conda_build_config.yaml
@@ -13,10 +13,10 @@ fortran_compiler_version:   # [linux]
   - 7                       # [linux and (x86_64 or ppc64le)]
   - 11                      # [linux and aarch64]
 
-c_compiler:                 # [win and arm64]
-  - vs2022                   # [win and arm64]
-cxx_compiler:               # [win and arm64]
-  - vs2022                   # [win and arm64]
+c_compiler:                 # [win]
+  - vs2022                   # [win]
+cxx_compiler:               # [win]
+  - vs2022                   # [win]
 
 target_platform:
   - win-64               # [win and not arm64]

--- a/buildscripts/condarecipe.local/conda_build_config.yaml
+++ b/buildscripts/condarecipe.local/conda_build_config.yaml
@@ -12,3 +12,12 @@ cxx_compiler_version:       # [linux or osx]
 fortran_compiler_version:   # [linux]
   - 7                       # [linux and (x86_64 or ppc64le)]
   - 11                      # [linux and aarch64]
+
+c_compiler:                 # [win and arm64]
+  - vs2022                   # [win and arm64]
+cxx_compiler:               # [win and arm64]
+  - vs2022                   # [win and arm64]
+
+target_platform:
+  - win-64               # [win and not arm64]
+  - win-arm64            # [win and arm64]

--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -26,6 +26,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - vs2022_{{ target_platform }}                      # [win and arm64]
     # OpenMP headers from llvm needed for OSX.
     - llvm-openmp={{ c_compiler_version }}              # [osx]
   host:
@@ -77,9 +78,9 @@ test:
     - llvm-openmp              # [osx]
     # This is for driving gdb tests
     - pexpect                  # [linux64]
-    # For testing ipython. At the time of writing ipykernel was not available
-    # for Python 3.12.
-    - ipykernel                # [not py==312]
+    # For testing ipython. ipykernel is not available on Python 3.12, or on
+    # win-arm64 (bootstrap channel).
+    - ipykernel                # [not (py==312 or (win and arm64))]
     # For memory monitoring
     - psutil
     # Need these for AOT. Do not init msvc as it may not be present

--- a/docs/upcoming_changes/10644.infrastructure.rst
+++ b/docs/upcoming_changes/10644.infrastructure.rst
@@ -1,0 +1,8 @@
+Add Windows on ARM64 CI and build support
+-----------------------------------------
+
+Added GitHub Actions workflows to build and test Numba conda packages and
+wheels on ``win-arm64`` runners. The conda recipe now supports ARM64
+Windows builds with VS2022. Several tests that trigger an LLVM 22
+AArch64 frame lowering assertion on ``win-arm64`` are skipped pending
+fix (`llvm/llvm-project#204060 <https://github.com/llvm/llvm-project/issues/204060>`_).

--- a/numba/core/typing/ctypes_utils.py
+++ b/numba/core/typing/ctypes_utils.py
@@ -4,6 +4,7 @@ Support for typing ctypes function pointers.
 
 
 import ctypes
+import platform
 import sys
 
 from numba.core import types, config
@@ -116,8 +117,9 @@ def make_function_type(cfnptr):
     # platforms, explicit conversion to a int64 should match.
     if cret == types.voidptr:
         cret = types.uintp
-    if sys.platform == 'win32' and not cfnptr._flags_ & ctypes._FUNCFLAG_CDECL:
-        # 'stdcall' calling convention under Windows
+    if (sys.platform == 'win32' and platform.machine() != 'ARM64'
+            and not cfnptr._flags_ & ctypes._FUNCFLAG_CDECL):
+        # 'stdcall' calling convention under x86_64 Windows.
         cconv = 'x86_stdcallcc'
     else:
         # Default C calling convention

--- a/numba/core/typing/ctypes_utils.py
+++ b/numba/core/typing/ctypes_utils.py
@@ -117,7 +117,7 @@ def make_function_type(cfnptr):
     # platforms, explicit conversion to a int64 should match.
     if cret == types.voidptr:
         cret = types.uintp
-    if (sys.platform == 'win32' and platform.machine() != 'ARM64'
+    if (sys.platform == 'win32' and platform.machine() == 'AMD64'
             and not cfnptr._flags_ & ctypes._FUNCFLAG_CDECL):
         # 'stdcall' calling convention under x86_64 Windows.
         cconv = 'x86_stdcallcc'

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -229,6 +229,8 @@ skip_macos_fenv_errors = unittest.skipIf(IS_MACOS,
     "fenv.h-like functionality unreliable on macOS")
 IS_MACOS_ARM64 = IS_MACOS and _uname.machine == 'arm64'
 IS_WIN_ARM64 = _uname.system == 'Windows' and _uname.machine == 'ARM64'
+skip_if_win_arm64 = unittest.skipIf(IS_WIN_ARM64,
+                                    "Not supported on Windows arm64")
 
 try:
     import scipy.linalg.cython_lapack

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -228,6 +228,7 @@ IS_MACOS = _uname.system == 'Darwin'
 skip_macos_fenv_errors = unittest.skipIf(IS_MACOS,
     "fenv.h-like functionality unreliable on macOS")
 IS_MACOS_ARM64 = IS_MACOS and _uname.machine == 'arm64'
+IS_WIN_ARM64 = _uname.system == 'Windows' and _uname.machine == 'ARM64'
 
 try:
     import scipy.linalg.cython_lapack

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -229,8 +229,13 @@ skip_macos_fenv_errors = unittest.skipIf(IS_MACOS,
     "fenv.h-like functionality unreliable on macOS")
 IS_MACOS_ARM64 = IS_MACOS and _uname.machine == 'arm64'
 IS_WIN_ARM64 = _uname.system == 'Windows' and _uname.machine == 'ARM64'
-skip_if_win_arm64 = unittest.skipIf(IS_WIN_ARM64,
-                                    "Not supported on Windows arm64")
+# LLVM 22 AArch64 FrameLowering assertion on win-arm64 when >=40 LLVM args
+# are passed (llvm/llvm-project#204060).
+skip_win_arm64_40args_problem = unittest.skipIf(
+    IS_WIN_ARM64,
+    "LLVM >=40-arg calls crash AArch64 frame lowering on win-arm64 "
+    "(llvm/llvm-project#204060)",
+)
 
 try:
     import scipy.linalg.cython_lapack

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -4,7 +4,8 @@ import numpy as np
 
 from numba import jit, njit, typeof, types
 from numba.np.numpy_support import numpy_version
-from numba.tests.support import TestCase, MemoryLeakMixin, tag, skip_if_numpy_2
+from numba.tests.support import (TestCase, MemoryLeakMixin, tag,
+                                 skip_if_numpy_2, skip_if_win_arm64)
 import unittest
 
 
@@ -728,7 +729,6 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
         a = a.flatten().tolist()
         q = q.flatten().tolist()
         check(a, q)
-        check(tuple(a), tuple(q))
 
         a = self.random.choice([1, 2, 3, 4], 10)
         q = np.linspace(0, q_upper_bound, 5)
@@ -761,6 +761,27 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
         a = np.array([2, 3, 4, 1])
         cfunc(a, [q_upper_bound / 2])
         np.testing.assert_equal(a, np.array([2, 3, 4, 1]))
+
+    def check_percentile_and_quantile_tuple_input(self, pyfunc, q_upper_bound):
+        cfunc = jit(nopython=True)(pyfunc)
+
+        def check(a, q, abs_tol=1e-12):
+            expected = pyfunc(a, q)
+            got = cfunc(a, q)
+            # NOTE: inf/nan is not checked, seems to be susceptible to upstream
+            # changes
+            finite = np.isfinite(expected)
+            if np.all(finite):
+                self.assertPreciseEqual(got, expected, abs_tol=abs_tol)
+            else:
+                self.assertPreciseEqual(got[finite], expected[finite],
+                                        abs_tol=abs_tol)
+
+        a = self.random.randn(27).reshape(3, 3, 3)
+        q = np.linspace(0, q_upper_bound, 14)[::-1]
+        a = a.flatten().tolist()
+        q = q.flatten().tolist()
+        check(tuple(a), tuple(q))
 
     def check_percentile_edge_cases(self, pyfunc, q_upper_bound=100):
         cfunc = jit(nopython=True)(pyfunc)
@@ -883,6 +904,31 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
         self.check_percentile_and_quantile(pyfunc, q_upper_bound=1)
         self.check_percentile_edge_cases(pyfunc, q_upper_bound=1)
         self.check_quantile_exceptions(pyfunc)
+
+    # tuple input crashes LLVM 22 AArch64 frame lowering on win-arm64
+    # (llvm/llvm-project#204060); extracted from check_percentile_and_quantile
+    # so it can be skipped on that target.
+    @skip_if_win_arm64
+    def test_percentile_tuple_input(self):
+        pyfunc = array_percentile_global
+        self.check_percentile_and_quantile_tuple_input(pyfunc,
+                                                        q_upper_bound=100)
+
+    @skip_if_win_arm64
+    def test_nanpercentile_tuple_input(self):
+        pyfunc = array_nanpercentile_global
+        self.check_percentile_and_quantile_tuple_input(pyfunc,
+                                                        q_upper_bound=100)
+
+    @skip_if_win_arm64
+    def test_quantile_tuple_input(self):
+        pyfunc = array_quantile_global
+        self.check_percentile_and_quantile_tuple_input(pyfunc, q_upper_bound=1)
+
+    @skip_if_win_arm64
+    def test_nanquantile_tuple_input(self):
+        pyfunc = array_nanquantile_global
+        self.check_percentile_and_quantile_tuple_input(pyfunc, q_upper_bound=1)
 
     def test_nanmedian_basic(self):
         pyfunc = array_nanmedian_global

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -5,7 +5,7 @@ import numpy as np
 from numba import jit, njit, typeof, types
 from numba.np.numpy_support import numpy_version
 from numba.tests.support import (TestCase, MemoryLeakMixin, tag,
-                                 skip_if_numpy_2, skip_if_win_arm64)
+                                 skip_if_numpy_2, skip_win_arm64_40args_problem)
 import unittest
 
 
@@ -908,24 +908,24 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
     # tuple input crashes LLVM 22 AArch64 frame lowering on win-arm64
     # (llvm/llvm-project#204060); extracted from check_percentile_and_quantile
     # so it can be skipped on that target.
-    @skip_if_win_arm64
+    @skip_win_arm64_40args_problem
     def test_percentile_tuple_input(self):
         pyfunc = array_percentile_global
         self.check_percentile_and_quantile_tuple_input(pyfunc,
                                                         q_upper_bound=100)
 
-    @skip_if_win_arm64
+    @skip_win_arm64_40args_problem
     def test_nanpercentile_tuple_input(self):
         pyfunc = array_nanpercentile_global
         self.check_percentile_and_quantile_tuple_input(pyfunc,
                                                         q_upper_bound=100)
 
-    @skip_if_win_arm64
+    @skip_win_arm64_40args_problem
     def test_quantile_tuple_input(self):
         pyfunc = array_quantile_global
         self.check_percentile_and_quantile_tuple_input(pyfunc, q_upper_bound=1)
 
-    @skip_if_win_arm64
+    @skip_win_arm64_40args_problem
     def test_nanquantile_tuple_input(self):
         pyfunc = array_nanquantile_global
         self.check_percentile_and_quantile_tuple_input(pyfunc, q_upper_bound=1)

--- a/numba/tests/test_interpreter.py
+++ b/numba/tests/test_interpreter.py
@@ -10,6 +10,7 @@ from numba.tests.support import (
     TestCase,
     MemoryLeakMixin,
     skip_unless_py10_or_later,
+    skip_if_win_arm64,
 )
 
 
@@ -186,6 +187,9 @@ class TestCallFunctionExPeepHole(MemoryLeakMixin, TestCase):
         b = cfunc(*total_args)
         self.assertEqual(a, b)
 
+    # >= 40-arg calls crash LLVM 22 AArch64 frame lowering on win-arm64
+    # (llvm/llvm-project#204060).
+    @skip_if_win_arm64
     @skip_unless_py10_or_later
     def test_small_args_small_kws(self):
         """
@@ -202,6 +206,7 @@ class TestCallFunctionExPeepHole(MemoryLeakMixin, TestCase):
         b = cfunc(*total_args)
         self.assertEqual(a, b)
 
+    @skip_if_win_arm64
     @skip_unless_py10_or_later
     def test_small_args_large_kws(self):
         """
@@ -218,6 +223,7 @@ class TestCallFunctionExPeepHole(MemoryLeakMixin, TestCase):
         b = cfunc(*total_args)
         self.assertEqual(a, b)
 
+    @skip_if_win_arm64
     @skip_unless_py10_or_later
     def test_large_args_small_kws(self):
         """
@@ -234,6 +240,7 @@ class TestCallFunctionExPeepHole(MemoryLeakMixin, TestCase):
         b = cfunc(*total_args)
         self.assertEqual(a, b)
 
+    @skip_if_win_arm64
     @skip_unless_py10_or_later
     def test_large_args_large_kws(self):
         """
@@ -395,6 +402,7 @@ class TestCallFunctionExPeepHole(MemoryLeakMixin, TestCase):
             str(raises.exception)
         )
 
+    @skip_if_win_arm64
     @skip_unless_py10_or_later
     def test_large_args_noninlined_controlflow(self):
         """

--- a/numba/tests/test_interpreter.py
+++ b/numba/tests/test_interpreter.py
@@ -10,7 +10,7 @@ from numba.tests.support import (
     TestCase,
     MemoryLeakMixin,
     skip_unless_py10_or_later,
-    skip_if_win_arm64,
+    skip_win_arm64_40args_problem,
 )
 
 
@@ -189,7 +189,7 @@ class TestCallFunctionExPeepHole(MemoryLeakMixin, TestCase):
 
     # >= 40-arg calls crash LLVM 22 AArch64 frame lowering on win-arm64
     # (llvm/llvm-project#204060).
-    @skip_if_win_arm64
+    @skip_win_arm64_40args_problem
     @skip_unless_py10_or_later
     def test_small_args_small_kws(self):
         """
@@ -206,7 +206,7 @@ class TestCallFunctionExPeepHole(MemoryLeakMixin, TestCase):
         b = cfunc(*total_args)
         self.assertEqual(a, b)
 
-    @skip_if_win_arm64
+    @skip_win_arm64_40args_problem
     @skip_unless_py10_or_later
     def test_small_args_large_kws(self):
         """
@@ -223,7 +223,7 @@ class TestCallFunctionExPeepHole(MemoryLeakMixin, TestCase):
         b = cfunc(*total_args)
         self.assertEqual(a, b)
 
-    @skip_if_win_arm64
+    @skip_win_arm64_40args_problem
     @skip_unless_py10_or_later
     def test_large_args_small_kws(self):
         """
@@ -240,7 +240,7 @@ class TestCallFunctionExPeepHole(MemoryLeakMixin, TestCase):
         b = cfunc(*total_args)
         self.assertEqual(a, b)
 
-    @skip_if_win_arm64
+    @skip_win_arm64_40args_problem
     @skip_unless_py10_or_later
     def test_large_args_large_kws(self):
         """
@@ -402,7 +402,7 @@ class TestCallFunctionExPeepHole(MemoryLeakMixin, TestCase):
             str(raises.exception)
         )
 
-    @skip_if_win_arm64
+    @skip_win_arm64_40args_problem
     @skip_unless_py10_or_later
     def test_large_args_noninlined_controlflow(self):
         """

--- a/numba/tests/test_mixed_tuple_unroller.py
+++ b/numba/tests/test_mixed_tuple_unroller.py
@@ -2,7 +2,8 @@ from collections import namedtuple
 import numpy as np
 
 from numba.tests.support import (TestCase, MemoryLeakMixin,
-                                 skip_parfors_unsupported, captured_stdout)
+                                 skip_parfors_unsupported, captured_stdout,
+                                 skip_if_win_arm64)
 from numba import njit, typed, literal_unroll, prange
 from numba.core import types, errors, ir
 from numba.testing import unittest
@@ -578,6 +579,9 @@ class TestMixedTupleUnroll(MemoryLeakMixin, TestCase):
         tup = ('a', 12)
         self.assertEqual(foo(tup), foo.py_func(tup))
 
+    # >= 40-arg calls crash LLVM 22 AArch64 frame lowering on win-arm64
+    # (llvm/llvm-project#204060).
+    @skip_if_win_arm64
     def test_07(self):
         # A mix bag of stuff as an arg to a function that unifies as `intp`.
         @njit
@@ -801,6 +805,7 @@ class TestMixedTupleUnroll(MemoryLeakMixin, TestCase):
 
         self.assertEqual(foo(), foo.py_func())
 
+    @skip_if_win_arm64
     def test_15(self):
         # mixed tuple unroll cannot return derivative of the induction var
 

--- a/numba/tests/test_mixed_tuple_unroller.py
+++ b/numba/tests/test_mixed_tuple_unroller.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from numba.tests.support import (TestCase, MemoryLeakMixin,
                                  skip_parfors_unsupported, captured_stdout,
-                                 skip_if_win_arm64)
+                                 skip_win_arm64_40args_problem)
 from numba import njit, typed, literal_unroll, prange
 from numba.core import types, errors, ir
 from numba.testing import unittest
@@ -581,7 +581,7 @@ class TestMixedTupleUnroll(MemoryLeakMixin, TestCase):
 
     # >= 40-arg calls crash LLVM 22 AArch64 frame lowering on win-arm64
     # (llvm/llvm-project#204060).
-    @skip_if_win_arm64
+    @skip_win_arm64_40args_problem
     def test_07(self):
         # A mix bag of stuff as an arg to a function that unifies as `intp`.
         @njit
@@ -805,7 +805,9 @@ class TestMixedTupleUnroll(MemoryLeakMixin, TestCase):
 
         self.assertEqual(foo(), foo.py_func())
 
-    @skip_if_win_arm64
+    # >= 40-arg calls crash LLVM 22 AArch64 frame lowering on win-arm64
+    # (llvm/llvm-project#204060).
+    @skip_win_arm64_40args_problem
     def test_15(self):
         # mixed tuple unroll cannot return derivative of the induction var
 

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -22,6 +22,7 @@ from numba.tests.support import (TestCase, MemoryLeakMixin,
                                  needs_blas, run_in_subprocess,
                                  skip_if_numpy_2, IS_NUMPY_2,
                                  IS_MACOS_ARM64, IS_WIN_ARM64,
+                                 skip_if_win_arm64,
                                  REDUCED_TESTING,
                                  skip_if_reduced_testing)
 import unittest
@@ -2656,6 +2657,16 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         for arr in a, (), np.array([]):
             check(arr)
 
+    def _check_partition_tuple_input(self, pyfunc):
+        cfunc = jit(nopython=True)(pyfunc)
+        d = np.arange(47)[::-1]
+        a = tuple(d.tolist())
+        self.assertEqual(cfunc(a, 6)[6], 6)
+        self.assertEqual(cfunc(a, 16)[16], 16)
+        self.assertPreciseEqual(cfunc(a, -6), cfunc(a, 41))
+        self.assertPreciseEqual(cfunc(a, -16), cfunc(a, 31))
+        self.partition_sanity_check(pyfunc, cfunc, d, -16)
+
     def test_partition_basic(self):
         # inspired by the test of the same name in:
         # https://github.com/numpy/numpy/blob/043a840/numpy/core/tests/test_multiarray.py    # noqa: E501
@@ -2700,9 +2711,9 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             self.assertEqual(cfunc(d, k)[k], k)
             self.partition_sanity_check(pyfunc, cfunc, d, k)
 
-        # rsorted, with input flavours: array, list and tuple
+        # rsorted, with input flavours: array and list
         d = np.arange(47)[::-1]
-        for a in d, d.tolist(), tuple(d.tolist()):
+        for a in d, d.tolist():
             self.assertEqual(cfunc(a, 6)[6], 6)
             self.assertEqual(cfunc(a, 16)[16], 16)
             self.assertPreciseEqual(cfunc(a, -6), cfunc(a, 41))
@@ -2771,6 +2782,12 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
                 # sanity check
                 self.partition_sanity_check(pyfunc, cfunc, d, i)
 
+    # large tuple input crashes LLVM 22 AArch64 frame lowering on win-arm64
+    # (llvm/llvm-project#204060)
+    @skip_if_win_arm64
+    def test_partition_tuple_input(self):
+        self._check_partition_tuple_input(partition)
+
     def test_argpartition_basic(self):
         # inspired by the test of the same name in:
         # https://github.com/numpy/numpy/blob/043a840/numpy/core/tests/test_multiarray.py    # noqa: E501
@@ -2817,9 +2834,9 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             self.assertEqual(cfunc(d, k)[k], k)
             self.partition_sanity_check(pyfunc, cfunc, d, k)
 
-        # rsorted, with input flavours: array, list and tuple
+        # rsorted, with input flavours: array and list
         d = np.arange(47)[::-1]
-        for a in d, d.tolist(), tuple(d.tolist()):
+        for a in d, d.tolist():
             self.assertEqual(cfunc(a, 6)[6], 40)
             self.assertEqual(cfunc(a, 16)[16], 30)
             self.assertPreciseEqual(cfunc(a, -6), cfunc(a, 41))
@@ -2879,6 +2896,22 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
                 np.testing.assert_array_less(p[i], p[i + 1:])
                 # sanity check
                 self.argpartition_sanity_check(pyfunc, cfunc, d, i)
+
+    def _check_argpartition_tuple_input(self, pyfunc):
+        cfunc = jit(nopython=True)(pyfunc)
+        d = np.arange(47)[::-1]
+        a = tuple(d.tolist())
+        self.assertEqual(cfunc(a, 6)[6], 40)
+        self.assertEqual(cfunc(a, 16)[16], 30)
+        self.assertPreciseEqual(cfunc(a, -6), cfunc(a, 41))
+        self.assertPreciseEqual(cfunc(a, -16), cfunc(a, 31))
+        self.argpartition_sanity_check(pyfunc, cfunc, d, -16)
+
+    # large tuple input crashes LLVM 22 AArch64 frame lowering on win-arm64
+    # (llvm/llvm-project#204060)
+    @skip_if_win_arm64
+    def test_argpartition_tuple_input(self):
+        self._check_argpartition_tuple_input(argpartition)
 
     def assert_partitioned(self, pyfunc, cfunc, d, kth):
         prev = 0
@@ -3845,10 +3878,8 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             yield a, 2, 0
             yield a, [1, 4, 72]
             yield list(a), [1, 4, 72]
-            yield tuple(a), [1, 4, 72]
             yield a, [1, 4, 72], 0
             yield list(a), [1, 4, 72], 0
-            yield tuple(a), [1, 4, 72], 0
 
             a = np.arange(64).reshape(4, 4, 4)
             yield a, 2
@@ -3892,6 +3923,16 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
 
             np.testing.assert_equal(expected, list(got))
 
+    def _check_split_tuple_input(self, func):
+        pyfunc = func
+        cfunc = jit(nopython=True)(pyfunc)
+        a = np.arange(100)
+        for args in ((tuple(a), [1, 4, 72]),
+                     (tuple(a), [1, 4, 72], 0)):
+            expected = pyfunc(*args)
+            got = cfunc(*args)
+            np.testing.assert_equal(expected, list(got))
+
     def _check_array_split(self, func):
         # array_split specific checks, mainly dealing with `int`s
         pyfunc = func
@@ -3928,6 +3969,16 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             njit(split)(np.ones(5), [3], axis=-3)
         self.assertIn("np.split: Argument axis out of bounds",
                       str(raises.exception))
+
+    # large tuple input crashes LLVM 22 AArch64 frame lowering on win-arm64
+    # (llvm/llvm-project#204060); extracted from _check_split.
+    @skip_if_win_arm64
+    def test_split_tuple_input(self):
+        self._check_split_tuple_input(split)
+
+    @skip_if_win_arm64
+    def test_array_split_tuple_input(self):
+        self._check_split_tuple_input(array_split)
 
     def test_vhdsplit_basic(self):
         # split and array_split have more comprehensive tests of splitting.

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -21,7 +21,8 @@ from numba.np.extensions import cross2d
 from numba.tests.support import (TestCase, MemoryLeakMixin,
                                  needs_blas, run_in_subprocess,
                                  skip_if_numpy_2, IS_NUMPY_2,
-                                 IS_MACOS_ARM64, REDUCED_TESTING,
+                                 IS_MACOS_ARM64, IS_WIN_ARM64,
+                                 REDUCED_TESTING,
                                  skip_if_reduced_testing)
 import unittest
 
@@ -4971,7 +4972,8 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             got = cfunc(x, xp, fp)
             self.assertPreciseEqual(expected, got, abs_tol=atol)
 
-    @unittest.skipIf(IS_NUMPY_2 and IS_MACOS_ARM64, "NEP 50 interaction issue.")
+    @unittest.skipIf(IS_NUMPY_2 and (IS_MACOS_ARM64 or IS_WIN_ARM64),
+                     "NEP 50 interaction issue.")
     def test_interp_complex_stress_tests(self):
         pyfunc = interp
         cfunc = jit(nopython=True)(pyfunc)

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -22,7 +22,7 @@ from numba.tests.support import (TestCase, MemoryLeakMixin,
                                  needs_blas, run_in_subprocess,
                                  skip_if_numpy_2, IS_NUMPY_2,
                                  IS_MACOS_ARM64, IS_WIN_ARM64,
-                                 skip_if_win_arm64,
+                                 skip_win_arm64_40args_problem,
                                  REDUCED_TESTING,
                                  skip_if_reduced_testing)
 import unittest
@@ -2784,7 +2784,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
 
     # large tuple input crashes LLVM 22 AArch64 frame lowering on win-arm64
     # (llvm/llvm-project#204060)
-    @skip_if_win_arm64
+    @skip_win_arm64_40args_problem
     def test_partition_tuple_input(self):
         self._check_partition_tuple_input(partition)
 
@@ -2909,7 +2909,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
 
     # large tuple input crashes LLVM 22 AArch64 frame lowering on win-arm64
     # (llvm/llvm-project#204060)
-    @skip_if_win_arm64
+    @skip_win_arm64_40args_problem
     def test_argpartition_tuple_input(self):
         self._check_argpartition_tuple_input(argpartition)
 
@@ -3972,11 +3972,11 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
 
     # large tuple input crashes LLVM 22 AArch64 frame lowering on win-arm64
     # (llvm/llvm-project#204060); extracted from _check_split.
-    @skip_if_win_arm64
+    @skip_win_arm64_40args_problem
     def test_split_tuple_input(self):
         self._check_split_tuple_input(split)
 
-    @skip_if_win_arm64
+    @skip_win_arm64_40args_problem
     def test_array_split_tuple_input(self):
         self._check_split_tuple_input(array_split)
 

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -48,7 +48,7 @@ from numba.tests.support import (TestCase, captured_stdout, MemoryLeakMixin,
                                  needs_lapack, disabled_test, skip_unless_scipy,
                                  needs_subprocess,
                                  skip_ppc64le_invalid_ctr_loop,
-                                 skip_if_win_arm64)
+                                 skip_win_arm64_40args_problem)
 from numba.core.extending import register_jitable
 from numba.core.bytecode import _fix_LOAD_GLOBAL_arg
 from numba.core import utils
@@ -1325,7 +1325,7 @@ class TestParfors(TestParforsBase):
 
     # crashes LLVM 22 AArch64 frame lowering on win-arm64
     # (llvm/llvm-project#204060).
-    @skip_if_win_arm64
+    @skip_win_arm64_40args_problem
     def test_arraymap(self):
         def test_impl(a, x, y):
             return a * x + y
@@ -1609,7 +1609,7 @@ class TestParfors(TestParforsBase):
 
     # crashes LLVM 22 AArch64 frame lowering on win-arm64
     # (llvm/llvm-project#204060).
-    @skip_if_win_arm64
+    @skip_win_arm64_40args_problem
     @needs_blas
     def test_parfor_generate_fuse(self):
         # issue #2857
@@ -1967,7 +1967,7 @@ class TestParfors(TestParforsBase):
 
     # crashes LLVM 22 AArch64 frame lowering on win-arm64
     # (llvm/llvm-project#204060).
-    @skip_if_win_arm64
+    @skip_win_arm64_40args_problem
     def test_high_dimension1(self):
         # issue6749
         def test_impl(x):

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -47,7 +47,8 @@ from numba.tests.support import (TestCase, captured_stdout, MemoryLeakMixin,
                                  skip_parfors_unsupported, _32bit, needs_blas,
                                  needs_lapack, disabled_test, skip_unless_scipy,
                                  needs_subprocess,
-                                 skip_ppc64le_invalid_ctr_loop)
+                                 skip_ppc64le_invalid_ctr_loop,
+                                 skip_if_win_arm64)
 from numba.core.extending import register_jitable
 from numba.core.bytecode import _fix_LOAD_GLOBAL_arg
 from numba.core import utils
@@ -1322,6 +1323,9 @@ class TestParforsUnsupported(TestCase):
 class TestParfors(TestParforsBase):
     """ Tests cpython, reduction and various parfors features"""
 
+    # crashes LLVM 22 AArch64 frame lowering on win-arm64
+    # (llvm/llvm-project#204060).
+    @skip_if_win_arm64
     def test_arraymap(self):
         def test_impl(a, x, y):
             return a * x + y
@@ -1603,6 +1607,9 @@ class TestParfors(TestParforsBase):
         out = np.ones(1)
         self.check(test_impl, out)
 
+    # crashes LLVM 22 AArch64 frame lowering on win-arm64
+    # (llvm/llvm-project#204060).
+    @skip_if_win_arm64
     @needs_blas
     def test_parfor_generate_fuse(self):
         # issue #2857
@@ -1958,6 +1965,9 @@ class TestParfors(TestParforsBase):
         x = np.ones((3,3))
         self.check(test_impl, x)
 
+    # crashes LLVM 22 AArch64 frame lowering on win-arm64
+    # (llvm/llvm-project#204060).
+    @skip_if_win_arm64
     def test_high_dimension1(self):
         # issue6749
         def test_impl(x):

--- a/numba/tests/test_parfors_passes.py
+++ b/numba/tests/test_parfors_passes.py
@@ -20,7 +20,8 @@ from numba.core import (
     errors
 )
 from numba.core.registry import cpu_target
-from numba.tests.support import (TestCase, is_parfors_unsupported)
+from numba.tests.support import (TestCase, is_parfors_unsupported,
+                                 skip_if_win_arm64)
 
 
 class MyPipeline(object):
@@ -307,6 +308,9 @@ class TestConvertNumpyPass(BaseTest):
 
         self.run_parallel(test_impl, *args)
 
+    # crashes LLVM 22 AArch64 frame lowering on win-arm64
+    # (llvm/llvm-project#204060).
+    @skip_if_win_arm64
     def test_numpy_arrayexpr_boardcast(self):
         def test_impl(a, b):
             return a + b + np.array(1)

--- a/numba/tests/test_parfors_passes.py
+++ b/numba/tests/test_parfors_passes.py
@@ -21,7 +21,7 @@ from numba.core import (
 )
 from numba.core.registry import cpu_target
 from numba.tests.support import (TestCase, is_parfors_unsupported,
-                                 skip_if_win_arm64)
+                                 skip_win_arm64_40args_problem)
 
 
 class MyPipeline(object):
@@ -310,7 +310,7 @@ class TestConvertNumpyPass(BaseTest):
 
     # crashes LLVM 22 AArch64 frame lowering on win-arm64
     # (llvm/llvm-project#204060).
-    @skip_if_win_arm64
+    @skip_win_arm64_40args_problem
     def test_numpy_arrayexpr_boardcast(self):
         def test_impl(a, b):
             return a + b + np.array(1)

--- a/numba/tests/test_sets.py
+++ b/numba/tests/test_sets.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from numba import jit, njit
 from numba.tests.support import (TestCase, enable_pyobj_flags, MemoryLeakMixin,
-                                 compile_function, skip_if_win_arm64)
+                                 compile_function, skip_win_arm64_40args_problem)
 
 
 Point = namedtuple('Point', ('a', 'b'))
@@ -626,15 +626,15 @@ class TestUnicodeSets(TestSets):
 
     # UniTuple[unicode, 3] unpacks to >=40 LLVM args; crashes frame lowering
     # on win-arm64 (llvm/llvm-project#204060).
-    @skip_if_win_arm64
+    @skip_win_arm64_40args_problem
     def test_isdisjoint(self):
         super().test_isdisjoint()
 
-    @skip_if_win_arm64
+    @skip_win_arm64_40args_problem
     def test_issubset(self):
         super().test_issubset()
 
-    @skip_if_win_arm64
+    @skip_win_arm64_40args_problem
     def test_issuperset(self):
         super().test_issuperset()
 

--- a/numba/tests/test_sets.py
+++ b/numba/tests/test_sets.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from numba import jit, njit
 from numba.tests.support import (TestCase, enable_pyobj_flags, MemoryLeakMixin,
-                                 compile_function)
+                                 compile_function, skip_if_win_arm64)
 
 
 Point = namedtuple('Point', ('a', 'b'))
@@ -623,6 +623,20 @@ class TestUnicodeSets(TestSets):
     """
     def _range(self, stop):
         return ['A{}'.format(i) for i in range(int(stop))]
+
+    # UniTuple[unicode, 3] unpacks to >=40 LLVM args; crashes frame lowering
+    # on win-arm64 (llvm/llvm-project#204060).
+    @skip_if_win_arm64
+    def test_isdisjoint(self):
+        super().test_isdisjoint()
+
+    @skip_if_win_arm64
+    def test_issubset(self):
+        super().test_issubset()
+
+    @skip_if_win_arm64
+    def test_issuperset(self):
+        super().test_issuperset()
 
 
 class TestSetsInvalidDtype(TestSets):

--- a/numba/tests/test_stencils.py
+++ b/numba/tests/test_stencils.py
@@ -13,7 +13,7 @@ from numba.core.compiler import compile_extra, Flags
 from numba.core.cpu import ParallelOptions
 from numba.tests.support import (
     skip_parfors_unsupported,
-    skip_if_win_arm64,
+    skip_win_arm64_40args_problem,
     _32bit,
 )
 from numba.core.errors import LoweringError, TypingError, NumbaValueError
@@ -365,7 +365,7 @@ class TestStencil(TestStencilBase):
     @skip_unsupported
     # crashes LLVM 22 AArch64 frame lowering on win-arm64
     # (llvm/llvm-project#204060).
-    @skip_if_win_arm64
+    @skip_win_arm64_40args_problem
     def test_stencil_mixed_types(self):
         def test_impl_seq(n):
             A = np.arange(n ** 2).reshape((n, n))
@@ -1917,7 +1917,9 @@ class TestManyStencils(TestStencilBase):
         self.check_exceptions(kernel, a, b, expected_exception=[NumbaValueError,
                                                                 LoweringError])
 
-    @skip_if_win_arm64
+    # crashes LLVM 22 AArch64 frame lowering on win-arm64
+    # (llvm/llvm-project#204060).
+    @skip_win_arm64_40args_problem
     def test_basic47(self):
         """3 args"""
         def kernel(a, b, c):
@@ -2011,7 +2013,9 @@ class TestManyStencils(TestStencilBase):
                               options={'standard_indexing': ['a', 'b']},
                               expected_exception=[ValueError, NumbaValueError])
 
-    @skip_if_win_arm64
+    # crashes LLVM 22 AArch64 frame lowering on win-arm64
+    # (llvm/llvm-project#204060).
+    @skip_win_arm64_40args_problem
     def test_basic52(self):
         """3 args, standard_indexing on middle arg """
         def kernel(a, b, c):

--- a/numba/tests/test_stencils.py
+++ b/numba/tests/test_stencils.py
@@ -11,7 +11,11 @@ from numba import njit, stencil
 from numba.core import types, registry
 from numba.core.compiler import compile_extra, Flags
 from numba.core.cpu import ParallelOptions
-from numba.tests.support import skip_parfors_unsupported, _32bit
+from numba.tests.support import (
+    skip_parfors_unsupported,
+    skip_if_win_arm64,
+    _32bit,
+)
 from numba.core.errors import LoweringError, TypingError, NumbaValueError
 import unittest
 
@@ -359,6 +363,9 @@ class TestStencil(TestStencilBase):
         self.check(test_impl_seq, test_seq, n)
 
     @skip_unsupported
+    # crashes LLVM 22 AArch64 frame lowering on win-arm64
+    # (llvm/llvm-project#204060).
+    @skip_if_win_arm64
     def test_stencil_mixed_types(self):
         def test_impl_seq(n):
             A = np.arange(n ** 2).reshape((n, n))
@@ -1910,6 +1917,7 @@ class TestManyStencils(TestStencilBase):
         self.check_exceptions(kernel, a, b, expected_exception=[NumbaValueError,
                                                                 LoweringError])
 
+    @skip_if_win_arm64
     def test_basic47(self):
         """3 args"""
         def kernel(a, b, c):
@@ -2003,6 +2011,7 @@ class TestManyStencils(TestStencilBase):
                               options={'standard_indexing': ['a', 'b']},
                               expected_exception=[ValueError, NumbaValueError])
 
+    @skip_if_win_arm64
     def test_basic52(self):
         """3 args, standard_indexing on middle arg """
         def kernel(a, b, c):


### PR DESCRIPTION
This PR adds GHA workflows and updates build/test scripts to support `win-arm64` binaries for both conda packages and wheels.

Since `miniconda` installer is not available yet on `win-arm64`, the workflows use `conda-incubator/setup-conda-standalone` to setup conda environment and build packages.

Related issues: https://github.com/numba/numba/issues/10549