### PR TITLE
Fix EOFError when loading a corrupt or truncated cache file

### DIFF
--- a/docs/source/developer/caching.rst
+++ b/docs/source/developer/caching.rst
@@ -84,7 +84,7 @@ If the cache directory is shared on a network filesystem, concurrent
 read/write of the cache is safe only if file replacement operation is atomic
 for the filesystem. Numba always writes to a unique temporary file first, it
 then replaces the target cache file path with the temporary file. Numba is
-tolerant against lost cache files and lost cache entries.
+tolerant against lost or corrupt cache files and cache entries.
 
 .. _cache-clearing:
 

--- a/docs/upcoming_changes/10656.bug_fix.rst
+++ b/docs/upcoming_changes/10656.bug_fix.rst
@@ -3,4 +3,5 @@ Fix ``EOFError`` when loading a corrupt or truncated cache file
 
 A corrupt or truncated on-disk cache file (for example from an
 interrupted write) raised ``EOFError`` on the next run. Numba now treats
-an unreadable cache file as a miss and recompiles the function.
+an unreadable cache file as a miss, emits a ``NumbaWarning``, and
+recompiles the function.

--- a/docs/upcoming_changes/10656.bug_fix.rst
+++ b/docs/upcoming_changes/10656.bug_fix.rst
@@ -1,0 +1,6 @@
+Fix ``EOFError`` when loading a corrupt or truncated cache file
+---------------------------------------------------------------
+
+A corrupt or truncated on-disk cache file (for example from an
+interrupted write) raised ``EOFError`` on the next run. Numba now treats
+an unreadable cache file as a miss and recompiles the function.

--- a/numba/core/caching.py
+++ b/numba/core/caching.py
@@ -577,6 +577,10 @@ class IndexDataCacheFile(object):
         except OSError:
             # File could have been removed while the index still refers it.
             return
+        except (EOFError, pickle.UnpicklingError):
+            # The data file is corrupt or truncated (e.g. an interrupted
+            # write), so treat it as a miss and recompile it.
+            return
 
     def _load_index(self):
         """
@@ -590,11 +594,18 @@ class IndexDataCacheFile(object):
         except FileNotFoundError:
             # Index doesn't exist yet?
             return {}
+        except (EOFError, pickle.UnpicklingError):
+            # Index is corrupt or truncated, so rebuild the cache.
+            return {}
         if version != self._version:
             # This is another version.  Avoid trying to unpickling the
             # rest of the stream, as that may fail.
             return {}
-        stamp, overloads = pickle.loads(data)
+        try:
+            stamp, overloads = pickle.loads(data)
+        except (EOFError, pickle.UnpicklingError):
+            # Index is corrupt or truncated, so rebuild the cache.
+            return {}
         _cache_log("[cache] index loaded from %r", self._index_path)
         if stamp != self._source_stamp:
             # Cache is not fresh.  Stale data files will be eventually

--- a/numba/core/caching.py
+++ b/numba/core/caching.py
@@ -580,7 +580,13 @@ class IndexDataCacheFile(object):
         except (EOFError, pickle.UnpicklingError):
             # The data file is corrupt or truncated (e.g. an interrupted
             # write), so treat it as a miss and recompile it.
+            self._warn_corrupt(self._data_path(data_name))
             return
+
+    def _warn_corrupt(self, path):
+        msg = f"Cache file {path!r} is corrupt and will be rebuilt."
+        warnings.warn(msg, NumbaWarning)
+        _cache_log("[cache] cache file %r is corrupt; rebuilding", path)
 
     def _load_index(self):
         """
@@ -596,6 +602,7 @@ class IndexDataCacheFile(object):
             return {}
         except (EOFError, pickle.UnpicklingError):
             # Index is corrupt or truncated, so rebuild the cache.
+            self._warn_corrupt(self._index_path)
             return {}
         if version != self._version:
             # This is another version.  Avoid trying to unpickling the
@@ -605,6 +612,7 @@ class IndexDataCacheFile(object):
             stamp, overloads = pickle.loads(data)
         except (EOFError, pickle.UnpicklingError):
             # Index is corrupt or truncated, so rebuild the cache.
+            self._warn_corrupt(self._index_path)
             return {}
         _cache_log("[cache] index loaded from %r", self._index_path)
         if stamp != self._source_stamp:

--- a/numba/tests/test_caching.py
+++ b/numba/tests/test_caching.py
@@ -528,6 +528,37 @@ class TestCache(DispatcherCacheUsecasesTest):
         f = mod.add_usecase
         self.assertPreciseEqual(f(2, 3), 15)
 
+    def _corrupt_cache_file(self, suffix, data=b""):
+        # Simulate an interrupted or partial write to a cache file.
+        [name] = [fn for fn in self.cache_contents()
+                  if fn.endswith(suffix)]
+        with open(os.path.join(self.cache_dir, name), "wb") as f:
+            f.write(data)
+
+    def test_corrupt_data_file(self):
+        # An empty data file is a miss, not an EOFError (#10434)
+        mod = self.import_module()
+        f = mod.add_usecase
+        self.assertPreciseEqual(f(2, 3), 6)
+        self.check_pycache(2)  # 1 index, 1 data
+        self._corrupt_cache_file(".nbc")
+        mod = self.import_module()
+        f = mod.add_usecase
+        self.assertPreciseEqual(f(2, 3), 6)
+        self.check_hits(f, 0, 1)
+
+    def test_corrupt_index_file(self):
+        # A garbage index file is a miss, not an UnpicklingError (#10434)
+        mod = self.import_module()
+        f = mod.add_usecase
+        self.assertPreciseEqual(f(2, 3), 6)
+        self.check_pycache(2)  # 1 index, 1 data
+        self._corrupt_cache_file(".nbi", b"not a pickle")
+        mod = self.import_module()
+        f = mod.add_usecase
+        self.assertPreciseEqual(f(2, 3), 6)
+        self.check_hits(f, 0, 1)
+
     def test_same_names(self):
         # Function with the same names should still disambiguate
         mod = self.import_module()

--- a/numba/tests/test_caching.py
+++ b/numba/tests/test_caching.py
@@ -544,8 +544,13 @@ class TestCache(DispatcherCacheUsecasesTest):
         self._corrupt_cache_file(".nbc")
         mod = self.import_module()
         f = mod.add_usecase
-        self.assertPreciseEqual(f(2, 3), 6)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always', NumbaWarning)
+            self.assertPreciseEqual(f(2, 3), 6)
         self.check_hits(f, 0, 1)
+        msgs = [str(x.message) for x in w]
+        self.assertTrue(any('is corrupt and will be rebuilt' in m
+                            for m in msgs), msgs)
 
     def test_corrupt_index_file(self):
         # A garbage index file is a miss, not an UnpicklingError (#10434)
@@ -556,8 +561,27 @@ class TestCache(DispatcherCacheUsecasesTest):
         self._corrupt_cache_file(".nbi", b"not a pickle")
         mod = self.import_module()
         f = mod.add_usecase
-        self.assertPreciseEqual(f(2, 3), 6)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always', NumbaWarning)
+            self.assertPreciseEqual(f(2, 3), 6)
         self.check_hits(f, 0, 1)
+        msgs = [str(x.message) for x in w]
+        self.assertTrue(any('is corrupt and will be rebuilt' in m
+                            for m in msgs), msgs)
+
+    def test_valid_cache_no_warning(self):
+        # A valid cache hit must not emit a corrupt-cache warning (#10434)
+        mod = self.import_module()
+        f = mod.add_usecase
+        self.assertPreciseEqual(f(2, 3), 6)
+        mod = self.import_module()
+        f = mod.add_usecase
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always', NumbaWarning)
+            self.assertPreciseEqual(f(2, 3), 6)
+        self.check_hits(f, 1, 0)
+        msgs = [str(x.message) for x in w]
+        self.assertFalse(any('is corrupt' in m for m in msgs), msgs)
 
     def test_same_names(self):
         # Function with the same names should still disambiguate


### PR DESCRIPTION
A corrupt or truncated cache file makes the next run raise `EOFError` instead of recompiling. This shows up after an interrupted write. `load` only caught `OSError` and `_load_index` only caught a missing index, so an unreadable but present file raised instead of being treated as a miss.

Numba now catches the unpickling errors in both the data-file and index-file load paths and treats the file as a cache miss, so the function recompiles and overwrites it. Missing entries were already handled this way.

Closes #10434
