### PR TITLE
feat: support np.tile in nopython mode

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -602,11 +602,9 @@ The following top-level functions are supported:
 * :func:`numpy.split`
 * :func:`numpy.stack` (only the first two arguments are supported)
 * :func:`numpy.swapaxes`
-* :func:`numpy.tile` (when ``reps`` is an integer, arrays up to 3-D are
-  supported; when ``reps`` is a tuple, only 1-D arrays and scalars are
-  supported; ``reps`` must be an integer or a tuple of integers)
 * :func:`numpy.take` (only the 2 first arguments)
 * :func:`numpy.take_along_axis` (the axis argument must be a literal value)
+* :func:`numpy.tile` (``reps`` must be an integer or a tuple of integers)
 * :func:`numpy.transpose`
 * :func:`numpy.trapezoid` (only the 3 first arguments)
 * :func:`numpy.trapz` (only the 3 first arguments)

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -602,6 +602,9 @@ The following top-level functions are supported:
 * :func:`numpy.split`
 * :func:`numpy.stack` (only the first two arguments are supported)
 * :func:`numpy.swapaxes`
+* :func:`numpy.tile` (when ``reps`` is an integer, arrays up to 3-D are
+  supported; when ``reps`` is a tuple, only 1-D arrays and scalars are
+  supported; ``reps`` must be an integer or a tuple of integers)
 * :func:`numpy.take` (only the 2 first arguments)
 * :func:`numpy.take_along_axis` (the axis argument must be a literal value)
 * :func:`numpy.transpose`

--- a/docs/upcoming_changes/10650.np_support.rst
+++ b/docs/upcoming_changes/10650.np_support.rst
@@ -1,1 +1,4 @@
+``np.tile`` is now supported in nopython mode
+---------------------------------------------
+
 ``np.tile`` is now supported in nopython mode.

--- a/docs/upcoming_changes/10650.np_support.rst
+++ b/docs/upcoming_changes/10650.np_support.rst
@@ -1,0 +1,1 @@
+``np.tile`` is now supported in nopython mode.

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -2996,6 +2996,145 @@ def array_repeat(a, repeats):
     return array_repeat_impl
 
 
+@register_jitable
+def _np_tile_repeat_along_axis(arr, reps, axis):
+    if reps == 1:
+        return arr
+    result = np.concatenate((arr, arr), axis=axis)
+    for _ in range(reps - 2):
+        result = np.concatenate((result, arr), axis=axis)
+    return result
+
+
+@overload(np.tile)
+def np_tile(A, reps):
+
+    if not type_can_asarray(A):
+        msg = 'The argument "A" must be array-like'
+        raise errors.TypingError(msg)
+
+    if isinstance(reps, types.Integer):
+        if isinstance(A, types.Array):
+            ndim = A.ndim
+            if ndim == 0:
+                # 0-d array, expand to 1-d then tile
+                def np_tile_scalar_int_impl(A, reps):
+                    if reps < 0:
+                        raise ValueError(
+                            "negative dimensions are not allowed")
+                    arr = np.asarray(A)
+                    if reps == 0:
+                        return np.empty(0, dtype=arr.dtype)
+                    arr = np.expand_dims(arr, 0)
+                    return _np_tile_repeat_along_axis(arr, reps, 0)
+
+                return np_tile_scalar_int_impl
+
+            elif ndim == 1:
+                def np_tile_1d_int_impl(A, reps):
+                    if reps < 0:
+                        raise ValueError(
+                            "negative dimensions are not allowed")
+                    arr = np.asarray(A)
+                    if reps == 0:
+                        return np.empty(0, dtype=arr.dtype)
+                    return _np_tile_repeat_along_axis(arr, reps, 0)
+
+                return np_tile_1d_int_impl
+
+            elif ndim == 2:
+                def np_tile_2d_int_impl(A, reps):
+                    if reps < 0:
+                        raise ValueError(
+                            "negative dimensions are not allowed")
+                    arr = np.asarray(A)
+                    if reps == 0:
+                        return np.empty((arr.shape[0], 0), dtype=arr.dtype)
+                    return _np_tile_repeat_along_axis(arr, reps, 1)
+
+                return np_tile_2d_int_impl
+
+            elif ndim == 3:
+                def np_tile_3d_int_impl(A, reps):
+                    if reps < 0:
+                        raise ValueError(
+                            "negative dimensions are not allowed")
+                    arr = np.asarray(A)
+                    if reps == 0:
+                        return np.empty((arr.shape[0], arr.shape[1], 0),
+                                        dtype=arr.dtype)
+                    return _np_tile_repeat_along_axis(arr, reps, 2)
+
+                return np_tile_3d_int_impl
+
+            else:
+                msg = ('np.tile with integer reps is only supported for '
+                       'arrays up to 3-D')
+                raise errors.TypingError(msg)
+        else:
+            # Non-array input (e.g. Python scalar, tuple).
+            # asarray on scalars gives 0-d, on tuples/lists gives 1-d.
+            # Split to keep return types unified.
+            if isinstance(A, (types.Integer, types.Float, types.Boolean,
+                              types.Complex)):
+                # Scalar (0-d after asarray)
+                def np_tile_nonarray_int_impl(A, reps):
+                    if reps < 0:
+                        raise ValueError(
+                            "negative dimensions are not allowed")
+                    arr = np.asarray(A)
+                    if reps == 0:
+                        return np.empty(0, dtype=arr.dtype)
+                    arr = np.expand_dims(arr, 0)
+                    return _np_tile_repeat_along_axis(arr, reps, 0)
+
+                return np_tile_nonarray_int_impl
+            else:
+                # Tuple/list (1-d after asarray)
+                def np_tile_seq_int_impl(A, reps):
+                    if reps < 0:
+                        raise ValueError(
+                            "negative dimensions are not allowed")
+                    arr = np.asarray(A)
+                    if reps == 0:
+                        return np.empty(0, dtype=arr.dtype)
+                    return _np_tile_repeat_along_axis(arr, reps, 0)
+
+                return np_tile_seq_int_impl
+
+    elif (isinstance(reps, types.UniTuple)
+          and isinstance(reps.dtype, types.Integer)):
+        if isinstance(A, types.Array) and A.ndim > 1:
+            msg = ('np.tile with tuple reps is only supported for '
+                   '1-D arrays and scalars')
+            raise errors.TypingError(msg)
+
+        def np_tile_tuple_impl(A, reps):
+            for r in reps:
+                if r < 0:
+                    raise ValueError(
+                        "negative dimensions are not allowed")
+            arr = np.asarray(A)
+            sz = arr.size
+            out_shape = reps[:-1] + (reps[-1] * sz,)
+            num_copies = 1
+            for r in reps:
+                num_copies *= r
+            if sz == 0 or num_copies == 0:
+                return np.empty(out_shape, dtype=arr.dtype)
+            out = np.empty(num_copies * sz, dtype=arr.dtype)
+            arr_flat = arr.flatten()
+            for i in range(num_copies):
+                out[i * sz : (i + 1) * sz] = arr_flat
+            return np.reshape(out, out_shape)
+
+        return np_tile_tuple_impl
+    else:
+        msg = ('The argument "reps" must be an integer or '
+               'a tuple of integers')
+        raise errors.TypingError(msg)
+
+
 @intrinsic
 def _intrin_get_itemsize(tyctx, dtype):
     """Computes the itemsize of the dtype"""

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -2997,136 +2997,150 @@ def array_repeat(a, repeats):
 
 
 @register_jitable
-def _np_tile_repeat_along_axis(arr, reps, axis):
-    if reps == 1:
-        return arr
-    result = np.concatenate((arr, arr), axis=axis)
-    for _ in range(reps - 2):
-        result = np.concatenate((result, arr), axis=axis)
-    return result
+def _np_tile_repeat_blocks(flat, block_size, nrep):
+    """Equivalent to c.reshape(-1, block_size).repeat(nrep, 0).ravel()
+    but in 1-D to keep the return type stable for Numba's type inference.
+    Numba's np.repeat has no axis parameter."""
+    n_blocks = len(flat) // block_size
+    out = np.empty(n_blocks * nrep * block_size, dtype=flat.dtype)
+    pos = 0
+    for i in range(n_blocks):
+        start = i * block_size
+        end = start + block_size
+        for _ in range(nrep):
+            out[pos:pos + block_size] = flat[start:end]
+            pos += block_size
+    return out
+
+
+def _np_tile_get_effective_ndim(A):
+    """Return the ndim of np.asarray(A) at compile time."""
+    if isinstance(A, types.Array):
+        return A.ndim
+    elif isinstance(A, (types.Integer, types.Float, types.Boolean,
+                        types.Complex)):
+        return 0
+    elif isinstance(A, (types.BaseTuple, types.List)):
+        return 1
+    return None
+
+
+def _generate_np_tile_promote(a_ndim, target_ndim):
+    """Generate a register_jitable that promotes an array from a_ndim
+    to target_ndim via expand_dims (equivalent to ndmin=target_ndim).
+    Uses separate variables per expand_dims call because Numba cannot
+    unify types across loop iterations that change an array's ndim."""
+    if a_ndim >= target_ndim:
+        @register_jitable
+        def _promote(arr):
+            return arr
+    else:
+        lines = ["def _promote(arr):"]
+        prev = "arr"
+        for i in range(target_ndim - a_ndim):
+            cur = f"arr{i}"
+            lines.append(f"    {cur} = np.expand_dims({prev}, 0)")
+            prev = cur
+        lines.append(f"    return {prev}")
+        ns = {}
+        exec("\n".join(lines), globals(), ns)
+        _promote = register_jitable(ns['_promote'])
+
+    return _promote
 
 
 @overload(np.tile)
 def np_tile(A, reps):
+    # Following NumPy's algorithm:
+    # https://github.com/numpy/numpy/blob/v2.4.0/numpy/lib/_shape_base_impl.py
+    # Deviations due to Numba limitations:
+    #   - np.array(A, ndmin=d) not supported → _generate_np_tile_promote
+    #   - np.repeat has no axis → _np_tile_repeat_blocks on flat data
+    #   - tuple concatenation limited → tuple_setitem with pre-allocated buffers
 
     if not type_can_asarray(A):
         msg = 'The argument "A" must be array-like'
         raise errors.TypingError(msg)
 
     if isinstance(reps, types.Integer):
-        if isinstance(A, types.Array):
-            ndim = A.ndim
-            if ndim == 0:
-                # 0-d array, expand to 1-d then tile
-                def np_tile_scalar_int_impl(A, reps):
-                    if reps < 0:
-                        raise ValueError(
-                            "negative dimensions are not allowed")
-                    arr = np.asarray(A)
-                    if reps == 0:
-                        return np.empty(0, dtype=arr.dtype)
-                    arr = np.expand_dims(arr, 0)
-                    return _np_tile_repeat_along_axis(arr, reps, 0)
+        a_ndim = _np_tile_get_effective_ndim(A)
+        if a_ndim is None:
+            msg = 'np.tile: unsupported input type'
+            raise errors.TypingError(msg)
+        out_ndim = max(a_ndim, 1)
+        shape_out_buf = tuple(range(out_ndim))
+        promote = _generate_np_tile_promote(a_ndim, out_ndim)
 
-                return np_tile_scalar_int_impl
+        def np_tile_int_impl(A, reps):
+            if reps < 0:
+                raise ValueError("negative dimensions are not allowed")
+            arr = promote(np.asarray(A))
+            # Build shape_out = arr.shape[:-1] + (arr.shape[-1] * reps,)
+            shape_out = shape_out_buf
+            for i in range(out_ndim - 1):
+                shape_out = tuple_setitem(shape_out, i, arr.shape[i])
+            shape_out = tuple_setitem(
+                shape_out, out_ndim - 1, arr.shape[out_ndim - 1] * reps)
+            if reps == 0 or arr.size == 0:
+                return np.empty(shape_out, dtype=arr.dtype)
+            # Core loop: for each dim, repeat flat blocks of size n
+            n = arr.size
+            c = arr.flatten()
+            for i in range(out_ndim):
+                dim_in = arr.shape[i]
+                nrep = reps if i == out_ndim - 1 else 1
+                if nrep != 1:
+                    c = _np_tile_repeat_blocks(c, n, nrep)
+                n = n // dim_in
+            return c.reshape(shape_out)
 
-            elif ndim == 1:
-                def np_tile_1d_int_impl(A, reps):
-                    if reps < 0:
-                        raise ValueError(
-                            "negative dimensions are not allowed")
-                    arr = np.asarray(A)
-                    if reps == 0:
-                        return np.empty(0, dtype=arr.dtype)
-                    return _np_tile_repeat_along_axis(arr, reps, 0)
-
-                return np_tile_1d_int_impl
-
-            elif ndim == 2:
-                def np_tile_2d_int_impl(A, reps):
-                    if reps < 0:
-                        raise ValueError(
-                            "negative dimensions are not allowed")
-                    arr = np.asarray(A)
-                    if reps == 0:
-                        return np.empty((arr.shape[0], 0), dtype=arr.dtype)
-                    return _np_tile_repeat_along_axis(arr, reps, 1)
-
-                return np_tile_2d_int_impl
-
-            elif ndim == 3:
-                def np_tile_3d_int_impl(A, reps):
-                    if reps < 0:
-                        raise ValueError(
-                            "negative dimensions are not allowed")
-                    arr = np.asarray(A)
-                    if reps == 0:
-                        return np.empty((arr.shape[0], arr.shape[1], 0),
-                                        dtype=arr.dtype)
-                    return _np_tile_repeat_along_axis(arr, reps, 2)
-
-                return np_tile_3d_int_impl
-
-            else:
-                msg = ('np.tile with integer reps is only supported for '
-                       'arrays up to 3-D')
-                raise errors.TypingError(msg)
-        else:
-            # Non-array input (e.g. Python scalar, tuple).
-            # asarray on scalars gives 0-d, on tuples/lists gives 1-d.
-            # Split to keep return types unified.
-            if isinstance(A, (types.Integer, types.Float, types.Boolean,
-                              types.Complex)):
-                # Scalar (0-d after asarray)
-                def np_tile_nonarray_int_impl(A, reps):
-                    if reps < 0:
-                        raise ValueError(
-                            "negative dimensions are not allowed")
-                    arr = np.asarray(A)
-                    if reps == 0:
-                        return np.empty(0, dtype=arr.dtype)
-                    arr = np.expand_dims(arr, 0)
-                    return _np_tile_repeat_along_axis(arr, reps, 0)
-
-                return np_tile_nonarray_int_impl
-            else:
-                # Tuple/list (1-d after asarray)
-                def np_tile_seq_int_impl(A, reps):
-                    if reps < 0:
-                        raise ValueError(
-                            "negative dimensions are not allowed")
-                    arr = np.asarray(A)
-                    if reps == 0:
-                        return np.empty(0, dtype=arr.dtype)
-                    return _np_tile_repeat_along_axis(arr, reps, 0)
-
-                return np_tile_seq_int_impl
+        return np_tile_int_impl
 
     elif (isinstance(reps, types.UniTuple)
           and isinstance(reps.dtype, types.Integer)):
-        if isinstance(A, types.Array) and A.ndim > 1:
-            msg = ('np.tile with tuple reps is only supported for '
-                   '1-D arrays and scalars')
+        d = len(reps)
+        a_ndim = _np_tile_get_effective_ndim(A)
+        if a_ndim is None:
+            msg = 'np.tile: unsupported input type'
             raise errors.TypingError(msg)
+        out_ndim = max(a_ndim, d)
+        shape_out_buf = tuple(range(out_ndim))
+        padded_buf = tuple(range(out_ndim))
+        promote = _generate_np_tile_promote(a_ndim, out_ndim)
 
         def np_tile_tuple_impl(A, reps):
+            has_zero = False
             for r in reps:
                 if r < 0:
-                    raise ValueError(
-                        "negative dimensions are not allowed")
-            arr = np.asarray(A)
-            sz = arr.size
-            out_shape = reps[:-1] + (reps[-1] * sz,)
-            num_copies = 1
-            for r in reps:
-                num_copies *= r
-            if sz == 0 or num_copies == 0:
-                return np.empty(out_shape, dtype=arr.dtype)
-            out = np.empty(num_copies * sz, dtype=arr.dtype)
-            arr_flat = arr.flatten()
-            for i in range(num_copies):
-                out[i * sz : (i + 1) * sz] = arr_flat
-            return np.reshape(out, out_shape)
+                    raise ValueError("negative dimensions are not allowed")
+                if r == 0:
+                    has_zero = True
+            arr = promote(np.asarray(A))
+            # Build padded reps: (1,)*(nd-d) + reps
+            nd = out_ndim
+            padded = padded_buf
+            extra = nd - d
+            for i in range(extra):
+                padded = tuple_setitem(padded, i, 1)
+            for i in range(d):
+                padded = tuple_setitem(padded, extra + i, reps[i])
+            # Build shape_out = tuple(s * t for s, t in zip(arr.shape, padded))
+            shape_out = shape_out_buf
+            for i in range(nd):
+                shape_out = tuple_setitem(
+                    shape_out, i, arr.shape[i] * padded[i])
+            if has_zero or arr.size == 0:
+                return np.empty(shape_out, dtype=arr.dtype)
+            # Core loop: same as integer path, but using padded reps
+            n = arr.size
+            c = arr.flatten()
+            for i in range(nd):
+                dim_in = arr.shape[i]
+                nrep = padded[i]
+                if nrep != 1:
+                    c = _np_tile_repeat_blocks(c, n, nrep)
+                n = n // dim_in
+            return c.reshape(shape_out)
 
         return np_tile_tuple_impl
     else:

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -398,6 +398,10 @@ def array_repeat(a, repeats):
     return np.asarray(a).repeat(repeats)
 
 
+def np_tile(A, reps):
+    return np.tile(A, reps)
+
+
 def np_select(condlist, choicelist, default=0):
     return np.select(condlist, choicelist, default=default)
 
@@ -5507,6 +5511,58 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             for rep in [True, "a", "1"]:
                 with self.assertRaises(TypingError):
                     nbfunc(np.ones(1), rep)
+
+    def test_tile(self):
+        pyfunc = np_tile
+        cfunc = jit(nopython=True)(pyfunc)
+
+        # 1-D arrays and scalars with integer and tuple reps
+        for a in (np.arange(5), np.array([]), 3.0, True, np.array([1, 2]),
+                  (1, 2, 3)):
+            for reps in (2, 0, (6,), (3, 3), (2, 1, 4)):
+                expected = pyfunc(a, reps)
+                got = cfunc(a, reps)
+                self.assertPreciseEqual(expected, got)
+
+        # Multi-dimensional arrays with integer reps (concatenate path)
+        for a in (np.arange(6).reshape(2, 3),
+                  np.arange(24).reshape(4, 3, 2)):
+            for reps in range(0, 4):
+                expected = pyfunc(a, reps)
+                got = cfunc(a, reps)
+                self.assertPreciseEqual(expected, got)
+
+    def test_tile_exception(self):
+        cfunc = jit(nopython=True)(np_tile)
+
+        self.disable_leak_check()
+
+        # Negative dimensions, integer reps
+        with self.assertRaises(ValueError) as raises:
+            cfunc(np.arange(3), -1)
+        self.assertIn("negative dimensions are not allowed",
+                      str(raises.exception))
+
+        # Negative dimensions, tuple reps
+        with self.assertRaises(ValueError) as raises:
+            cfunc(np.arange(3), (2, -1))
+        self.assertIn("negative dimensions are not allowed",
+                      str(raises.exception))
+
+        # Non-integer reps
+        with self.assertTypingError() as raises:
+            cfunc(np.arange(3), 1.5)
+        self.assertIn("reps", str(raises.exception))
+
+        # Multi-dimensional array with tuple reps (not supported)
+        with self.assertTypingError() as raises:
+            cfunc(np.arange(6).reshape(2, 3), (2, 1))
+        self.assertIn("1-D", str(raises.exception))
+
+        # High-dimensional array with integer reps (not supported)
+        with self.assertTypingError() as raises:
+            cfunc(np.arange(16).reshape(2, 2, 2, 2), 2)
+        self.assertIn("3-D", str(raises.exception))
 
     def test_select(self):
         np_pyfunc = np_select

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -5518,16 +5518,22 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
 
         # 1-D arrays and scalars with integer and tuple reps
         for a in (np.arange(5), np.array([]), 3.0, True, np.array([1, 2]),
-                  (1, 2, 3)):
-            for reps in (2, 0, (6,), (3, 3), (2, 1, 4)):
+                  (1, 2, 3), [1, 2, 3]):
+            for reps in (2, 0, 1, (6,), (3, 3), (2, 1, 4)):
                 expected = pyfunc(a, reps)
                 got = cfunc(a, reps)
                 self.assertPreciseEqual(expected, got)
 
-        # Multi-dimensional arrays with integer reps (concatenate path)
+        # Multi-dimensional arrays with integer and tuple reps
         for a in (np.arange(6).reshape(2, 3),
-                  np.arange(24).reshape(4, 3, 2)):
-            for reps in range(0, 4):
+                  np.arange(24).reshape(4, 3, 2),
+                  np.arange(16).reshape(2, 2, 2, 2)):
+            for reps in (0, 1, 2, 3):
+                expected = pyfunc(a, reps)
+                got = cfunc(a, reps)
+                self.assertPreciseEqual(expected, got)
+            # Tuple reps for multi-dim arrays
+            for reps in ((2,), (1, 2), (2, 1), (2, 3), (3, 2, 1)):
                 expected = pyfunc(a, reps)
                 got = cfunc(a, reps)
                 self.assertPreciseEqual(expected, got)
@@ -5553,16 +5559,6 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         with self.assertTypingError() as raises:
             cfunc(np.arange(3), 1.5)
         self.assertIn("reps", str(raises.exception))
-
-        # Multi-dimensional array with tuple reps (not supported)
-        with self.assertTypingError() as raises:
-            cfunc(np.arange(6).reshape(2, 3), (2, 1))
-        self.assertIn("1-D", str(raises.exception))
-
-        # High-dimensional array with integer reps (not supported)
-        with self.assertTypingError() as raises:
-            cfunc(np.arange(16).reshape(2, 2, 2, 2), 2)
-        self.assertIn("3-D", str(raises.exception))
 
     def test_select(self):
         np_pyfunc = np_select


### PR DESCRIPTION
## Summary

Implement `np.tile` in nopython mode, following NumPy's algorithm.

## Implementation

The implementation faithfully follows NumPy's `tile` algorithm ([reference](https://github.com/numpy/numpy/blob/v2.4.0/numpy/lib/_shape_base_impl.py)):

1. **Dimension promotion** (`np.array(A, ndmin=d)`) — NumPy promotes `A` to at least `d` dimensions. Since Numba doesn't support the `ndmin` parameter, `_generate_np_tile_promote` generates a `register_jitable` function that chains `np.expand_dims` calls to the target ndim.

2. **Build output shape** (`tuple(s * t for s, t in zip(c.shape, tup))`) — Since Numba doesn't support tuple concatenation or generator expressions for tuple construction, we use `tuple_setitem` with compile-time pre-allocated buffers (following the pattern used in `sliding_window_view`, `np.swapaxes`, etc.).

3. **Core loop** (`c.reshape(-1, n).repeat(nrep, 0)`) — Since Numba's `np.repeat` has no `axis` parameter, `_np_tile_repeat_blocks` operates on the flattened representation throughout, repeating each block of `n` elements `nrep` times. This is equivalent to `c.reshape(-1, n).repeat(nrep, 0).ravel()`. A `flatten()` (always copies) is used instead of `ravel()` to ensure the result is always a copy, matching NumPy's behavior.

## Supported features

- `A`: arrays of any dimensionality, scalars, booleans, tuples, and lists
- `reps`: integer or tuple of integers
- Negative `reps` raises `ValueError`
- Zero `reps` returns an empty array with the correct shape
- `reps == 1` returns a copy (not a view), matching NumPy

## Files changed

- `numba/np/arrayobj.py`: `np.tile` overload implementation
- `numba/tests/test_np_functions.py`: tests for `np.tile`
- `docs/source/reference/numpysupported.rst`: add `numpy.tile` to supported functions list
- `docs/upcoming_changes/10650.np_support.rst`: changelog entry
