### PR TITLE
update Numba CI and builds for Windows with VS2026

### DIFF
--- a/.github/workflows/numba_win-64_wheel_builder.yml
+++ b/.github/workflows/numba_win-64_wheel_builder.yml
@@ -86,7 +86,32 @@ jobs:
           fi
           python -m pip install build numpy==${{ matrix.numpy_build }} setuptools wheel tbb==2021.6 tbb-devel==2021.6
 
+      - name: Setup MSVC v14.44 (v143) environment
+        shell: cmd
+        run: |
+          REM Same locator as buildscripts/condarecipe.local/bld.bat: find
+          REM VS2022 or VS2026 and pin the MSVC v14.44 (v143) toolset, then
+          REM export the activated environment to the following steps.
+          for /F "usebackq tokens=*" %%i in (`vswhere.exe -nologo -products * -version "[17.0,19.0)" -property installationPath`) do (
+            set "VSINSTALLDIR=%%i\"
+          )
+          if not exist "%VSINSTALLDIR%" (
+            echo Could not find VS 2022 or VS 2026
+            exit /B 1
+          )
+          call "%VSINSTALLDIR%VC\Auxiliary\Build\vcvarsall.bat" x64 -vcvars_ver=14.44
+          if errorlevel 1 exit /B 1
+          >>"%GITHUB_ENV%" echo PATH=%PATH%
+          >>"%GITHUB_ENV%" echo INCLUDE=%INCLUDE%
+          >>"%GITHUB_ENV%" echo LIB=%LIB%
+
       - name: Build wheel
+        env:
+          # Use the pre-activated MSVC v14.44 environment instead of
+          # setuptools' own discovery, which would pick VS2026's native
+          # v14.5x toolset. use 14.44 instead.
+          DISTUTILS_USE_SDK: '1'
+          MSSdk: '1'
         run: python -m build --wheel --no-isolation
 
       - name: Upload numba wheel

--- a/.github/workflows/numba_win-64_wheel_builder.yml
+++ b/.github/workflows/numba_win-64_wheel_builder.yml
@@ -96,7 +96,14 @@ jobs:
             echo "Could not find VS 2022 or VS 2026"
             exit 1
           fi
-          cmd //s //c "\"$VSINSTALLDIR\VC\Auxiliary\Build\vcvarsall.bat\" x64 -vcvars_ver=14.44 >NUL && set" | tr -d '\r' > "$RUNNER_TEMP/msvc_env.txt"
+          # Quotes inside an inline `cmd //c` argument get mangled between
+          # bash and cmd, so activate via a temporary batch file instead.
+          {
+            printf '@call "%s\\VC\\Auxiliary\\Build\\vcvarsall.bat" x64 -vcvars_ver=14.44 >NUL || exit /b 1\r\n' "$VSINSTALLDIR"
+            printf '@set\r\n'
+          } > "$RUNNER_TEMP/msvc_env.bat"
+          set -o pipefail
+          cmd //c "$(cygpath -w "$RUNNER_TEMP/msvc_env.bat")" | tr -d '\r' > "$RUNNER_TEMP/msvc_env.txt"
           grep -iE '^(PATH|INCLUDE|LIB)=' "$RUNNER_TEMP/msvc_env.txt" >> "$GITHUB_ENV"
           # git-bash's login profile prepends Git\usr\bin to PATH in every
           # bash step, so its GNU link.exe would shadow MSVC's linker no

--- a/.github/workflows/numba_win-64_wheel_builder.yml
+++ b/.github/workflows/numba_win-64_wheel_builder.yml
@@ -87,23 +87,21 @@ jobs:
           python -m pip install build numpy==${{ matrix.numpy_build }} setuptools wheel tbb==2021.6 tbb-devel==2021.6
 
       - name: Setup MSVC v14.44 (v143) environment
-        shell: cmd
         run: |
-          REM Same locator as buildscripts/condarecipe.local/bld.bat: find
-          REM VS2022 or VS2026 and pin the MSVC v14.44 (v143) toolset, then
-          REM export the activated environment to the following steps.
-          for /F "usebackq tokens=*" %%i in (`vswhere.exe -nologo -products * -version "[17.0,19.0)" -property installationPath`) do (
-            set "VSINSTALLDIR=%%i\"
-          )
-          if not exist "%VSINSTALLDIR%" (
-            echo Could not find VS 2022 or VS 2026
-            exit /B 1
-          )
-          call "%VSINSTALLDIR%VC\Auxiliary\Build\vcvarsall.bat" x64 -vcvars_ver=14.44
-          if errorlevel 1 exit /B 1
-          >>"%GITHUB_ENV%" echo PATH=%PATH%
-          >>"%GITHUB_ENV%" echo INCLUDE=%INCLUDE%
-          >>"%GITHUB_ENV%" echo LIB=%LIB%
+          # Same locator as buildscripts/condarecipe.local/bld.bat: find
+          # VS2022 or VS2026 and pin the MSVC v14.44 (v143) toolset, then
+          # export the activated environment to the following steps.
+          VSINSTALLDIR=$(vswhere.exe -nologo -latest -products '*' -version '[17.0,19.0)' -property installationPath | tr -d '\r')
+          if [ -z "$VSINSTALLDIR" ]; then
+            echo "Could not find VS 2022 or VS 2026"
+            exit 1
+          fi
+          cmd //s //c "\"$VSINSTALLDIR\VC\Auxiliary\Build\vcvarsall.bat\" x64 -vcvars_ver=14.44 >NUL && set" | tr -d '\r' > "$RUNNER_TEMP/msvc_env.txt"
+          grep -iE '^(PATH|INCLUDE|LIB)=' "$RUNNER_TEMP/msvc_env.txt" >> "$GITHUB_ENV"
+          # git-bash's login profile prepends Git\usr\bin to PATH in every
+          # bash step, so its GNU link.exe would shadow MSVC's linker no
+          # matter what PATH we export; remove the shadowing binary.
+          rm -f /usr/bin/link.exe
 
       - name: Build wheel
         env:

--- a/buildscripts/condarecipe.local/bld.bat
+++ b/buildscripts/condarecipe.local/bld.bat
@@ -1,13 +1,15 @@
-REM Setup VS2022 environment manually to avoid conda vs2022 activation issues
-REM on Windows Server 2025 (hardcoded toolset version mismatches)
-for /F "usebackq tokens=*" %%i in (`vswhere.exe -nologo -products * -version "[17.0,18.0)" -property installationPath`) do (
+REM Setup VS environment (VS2022 or VS2026) manually to avoid conda vs2022
+REM activation issues on Windows Server 2025
+for /F "usebackq tokens=*" %%i in (`vswhere.exe -nologo -products * -version "[17.0,19.0)" -property installationPath`) do (
   set "VSINSTALLDIR=%%i\\"
 )
 if not exist "%VSINSTALLDIR%" (
-  echo "Could not find VS 2022"
+  echo "Could not find VS 2022 or VS 2026"
   exit /B 1
 )
-call "%VSINSTALLDIR%VC\Auxiliary\Build\vcvarsall.bat" x64
+REM Pin MSVC v14.44 (v143) to keep the vs2015_runtime >=14.44 run-dependency
+REM pins valid; VS2026 would otherwise default to its native v14.5x toolset.
+call "%VSINSTALLDIR%VC\Auxiliary\Build\vcvarsall.bat" x64 -vcvars_ver=14.44
 
 %PYTHON% setup.py build install --single-version-externally-managed --record=record.txt
 


### PR DESCRIPTION
Parallel PR to https://github.com/numba/llvmlite/pull/1437 for Numba, this PR enables support for building Numba using the same windows compiler toolset under new VS2026.

- For conda builds, update to activation script pins toolset version to MSVC v14.44 (v143).
- For wheel builds, Numba uses setuptools which auto-discovers VS installation. If left as is, it silently would default to using native toolset to VS2026 which is MSVC 14.51.36231 (newer than llvmdev and llvmlite), which could cause problems downstream. see this workflow run - https://github.com/numba/numba/actions/runs/27353470756/job/80828283100
To match llvmlite and pin to MSVC v14.44 (v143), this adds an additional step on win-64 workflow that activates variables to use `14.44` toolset on VS2026.