### PR TITLE
Fix: `np.mean` precision for `float32`/`complex64` arrays

### DIFF
--- a/docs/upcoming_changes/10649.bug_fix.rst
+++ b/docs/upcoming_changes/10649.bug_fix.rst
@@ -1,0 +1,7 @@
+Fix rounding error in ``mean`` for integer and boolean arrays
+-------------------------------------------------------------
+
+Computing ``np.mean`` over an integer or boolean array cast the element count
+to the array's dtype before dividing, which could narrow the divisor and
+produce a slightly incorrect result. The division is now performed in full
+precision and only the final mean is cast, matching NumPy's result.

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -482,7 +482,7 @@ def array_mean(a):
                 c = acc_init
                 for v in np.nditer(a):
                     c += v.item()
-                return c / dtype.type(a.size)
+                return dtype.type(c / a.size)
         else:
             # For datetime/timedelta, don't add special empty array handling
             # Let it behave as before (NumPy itself raises error for empty

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -517,6 +517,17 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
         expected = np.mean(arr)
         self.assertPreciseEqual(cfunc(arr), expected)
 
+    def test_mean_count_rounding(self):
+        # Reproducer from issue #10647: 2**24 + 1 is the smallest length
+        # not exactly representable as float32, so any incorrect cast
+        # in the computation will mismatch the np result.
+        n = 2**24 + 1
+        for dtype in (np.float32, np.complex64):
+            arr = np.zeros(n, dtype=dtype)
+            arr[0] = dtype(2**24 - 1)
+            npr, nbr = run_comparative(array_mean, arr)
+            self.assertPreciseEqual(npr, nbr)
+
     def test_mean_empty_timedelta(self):
         """Test that mean of empty timedelta array returns NaT"""
         cfunc = jit(nopython=True)(array_mean)


### PR DESCRIPTION
Fixes: #10647 

`array_mean` computed `c / dtype.type(a.size)`, casting the element count to
the result dtype before dividing. For `float32` (and `complex64`) arrays,
integers above 2**24 are not all exactly representable.

This PR changes the final step to `dtype.type(c / a.size)`: divide by the exact
integer count (promoted to double precision), then round once to the result
dtype. This mirrors NumPy's own `ret.dtype.type(ret / rcount)` in
[`numpy/_core/_methods.py`](https://github.com/numpy/numpy/blob/ce6dd7dc551d0182be509b501069e5253dbf493f/numpy/_core/_methods.py#L142), so results now match NumPy bit-for-bit. 

The result dtype remains unchanged (`float32` in, `float32` out).