### PR TITLE
Add cumulative sum ArrayIterator implementation

### DIFF
--- a/docs/upcoming_changes/10657.improvement.rst
+++ b/docs/upcoming_changes/10657.improvement.rst
@@ -1,0 +1,6 @@
+``np.cumsum`` now supports dynamic ``axis`` argument.
+-----------------------------------------------------
+
+The ``np.cumsum`` function now supports a dynamic ``axis`` argument,
+allowing users to specify the axis along which to perform the
+operation at runtime. 

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -766,10 +766,9 @@ def _numpy_cumsum_axis(typingctx, aryty, axisty, dtype):
         acc_shape = get_spliced_tuple(
             context, builder, ary.shape.type, ary.shape, axis
         )
+        acc_type = types.Array(ret_dtype, aryty.ndim - 1, layout='C')
         acc = _empty_nd_impl(
-            context, builder, types.Array(
-                ret_dtype, aryty.ndim - 1, layout='C'
-            ),
+            context, builder, acc_type,
             cgutils.unpack_tuple(builder, acc_shape)
         )
         cgutils.memset(
@@ -816,6 +815,8 @@ def _numpy_cumsum_axis(typingctx, aryty, axisty, dtype):
                 )
                 builder.store(res_val, acc_ptr)
             builder.store(builder.load(acc_ptr), res_ptr)
+
+        context.nrt.decref(builder, acc_type, acc._getvalue())
 
         return impl_ret_new_ref(
             context, builder, sig.return_type, res._getvalue()

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -471,7 +471,7 @@ def _numpy_sum(typingctx, aryty, axisty, dtype):
             (sig.return_type, sig.return_type),
             {}
         )
-        if context.data_model_manager[ret_dtype]._fe_type is bool:
+        if context.data_model_manager[ret_dtype]._fe_type is types.boolean:
             add_funcfn = lambda builder, args: builder.or_(*args)
         else:
             add_funcfn = context.get_function(fnty, fn_sig)
@@ -525,7 +525,7 @@ def _numpy_sum_axis(typingctx, aryty, axisty, dtype):
             (sig.return_type.dtype, sig.return_type.dtype),
             {}
         )
-        if context.data_model_manager[ret_dtype]._fe_type is bool:
+        if context.data_model_manager[ret_dtype]._fe_type is types.boolean:
             add_funcfn = lambda builder, args: builder.or_(*args)
         else:
             add_funcfn = context.get_function(fnty, fn_sig)

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -97,19 +97,22 @@ class EntireIterator():
         cur_index = builder.load(self.index)
         with builder.if_then(builder.icmp_signed('>=', cur_index, self.size),
                              likely=False):
-            builder.store(
-                builder.sub(
-                    builder.load(self.ary_int_ptr),
-                    builder.mul(self.dim_stride, builder.load(self.index))
-                ), self.ary_int_ptr
+            # Reset pointer by subtracting total offset
+            offset = builder.mul(self.dim_stride, builder.load(self.index))
+            neg_offset = builder.sub(Constant(self.ll_intp, 0), offset)
+            new_ptr = cgutils.pointer_add(
+                builder, builder.load(self.ary_int_ptr), neg_offset
             )
+            builder.store(new_ptr, self.ary_int_ptr)
             for i in range(len(self.extra_variations)):
-                builder.store(
-                    builder.sub(builder.load(self.extra_iter_ptrs[i]),
-                                builder.mul(self.extra_dim_strides[i],
-                                            builder.load(self.index))),
-                    self.extra_iter_ptrs[i]
+                offset = builder.mul(
+                    self.extra_dim_strides[i], builder.load(self.index)
                 )
+                neg_offset = builder.sub(Constant(self.ll_intp, 0), offset)
+                new_ptr = cgutils.pointer_add(
+                    builder, builder.load(self.extra_iter_ptrs[i]), neg_offset
+                )
+                builder.store(new_ptr, self.extra_iter_ptrs[i])
             builder.branch(self.bb_end)
         return cur_index
 
@@ -117,17 +120,18 @@ class EntireIterator():
         builder = self.builder
         next_index = cgutils.increment_index(builder, builder.load(self.index))
 
-        builder.store(builder.add(
-            builder.load(self.ary_int_ptr), self.dim_stride
-        ), self.ary_int_ptr)
+        # Advance pointer using pointer_add
+        new_ptr = cgutils.pointer_add(
+            builder, builder.load(self.ary_int_ptr), self.dim_stride
+        )
+        builder.store(new_ptr, self.ary_int_ptr)
         for i in range(len(self.extra_variations)):
-            builder.store(
-                builder.add(
-                    builder.load(self.extra_iter_ptrs[i]),
-                    self.extra_dim_strides[i]
-                ),
-                self.extra_iter_ptrs[i]
+            new_ptr = cgutils.pointer_add(
+                builder,
+                builder.load(self.extra_iter_ptrs[i]),
+                self.extra_dim_strides[i]
             )
+            builder.store(new_ptr, self.extra_iter_ptrs[i])
 
         builder.store(next_index, self.index)
         builder.branch(self.bb_start)
@@ -142,8 +146,8 @@ class ArrayIterator:
         self.aryty = aryty
         self.ary = ary
         self.ll_intp = self.context.get_value_type(types.intp)
-        self.iter_ptr = cgutils.alloca_once(builder, self.ll_intp)
-        builder.store(builder.ptrtoint(ary.data, self.ll_intp), self.iter_ptr)
+        self.iter_ptr = cgutils.alloca_once(builder, ary.data.type)
+        builder.store(ary.data, self.iter_ptr)
         self.extra_iter_ptrs = []
         self.extra_strides = []
         self.extra_variations = []
@@ -162,11 +166,10 @@ class ArrayIterator:
                 )
                 self.extra_variations.append(extra_masks[i])
                 extra_ary = extra_arys[i]
-                extra_iter_ptr = cgutils.alloca_once(builder, self.ll_intp)
-                builder.store(
-                    builder.ptrtoint(extra_ary.data, self.ll_intp),
-                    extra_iter_ptr
+                extra_iter_ptr = cgutils.alloca_once(
+                    builder, extra_ary.data.type
                 )
+                builder.store(extra_ary.data, extra_iter_ptr)
                 self.extra_iter_ptrs.append(extra_iter_ptr)
                 self.extra_types.append(extra_ary.data.type)
 
@@ -246,18 +249,13 @@ class ArrayIterator:
 
         if getattr(self, 'extra_iter_ptrs', None):
             extra_ptrs = [
-                self.builder.inttoptr(
-                    self.builder.load(self.extra_iter_ptrs[i]),
-                    self.extra_types[i]
-                ) for i in range(len(self.extra_iter_ptrs))
+                self.builder.load(self.extra_iter_ptrs[i])
+                for i in range(len(self.extra_iter_ptrs))
             ]
-            return self.builder.inttoptr(
-                self.builder.load(self.iter_ptr), self.ary.data.type
-            ), tuple(extra_ptrs)
+            return self.builder.load(self.iter_ptr), tuple(extra_ptrs)
+
         else:
-            return self.builder.inttoptr(
-                self.builder.load(self.iter_ptr), self.ary.data.type
-            )
+            return self.builder.load(self.iter_ptr)
 
     def loop_tail(self):
         for indexer in reversed(self.indexers):

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -477,8 +477,7 @@ def _numpy_sum(typingctx, aryty, axisty, dtype):
         with ArrayIterator(context, builder, aryty, ary) as iter_val_ptr:
             val = load_item(context, builder, aryty, iter_val_ptr)
             res_val = add_funcfn(builder, (
-                context.data_model_manager[ret_dtype].load_from_data_pointer(
-                    builder, result),
+                builder.load(result),
                 context.cast(builder, val, aryty.dtype, sig.return_type)))
             builder.store(res_val, result)
 
@@ -536,8 +535,7 @@ def _numpy_sum_axis(typingctx, aryty, axisty, dtype):
             res_ptr = res_ptr_tup[0]
             val = load_item(context, builder, aryty, ary_iter_ptr)
             res_val = add_funcfn(builder, (
-                context.data_model_manager[ret_dtype].load_from_data_pointer(
-                    builder, res_ptr),
+                load_item(context, builder, sig.return_type, res_ptr),
                 context.cast(builder, val, aryty.dtype, sig.return_type.dtype)))
             store_item(context, builder, sig.return_type, res_val, res_ptr)
 
@@ -655,8 +653,7 @@ def _numpy_cumsum(typingctx, aryty, axisty, dtype):
             res_ptr = res_ptr_tup[0]
             val = load_item(context, builder, aryty, iter_val_ptr)
             res_val = add_funcfn(builder, (
-                context.data_model_manager[ret_dtype].load_from_data_pointer(
-                    builder, acc),
+                builder.load(acc),
                 context.cast(builder, val, aryty.dtype, sig.return_type.dtype)))
             builder.store(res_val, acc)
             store_item(context, builder, sig.return_type,
@@ -724,8 +721,7 @@ def _numpy_cumsum_axis(typingctx, aryty, axisty, dtype):
             res_ptr, acc_ptr = res_ptr_tup
             val = load_item(context, builder, aryty, ary_iter_ptr)
             res_val = add_funcfn(builder, (
-                context.data_model_manager[ret_dtype].load_from_data_pointer(
-                    builder, acc_ptr),
+                load_item(context, builder, sig.return_type, acc_ptr),
                 context.cast(builder, val, aryty.dtype, sig.return_type.dtype)))
             store_item(context, builder, acc_type, res_val, acc_ptr)
             store_item(context, builder, sig.return_type,

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -470,7 +470,7 @@ def _numpy_sum(typingctx, aryty, axisty, dtype):
             (sig.return_type, sig.return_type),
             {}
         )
-        if context.data_model_manager[ret_dtype]._fe_type is types.boolean:
+        if isinstance(ret_dtype, types.Boolean):
             add_funcfn = lambda builder, args: builder.or_(*args)
         else:
             add_funcfn = context.get_function(fnty, fn_sig)
@@ -525,7 +525,7 @@ def _numpy_sum_axis(typingctx, aryty, axisty, dtype):
             (sig.return_type.dtype, sig.return_type.dtype),
             {}
         )
-        if context.data_model_manager[ret_dtype]._fe_type is types.boolean:
+        if isinstance(ret_dtype, types.Boolean):
             add_funcfn = lambda builder, args: builder.or_(*args)
         else:
             add_funcfn = context.get_function(fnty, fn_sig)
@@ -645,7 +645,7 @@ def _numpy_cumsum(typingctx, aryty, axisty, dtype):
             (sig.return_type.dtype, sig.return_type.dtype),
             {}
         )
-        if context.data_model_manager[ret_dtype]._fe_type is types.boolean:
+        if isinstance(ret_dtype, types.Boolean):
             add_funcfn = lambda builder, args: builder.or_(*args)
         else:
             add_funcfn = context.get_function(fnty, fn_sig)
@@ -710,7 +710,7 @@ def _numpy_cumsum_axis(typingctx, aryty, axisty, dtype):
             (sig.return_type.dtype, sig.return_type.dtype),
             {}
         )
-        if context.data_model_manager[ret_dtype]._fe_type is types.boolean:
+        if isinstance(ret_dtype, types.Boolean):
             add_funcfn = lambda builder, args: builder.or_(*args)
         else:
             add_funcfn = context.get_function(fnty, fn_sig)

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -477,8 +477,8 @@ def _numpy_sum(typingctx, aryty, axisty, dtype):
         with ArrayIterator(context, builder, aryty, ary) as iter_val_ptr:
             val = load_item(context, builder, aryty, iter_val_ptr)
             res_val = add_funcfn(builder, (
-                context.data_model_manager[ret_dtype].from_data(
-                    builder, builder.load(result)),
+                context.data_model_manager[ret_dtype].load_from_data_pointer(
+                    builder, result),
                 context.cast(builder, val, aryty.dtype, sig.return_type)))
             builder.store(res_val, result)
 
@@ -536,8 +536,8 @@ def _numpy_sum_axis(typingctx, aryty, axisty, dtype):
             res_ptr = res_ptr_tup[0]
             val = load_item(context, builder, aryty, ary_iter_ptr)
             res_val = add_funcfn(builder, (
-                context.data_model_manager[ret_dtype].from_data(
-                    builder, builder.load(res_ptr)),
+                context.data_model_manager[ret_dtype].load_from_data_pointer(
+                    builder, res_ptr),
                 context.cast(builder, val, aryty.dtype, sig.return_type.dtype)))
             store_item(context, builder, sig.return_type, res_val, res_ptr)
 
@@ -655,8 +655,8 @@ def _numpy_cumsum(typingctx, aryty, axisty, dtype):
             res_ptr = res_ptr_tup[0]
             val = load_item(context, builder, aryty, iter_val_ptr)
             res_val = add_funcfn(builder, (
-                context.data_model_manager[ret_dtype].from_data(
-                    builder, builder.load(acc)),
+                context.data_model_manager[ret_dtype].load_from_data_pointer(
+                    builder, acc),
                 context.cast(builder, val, aryty.dtype, sig.return_type.dtype)))
             builder.store(res_val, acc)
             store_item(context, builder, sig.return_type,
@@ -724,8 +724,8 @@ def _numpy_cumsum_axis(typingctx, aryty, axisty, dtype):
             res_ptr, acc_ptr = res_ptr_tup
             val = load_item(context, builder, aryty, ary_iter_ptr)
             res_val = add_funcfn(builder, (
-                context.data_model_manager[ret_dtype].from_data(
-                    builder, builder.load(acc_ptr)),
+                context.data_model_manager[ret_dtype].load_from_data_pointer(
+                    builder, acc_ptr),
                 context.cast(builder, val, aryty.dtype, sig.return_type.dtype)))
             store_item(context, builder, acc_type, res_val, acc_ptr)
             store_item(context, builder, sig.return_type,

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -9,7 +9,6 @@ import operator
 import warnings
 
 import llvmlite.ir
-from numba.core.typing import context
 from numba.np.types.datetime import NPDatetime, NPTimedelta
 import numpy as np
 
@@ -480,7 +479,8 @@ def _numpy_sum(typingctx, aryty, axisty, dtype):
         with ArrayIterator(context, builder, aryty, ary) as iter_val_ptr:
             val = load_item(context, builder, aryty, iter_val_ptr)
             res_val = add_funcfn(builder, (
-                context.data_model_manager[ret_dtype].from_data(builder, builder.load(result)),
+                context.data_model_manager[ret_dtype].from_data(
+                    builder, builder.load(result)),
                 context.cast(builder, val, aryty.dtype, sig.return_type)))
             builder.store(res_val, result)
 
@@ -538,7 +538,8 @@ def _numpy_sum_axis(typingctx, aryty, axisty, dtype):
             res_ptr = res_ptr_tup[0]
             val = load_item(context, builder, aryty, ary_iter_ptr)
             res_val = add_funcfn(builder, (
-                context.data_model_manager[ret_dtype].from_data(builder, builder.load(res_ptr)),
+                context.data_model_manager[ret_dtype].from_data(
+                    builder, builder.load(res_ptr)),
                 context.cast(builder, val, aryty.dtype, sig.return_type.dtype)))
             store_item(context, builder, sig.return_type, res_val, res_ptr)
 
@@ -656,10 +657,12 @@ def _numpy_cumsum(typingctx, aryty, axisty, dtype):
             res_ptr = res_ptr_tup[0]
             val = load_item(context, builder, aryty, iter_val_ptr)
             res_val = add_funcfn(builder, (
-                context.data_model_manager[ret_dtype].from_data(builder, builder.load(acc)),
+                context.data_model_manager[ret_dtype].from_data(
+                    builder, builder.load(acc)),
                 context.cast(builder, val, aryty.dtype, sig.return_type.dtype)))
             builder.store(res_val, acc)
-            store_item(context, builder, sig.return_type, builder.load(acc), res_ptr)
+            store_item(context, builder, sig.return_type,
+                       builder.load(acc), res_ptr)
 
         return impl_ret_new_ref(
             context, builder, sig.return_type, res._getvalue()
@@ -723,10 +726,12 @@ def _numpy_cumsum_axis(typingctx, aryty, axisty, dtype):
             res_ptr, acc_ptr = res_ptr_tup
             val = load_item(context, builder, aryty, ary_iter_ptr)
             res_val = add_funcfn(builder, (
-                context.data_model_manager[ret_dtype].from_data(builder, builder.load(acc_ptr)),
+                context.data_model_manager[ret_dtype].from_data(
+                    builder, builder.load(acc_ptr)),
                 context.cast(builder, val, aryty.dtype, sig.return_type.dtype)))
             store_item(context, builder, acc_type, res_val, acc_ptr)
-            store_item(context, builder, sig.return_type, builder.load(acc_ptr), res_ptr)
+            store_item(context, builder, sig.return_type,
+                       builder.load(acc_ptr), res_ptr)
 
         context.nrt.decref(builder, acc_type, acc._getvalue())
 

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -154,32 +154,13 @@ class ArrayIterator:
             assert len(extra_masks) == len(extra_arys)
             extra_masks = list(extra_masks)
             for i in range(len(extra_masks)):
-                # Wraparound for negative axis, convert to positive axis
-                extra_masks[i] = builder.add(
-                    extra_masks[i],
-                    builder.select(
-                        builder.icmp_signed(
-                            '<', extra_masks[i], Constant(self.ll_intp, 0)
-                        ), Constant(self.ll_intp, aryty.ndim),
-                        Constant(self.ll_intp, 0)))
-                # Check if axis is valid for the given array
-                is_not_valid = builder.or_(
-                    builder.icmp_signed(
-                        '>=', extra_masks[i],
-                        Constant(self.ll_intp, aryty.ndim)),
-                    builder.icmp_signed(
-                        '<', extra_masks[i],
-                        Constant(self.ll_intp, 0))
+                self.extra_strides.append(
+                    self.make_stride_from_mask(
+                        context, builder, extra_masks[i],
+                        extra_arys[i].strides
+                    )
                 )
-                with builder.if_then(is_not_valid, likely=True):
-                    context.call_conv.return_user_exc(
-                        builder, ValueError,
-                        ("Axis out of bounds.",))
-                mask_tup = get_mask(
-                    context, builder,
-                    ary.shape.type.count, extra_masks[i]
-                )
-                self.extra_variations.append(mask_tup)
+                self.extra_variations.append(extra_masks[i])
                 extra_ary = extra_arys[i]
                 extra_iter_ptr = cgutils.alloca_once(builder, self.ll_intp)
                 builder.store(
@@ -188,11 +169,6 @@ class ArrayIterator:
                 )
                 self.extra_iter_ptrs.append(extra_iter_ptr)
                 self.extra_types.append(extra_ary.data.type)
-                self.extra_strides.append(tuple_additem(
-                    context, builder, extra_ary.strides.type,
-                    extra_ary.strides, extra_masks[i],
-                    Constant(context.get_value_type(types.intp), 0))
-                )
 
         self.indexers = [
             EntireIterator(
@@ -207,6 +183,49 @@ class ArrayIterator:
                 self.extra_iter_ptrs,
             ) for dim in range(aryty.ndim)
         ]
+
+    def make_stride_from_mask(self, context, builder, mask, strides):
+        # Create resulting tuple type
+        result_tuple_ty = types.UniTuple(types.intp, mask.type.count)
+        result_tuple = cgutils.get_null_value(
+            context.get_value_type(result_tuple_ty)
+        )
+        stack = cgutils.alloca_once(builder, result_tuple.type)
+        builder.store(result_tuple, stack)
+        strides_stack = cgutils.alloca_once(builder, strides.type)
+        builder.store(strides, strides_stack)
+        zero = Constant(self.ll_intp, 0)
+        acc = cgutils.alloca_once(builder, self.ll_intp)
+        builder.store(zero, acc)
+
+        for i in range(mask.type.count):
+            with builder.if_then(builder.extract_value(mask, i)):
+                # Get the stride at the current index in the original tuple.
+                offptr = builder.gep(
+                    strides_stack, [zero.type(0), builder.load(acc)],
+                    inbounds=True
+                )
+                stride_val = builder.load(offptr)
+                # Store the stride value in the result tuple
+                offptr = builder.gep(
+                    stack, [zero.type(0), Constant(self.ll_intp, i)],
+                    inbounds=True
+                )
+                builder.store(stride_val, offptr)
+                # Increment the index
+                builder.store(builder.add(
+                    builder.load(acc), Constant(self.ll_intp, 1)
+                ), acc)
+
+            with builder.if_then(builder.not_(builder.extract_value(mask, i))):
+                # Set the stride to 0 in the result tuple
+                offptr = builder.gep(
+                    stack, [zero.type(0), Constant(self.ll_intp, i)],
+                    inbounds=True
+                )
+                builder.store(Constant(self.ll_intp, 0), offptr)
+
+        return builder.load(stack)
 
     def prepare(self):
         for indexer in self.indexers:
@@ -354,12 +373,16 @@ def tuple_additem(context, builder, tuplety, tupleval, idx, val):
     return builder.load(stack)
 
 
-def get_mask(context, builder, mask_length, axis):
+def get_mask(context, builder, mask_length, axis, inverted=False):
     # Return a tuple of booleans where the value is True if the
     # dimension is not the axis and False if it is the axis.
     # Axis is a runtime value.
 
+    if not isinstance(axis, (list, tuple)):
+        axis = [axis]
+
     ll_intp = context.get_value_type(types.intp)
+    ll_bool = context.get_value_type(types.boolean)
 
     # Create an empty tuple to hold the result, the resulting tuple
     # has the same number of dimensions as the original tuple,
@@ -373,11 +396,38 @@ def get_mask(context, builder, mask_length, axis):
     stack = cgutils.alloca_once(builder, result_tuple.type)
     builder.store(result_tuple, stack)
 
-    for i in range(mask_length):
-        idx = Constant(ll_intp, i)
-        val = builder.icmp_signed('!=', idx, axis)
-        offptr = builder.gep(stack, [idx.type(0), idx], inbounds=True)
-        builder.store(val, offptr)
+    for _axis in axis:
+        if _axis is not None:
+            # Wraparound for negative axis, convert to positive axis
+            _axis = builder.add(
+                _axis,
+                builder.select(
+                    builder.icmp_signed('<', _axis, Constant(ll_intp, 0)),
+                    Constant(ll_intp, mask_length), Constant(ll_intp, 0)
+                )
+            )
+            # Check if axis is valid for the given array
+            is_not_valid = builder.or_(
+                builder.icmp_signed(
+                    '>=', _axis,
+                    Constant(ll_intp, mask_length)
+                ),
+                builder.icmp_signed('<', _axis, Constant(ll_intp, 0))
+            )
+            with builder.if_then(is_not_valid, likely=True):
+                context.call_conv.return_user_exc(
+                    builder, ValueError,
+                    ("Axis out of bounds.",))
+        for i in range(mask_length):
+            idx = Constant(ll_intp, i)
+            if _axis is not None:
+                val = builder.icmp_signed('!=', idx, _axis)
+            else:
+                val = Constant(ll_bool, 1)
+            if inverted:
+                val = builder.not_(val)
+            offptr = builder.gep(stack, [idx.type(0), idx], inbounds=True)
+            builder.store(val, offptr)
 
     return builder.load(stack)
 
@@ -497,9 +547,10 @@ def _numpy_sum_axis(typingctx, aryty, axisty, dtype):
         )
         add_funcfn = context.get_function(fnty, fn_sig)
 
+        mask = get_mask(context, builder, aryty.ndim, axis)
         # Loop on source and copy to destination
         with ArrayIterator(
-            context, builder, aryty, ary, (axis,), (res,)
+            context, builder, aryty, ary, (mask,), (res,)
         ) as (ary_iter_ptr, res_ptr_tup):
             res_ptr = res_ptr_tup[0]
             val = load_item(context, builder, aryty, ary_iter_ptr)
@@ -595,29 +646,206 @@ def array_prod(a):
         return scalar_prod_impl
 
 
+@intrinsic
+def _numpy_cumsum(typingctx, aryty, axisty, dtype):
+    if is_nonelike(dtype):
+        ret_dtype = aryty.dtype
+        if ret_dtype == types.bool_:
+            ret_dtype = types.intp
+        if (
+            isinstance(aryty.dtype, types.Integer) and
+            aryty.dtype.bitwidth < types.intp.bitwidth
+        ):
+            # For signed integers smaller than intp,
+            # use intp as the accumulator
+            ret_dtype = types.intp
+    else:
+        ret_dtype = dtype.dtype
+
+    ret = types.Array(ret_dtype, aryty.ndim, layout='C')
+    sig = ret(aryty, axisty, dtype)
+
+    def codegen(context, builder, sig, args):
+        ary, _, _ = args
+
+        ary = make_array(aryty)(context, builder, ary)
+        if isinstance(ret_dtype, types.NPTimedelta):
+            zero = context.get_constant(ret_dtype, ret_dtype(0))
+        else:
+            zero = context.get_constant(ret_dtype, 0)
+        acc = cgutils.alloca_once_value(builder, zero)
+
+        res = _empty_nd_impl(
+            context, builder, sig.return_type,
+            cgutils.unpack_tuple(builder, ary.shape)
+        )
+        cgutils.memset(
+            builder, res.data,
+            builder.mul(res.itemsize, res.nitems), 0
+        )
+
+        fnty = context.typing_context.resolve_value_type(operator.iadd)
+        fn_sig = fnty.get_call_type(
+            context.typing_context,
+            (sig.return_type.dtype, sig.return_type.dtype),
+            {}
+        )
+        add_funcfn = context.get_function(fnty, fn_sig)
+        mask = get_mask(context, builder, aryty.ndim, None)
+        # Loop on source and copy to destination
+        with ArrayIterator(context, builder, aryty, ary,
+                           (mask,), (res,)) as (iter_val_ptr, res_ptr_tup):
+            res_ptr = res_ptr_tup[0]
+            val = load_item(context, builder, aryty, iter_val_ptr)
+            if isinstance(ret_dtype, types.Boolean):
+                # This is required because NumPy booleans are stored as 8-bit
+                # integers whilst in llvm they are 1-bit, so we need to
+                # zero-extend them instead of a builder.cast.
+                res_val = builder.load(acc)
+                res_val = builder.or_(
+                    res_val,
+                    builder.zext(
+                        val,
+                        llvmlite.ir.IntType(res_val.type.width)
+                    )
+                )
+                builder.store(res_val, acc)
+            else:
+                res_val = add_funcfn(builder, (
+                    builder.load(acc),
+                    context.cast(builder, val, aryty.dtype,
+                                 sig.return_type.dtype)))
+                builder.store(res_val, acc)
+            builder.store(builder.load(acc), res_ptr)
+
+        return impl_ret_new_ref(
+            context, builder, sig.return_type, res._getvalue()
+        )
+
+    return sig, codegen
+
+
+@intrinsic
+def _numpy_cumsum_axis(typingctx, aryty, axisty, dtype):
+    assert isinstance(axisty, types.Integer), \
+        "Only integer axis supported for now"
+
+    if is_nonelike(dtype):
+        ret_dtype = aryty.dtype
+        if ret_dtype == types.bool_:
+            # This is required to match NumPy's behavior where
+            # bools are promoted to intp for cumsum
+            ret_dtype = types.intp
+        if (
+            isinstance(aryty.dtype, types.Integer)
+            and aryty.dtype.bitwidth < types.intp.bitwidth
+        ):
+            # For signed integers smaller than intp,
+            # use intp as the accumulator
+            ret_dtype = types.intp
+    else:
+        ret_dtype = dtype.dtype
+
+    ret = types.Array(ret_dtype, aryty.ndim, layout='C')
+    sig = ret(aryty, axisty, dtype)
+
+    def codegen(context, builder, sig, args):
+        ary, axis, _ = args
+
+        ary = make_array(aryty)(context, builder, ary)
+
+        res = _empty_nd_impl(
+            context, builder, sig.return_type,
+            cgutils.unpack_tuple(builder, ary.shape)
+        )
+        cgutils.memset(
+            builder, res.data,
+            builder.mul(res.itemsize, res.nitems), 0
+        )
+
+        acc_shape = get_spliced_tuple(
+            context, builder, ary.shape.type, ary.shape, axis
+        )
+        acc = _empty_nd_impl(
+            context, builder, types.Array(
+                ret_dtype, aryty.ndim - 1, layout='C'
+            ),
+            cgutils.unpack_tuple(builder, acc_shape)
+        )
+        cgutils.memset(
+            builder, acc.data,
+            builder.mul(acc.itemsize, acc.nitems), 0
+        )
+
+        fnty = context.typing_context.resolve_value_type(operator.iadd)
+        fn_sig = fnty.get_call_type(
+            context.typing_context,
+            (sig.return_type.dtype, sig.return_type.dtype),
+            {}
+        )
+        add_funcfn = context.get_function(fnty, fn_sig)
+        mask = get_mask(context, builder, aryty.ndim, None)
+        inverted_mask = get_mask(context, builder, aryty.ndim, axis)
+
+        # Loop on source and copy to destination
+        with ArrayIterator(
+            context, builder, aryty, ary, (mask, inverted_mask),
+            (res, acc)
+        ) as (ary_iter_ptr, res_ptr_tup):
+            res_ptr, acc_ptr = res_ptr_tup
+            val = load_item(context, builder, aryty, ary_iter_ptr)
+            if isinstance(ret_dtype, types.Boolean):
+                # This is required because NumPy booleans are stored as 8-bit
+                # integers whilst in llvm they are 1-bit, so we need to
+                # zero-extend them instead of a builder.cast.
+                res_val = builder.load(acc_ptr)
+                res_val = builder.or_(
+                    res_val,
+                    builder.zext(
+                        val,
+                        llvmlite.ir.IntType(res_val.type.width)
+                    )
+                )
+                builder.store(res_val, acc_ptr)
+            else:
+                res_val = add_funcfn(builder, (
+                    builder.load(acc_ptr),
+                    context.cast(
+                        builder, val, aryty.dtype,
+                        sig.return_type.dtype))
+                )
+                builder.store(res_val, acc_ptr)
+            builder.store(builder.load(acc_ptr), res_ptr)
+
+        return impl_ret_new_ref(
+            context, builder, sig.return_type, res._getvalue()
+        )
+
+    return sig, codegen
+
+
 @overload(np.cumsum)
 @overload_method(types.Array, "cumsum")
-def array_cumsum(a):
+def array_cumsum(a, axis=None, dtype=None):
     if isinstance(a, types.Array):
-        is_integer = a.dtype in types.signed_domain
-        is_bool = a.dtype == types.bool_
-        if (is_integer and a.dtype.bitwidth < types.intp.bitwidth)\
-                or is_bool:
-            dtype = as_dtype(types.intp)
+        if is_nonelike(axis):
+            def array_cumsum_impl(a, axis=None, dtype=None):
+                return _numpy_cumsum(a, axis, dtype).reshape(a.size)
         else:
-            dtype = as_dtype(a.dtype)
-
-        acc_init = get_accumulator(dtype, 0)
-
-        def array_cumsum_impl(a):
-            out = np.empty(a.size, dtype)
-            c = acc_init
-            for idx, v in enumerate(a.flat):
-                c += v
-                out[idx] = c
-            return out
+            def array_cumsum_impl(a, axis=None, dtype=None):
+                return _numpy_cumsum_axis(a, axis, dtype)
 
         return array_cumsum_impl
+    elif isinstance(a, (types.Number, types.Boolean)):
+        if is_nonelike(dtype):
+            acc_init = as_dtype(a).type(0)
+        else:
+            acc_init = as_dtype(dtype).type(0)
+
+        def scalar_cumsum_impl(a, axis=None, dtype=None):
+            return acc_init + a
+
+        return scalar_cumsum_impl
 
 
 @overload(np.cumprod)

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -9,6 +9,7 @@ import operator
 import warnings
 
 import llvmlite.ir
+from numba.core.typing import context
 from numba.np.types.datetime import NPDatetime, NPTimedelta
 import numpy as np
 
@@ -432,8 +433,7 @@ def get_mask(context, builder, mask_length, axis, inverted=False):
     return builder.load(stack)
 
 
-@intrinsic
-def _numpy_sum(typingctx, aryty, axisty, dtype):
+def get_ret_dtype_if_any(aryty, dtype):
     if is_nonelike(dtype):
         ret_dtype = aryty.dtype
         if ret_dtype == types.bool_:
@@ -447,7 +447,12 @@ def _numpy_sum(typingctx, aryty, axisty, dtype):
             ret_dtype = types.intp
     else:
         ret_dtype = dtype.dtype
+    return ret_dtype
 
+
+@intrinsic
+def _numpy_sum(typingctx, aryty, axisty, dtype):
+    ret_dtype = get_ret_dtype_if_any(aryty, dtype)
     sig = ret_dtype(aryty, axisty, dtype)
 
     def codegen(context, builder, sig, args):
@@ -466,29 +471,18 @@ def _numpy_sum(typingctx, aryty, axisty, dtype):
             (sig.return_type, sig.return_type),
             {}
         )
-        add_funcfn = context.get_function(fnty, fn_sig)
+        if context.data_model_manager[ret_dtype]._fe_type is bool:
+            add_funcfn = lambda builder, args: builder.or_(*args)
+        else:
+            add_funcfn = context.get_function(fnty, fn_sig)
 
         # Loop on source and copy to destination
         with ArrayIterator(context, builder, aryty, ary) as iter_val_ptr:
             val = load_item(context, builder, aryty, iter_val_ptr)
-            if isinstance(ret_dtype, types.Boolean):
-                # This is required because NumPy booleans are stored as 8-bit
-                # integers whilst in llvm they are 1-bit, so we need to
-                # zero-extend them instead of a builder.cast.
-                res_val = builder.load(result)
-                res_val = builder.or_(
-                    res_val,
-                    builder.zext(
-                        val,
-                        llvmlite.ir.IntType(res_val.type.width)
-                    )
-                )
-                builder.store(res_val, result)
-            else:
-                res_val = add_funcfn(builder, (
-                    builder.load(result),
-                    context.cast(builder, val, aryty.dtype, sig.return_type)))
-                builder.store(res_val, result)
+            res_val = add_funcfn(builder, (
+                context.data_model_manager[ret_dtype].from_data(builder, builder.load(result)),
+                context.data_model_manager[ret_dtype].from_data(builder, context.cast(builder, val, aryty.dtype, sig.return_type))))
+            builder.store(res_val, result)
 
         return impl_ret_borrowed(
             context, builder, sig.return_type, builder.load(result)
@@ -499,21 +493,7 @@ def _numpy_sum(typingctx, aryty, axisty, dtype):
 
 @intrinsic
 def _numpy_sum_axis(typingctx, aryty, axisty, dtype):
-    if is_nonelike(dtype):
-        ret_dtype = aryty.dtype
-        if ret_dtype == types.bool_:
-            # This is required to match NumPy's behavior where
-            # bools are promoted to intp for sum
-            ret_dtype = types.intp
-        if (
-            isinstance(aryty.dtype, types.Integer)
-            and aryty.dtype.bitwidth < types.intp.bitwidth
-        ):
-            # For signed integers smaller than intp,
-            # use intp as the accumulator
-            ret_dtype = types.intp
-    else:
-        ret_dtype = dtype.dtype
+    ret_dtype = get_ret_dtype_if_any(aryty, dtype)
 
     assert aryty.ndim > 0, \
         "Array must have at least 1 dimension for sum with axis"
@@ -545,7 +525,10 @@ def _numpy_sum_axis(typingctx, aryty, axisty, dtype):
             (sig.return_type.dtype, sig.return_type.dtype),
             {}
         )
-        add_funcfn = context.get_function(fnty, fn_sig)
+        if context.data_model_manager[ret_dtype]._fe_type is bool:
+            add_funcfn = lambda builder, args: builder.or_(*args)
+        else:
+            add_funcfn = context.get_function(fnty, fn_sig)
 
         mask = get_mask(context, builder, aryty.ndim, axis)
         # Loop on source and copy to destination
@@ -554,27 +537,10 @@ def _numpy_sum_axis(typingctx, aryty, axisty, dtype):
         ) as (ary_iter_ptr, res_ptr_tup):
             res_ptr = res_ptr_tup[0]
             val = load_item(context, builder, aryty, ary_iter_ptr)
-            if isinstance(ret_dtype, types.Boolean):
-                # This is required because NumPy booleans are stored as 8-bit
-                # integers whilst in llvm they are 1-bit, so we need to
-                # zero-extend them instead of a builder.cast.
-                res_val = builder.load(res_ptr)
-                res_val = builder.or_(
-                    res_val,
-                    builder.zext(
-                        val,
-                        llvmlite.ir.IntType(res_val.type.width)
-                    )
-                )
-                builder.store(res_val, res_ptr)
-            else:
-                res_val = add_funcfn(builder, (
-                    builder.load(res_ptr),
-                    context.cast(
-                        builder, val, aryty.dtype,
-                        sig.return_type.dtype))
-                )
-                builder.store(res_val, res_ptr)
+            res_val = add_funcfn(builder, (
+                context.data_model_manager[ret_dtype].from_data(builder, builder.load(res_ptr)),
+                context.data_model_manager[ret_dtype].from_data(builder, context.cast(builder, val, aryty.dtype, sig.return_type.dtype))))
+            builder.store(context.data_model_manager[ret_dtype].as_data(builder, res_val), res_ptr)
 
         return impl_ret_new_ref(
             context, builder, sig.return_type, res._getvalue()
@@ -648,19 +614,7 @@ def array_prod(a):
 
 @intrinsic
 def _numpy_cumsum(typingctx, aryty, axisty, dtype):
-    if is_nonelike(dtype):
-        ret_dtype = aryty.dtype
-        if ret_dtype == types.bool_:
-            ret_dtype = types.intp
-        if (
-            isinstance(aryty.dtype, types.Integer) and
-            aryty.dtype.bitwidth < types.intp.bitwidth
-        ):
-            # For signed integers smaller than intp,
-            # use intp as the accumulator
-            ret_dtype = types.intp
-    else:
-        ret_dtype = dtype.dtype
+    ret_dtype = get_ret_dtype_if_any(aryty, dtype)
 
     ret = types.Array(ret_dtype, aryty.ndim, layout='C')
     sig = ret(aryty, axisty, dtype)
@@ -690,33 +644,22 @@ def _numpy_cumsum(typingctx, aryty, axisty, dtype):
             (sig.return_type.dtype, sig.return_type.dtype),
             {}
         )
-        add_funcfn = context.get_function(fnty, fn_sig)
+        if context.data_model_manager[ret_dtype]._fe_type is bool:
+            add_funcfn = lambda builder, args: builder.or_(*args)
+        else:
+            add_funcfn = context.get_function(fnty, fn_sig)
+
         mask = get_mask(context, builder, aryty.ndim, None)
         # Loop on source and copy to destination
         with ArrayIterator(context, builder, aryty, ary,
                            (mask,), (res,)) as (iter_val_ptr, res_ptr_tup):
             res_ptr = res_ptr_tup[0]
             val = load_item(context, builder, aryty, iter_val_ptr)
-            if isinstance(ret_dtype, types.Boolean):
-                # This is required because NumPy booleans are stored as 8-bit
-                # integers whilst in llvm they are 1-bit, so we need to
-                # zero-extend them instead of a builder.cast.
-                res_val = builder.load(acc)
-                res_val = builder.or_(
-                    res_val,
-                    builder.zext(
-                        val,
-                        llvmlite.ir.IntType(res_val.type.width)
-                    )
-                )
-                builder.store(res_val, acc)
-            else:
-                res_val = add_funcfn(builder, (
-                    builder.load(acc),
-                    context.cast(builder, val, aryty.dtype,
-                                 sig.return_type.dtype)))
-                builder.store(res_val, acc)
-            builder.store(builder.load(acc), res_ptr)
+            res_val = add_funcfn(builder, (
+                context.data_model_manager[ret_dtype].from_data(builder, builder.load(acc)),
+                context.data_model_manager[ret_dtype].from_data(builder, context.cast(builder, val, aryty.dtype, sig.return_type.dtype))))
+            builder.store(res_val, acc)
+            builder.store(context.data_model_manager[ret_dtype].as_data(builder, builder.load(acc)), res_ptr)
 
         return impl_ret_new_ref(
             context, builder, sig.return_type, res._getvalue()
@@ -727,25 +670,7 @@ def _numpy_cumsum(typingctx, aryty, axisty, dtype):
 
 @intrinsic
 def _numpy_cumsum_axis(typingctx, aryty, axisty, dtype):
-    assert isinstance(axisty, types.Integer), \
-        "Only integer axis supported for now"
-
-    if is_nonelike(dtype):
-        ret_dtype = aryty.dtype
-        if ret_dtype == types.bool_:
-            # This is required to match NumPy's behavior where
-            # bools are promoted to intp for cumsum
-            ret_dtype = types.intp
-        if (
-            isinstance(aryty.dtype, types.Integer)
-            and aryty.dtype.bitwidth < types.intp.bitwidth
-        ):
-            # For signed integers smaller than intp,
-            # use intp as the accumulator
-            ret_dtype = types.intp
-    else:
-        ret_dtype = dtype.dtype
-
+    ret_dtype = get_ret_dtype_if_any(aryty, dtype)
     ret = types.Array(ret_dtype, aryty.ndim, layout='C')
     sig = ret(aryty, axisty, dtype)
 
@@ -782,7 +707,11 @@ def _numpy_cumsum_axis(typingctx, aryty, axisty, dtype):
             (sig.return_type.dtype, sig.return_type.dtype),
             {}
         )
-        add_funcfn = context.get_function(fnty, fn_sig)
+        if context.data_model_manager[ret_dtype]._fe_type is bool:
+            add_funcfn = lambda builder, args: builder.or_(*args)
+        else:
+            add_funcfn = context.get_function(fnty, fn_sig)
+
         mask = get_mask(context, builder, aryty.ndim, None)
         inverted_mask = get_mask(context, builder, aryty.ndim, axis)
 
@@ -793,27 +722,10 @@ def _numpy_cumsum_axis(typingctx, aryty, axisty, dtype):
         ) as (ary_iter_ptr, res_ptr_tup):
             res_ptr, acc_ptr = res_ptr_tup
             val = load_item(context, builder, aryty, ary_iter_ptr)
-            if isinstance(ret_dtype, types.Boolean):
-                # This is required because NumPy booleans are stored as 8-bit
-                # integers whilst in llvm they are 1-bit, so we need to
-                # zero-extend them instead of a builder.cast.
-                res_val = builder.load(acc_ptr)
-                res_val = builder.or_(
-                    res_val,
-                    builder.zext(
-                        val,
-                        llvmlite.ir.IntType(res_val.type.width)
-                    )
-                )
-                builder.store(res_val, acc_ptr)
-            else:
-                res_val = add_funcfn(builder, (
-                    builder.load(acc_ptr),
-                    context.cast(
-                        builder, val, aryty.dtype,
-                        sig.return_type.dtype))
-                )
-                builder.store(res_val, acc_ptr)
+            res_val = add_funcfn(builder, (
+                context.data_model_manager[ret_dtype].from_data(builder, builder.load(acc_ptr)),
+                context.data_model_manager[ret_dtype].from_data(builder, context.cast(builder, val, aryty.dtype, sig.return_type.dtype))))
+            builder.store(context.data_model_manager[ret_dtype].as_data(builder, res_val), acc_ptr)
             builder.store(builder.load(acc_ptr), res_ptr)
 
         context.nrt.decref(builder, acc_type, acc._getvalue())
@@ -828,12 +740,27 @@ def _numpy_cumsum_axis(typingctx, aryty, axisty, dtype):
 @overload(np.cumsum)
 @overload_method(types.Array, "cumsum")
 def array_cumsum(a, axis=None, dtype=None):
+    if not (isinstance(axis, types.Integer) or is_nonelike(axis)):
+        raise TypingError(
+            "NumPy cumsum only suppports integer axis value"
+        )
     if isinstance(a, types.Array):
-        if is_nonelike(axis):
+        axis_length = 1
+        if is_nonelike(axis) or a.ndim == axis_length:
             def array_cumsum_impl(a, axis=None, dtype=None):
-                return _numpy_cumsum(a, axis, dtype).reshape(a.size)
+                if axis is not None and (axis < -a.ndim or axis >= a.ndim):
+                    raise ValueError(
+                        f"axis {axis} is out of bounds for "
+                        f"array of dimension {a.ndim}"
+                    )
+                return _numpy_cumsum(a, axis, dtype)
         else:
             def array_cumsum_impl(a, axis=None, dtype=None):
+                if axis is not None and (axis < -a.ndim or axis >= a.ndim):
+                    raise ValueError(
+                        f"axis {axis} is out of bounds for "
+                        f"array of dimension {a.ndim}"
+                    )
                 return _numpy_cumsum_axis(a, axis, dtype)
 
         return array_cumsum_impl

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -481,7 +481,7 @@ def _numpy_sum(typingctx, aryty, axisty, dtype):
             val = load_item(context, builder, aryty, iter_val_ptr)
             res_val = add_funcfn(builder, (
                 context.data_model_manager[ret_dtype].from_data(builder, builder.load(result)),
-                context.data_model_manager[ret_dtype].from_data(builder, context.cast(builder, val, aryty.dtype, sig.return_type))))
+                context.cast(builder, val, aryty.dtype, sig.return_type)))
             builder.store(res_val, result)
 
         return impl_ret_borrowed(
@@ -539,8 +539,8 @@ def _numpy_sum_axis(typingctx, aryty, axisty, dtype):
             val = load_item(context, builder, aryty, ary_iter_ptr)
             res_val = add_funcfn(builder, (
                 context.data_model_manager[ret_dtype].from_data(builder, builder.load(res_ptr)),
-                context.data_model_manager[ret_dtype].from_data(builder, context.cast(builder, val, aryty.dtype, sig.return_type.dtype))))
-            builder.store(context.data_model_manager[ret_dtype].as_data(builder, res_val), res_ptr)
+                context.cast(builder, val, aryty.dtype, sig.return_type.dtype)))
+            store_item(context, builder, sig.return_type, res_val, res_ptr)
 
         return impl_ret_new_ref(
             context, builder, sig.return_type, res._getvalue()
@@ -644,7 +644,7 @@ def _numpy_cumsum(typingctx, aryty, axisty, dtype):
             (sig.return_type.dtype, sig.return_type.dtype),
             {}
         )
-        if context.data_model_manager[ret_dtype]._fe_type is bool:
+        if context.data_model_manager[ret_dtype]._fe_type is types.boolean:
             add_funcfn = lambda builder, args: builder.or_(*args)
         else:
             add_funcfn = context.get_function(fnty, fn_sig)
@@ -657,9 +657,9 @@ def _numpy_cumsum(typingctx, aryty, axisty, dtype):
             val = load_item(context, builder, aryty, iter_val_ptr)
             res_val = add_funcfn(builder, (
                 context.data_model_manager[ret_dtype].from_data(builder, builder.load(acc)),
-                context.data_model_manager[ret_dtype].from_data(builder, context.cast(builder, val, aryty.dtype, sig.return_type.dtype))))
+                context.cast(builder, val, aryty.dtype, sig.return_type.dtype)))
             builder.store(res_val, acc)
-            builder.store(context.data_model_manager[ret_dtype].as_data(builder, builder.load(acc)), res_ptr)
+            store_item(context, builder, sig.return_type, builder.load(acc), res_ptr)
 
         return impl_ret_new_ref(
             context, builder, sig.return_type, res._getvalue()
@@ -707,7 +707,7 @@ def _numpy_cumsum_axis(typingctx, aryty, axisty, dtype):
             (sig.return_type.dtype, sig.return_type.dtype),
             {}
         )
-        if context.data_model_manager[ret_dtype]._fe_type is bool:
+        if context.data_model_manager[ret_dtype]._fe_type is types.boolean:
             add_funcfn = lambda builder, args: builder.or_(*args)
         else:
             add_funcfn = context.get_function(fnty, fn_sig)
@@ -724,9 +724,9 @@ def _numpy_cumsum_axis(typingctx, aryty, axisty, dtype):
             val = load_item(context, builder, aryty, ary_iter_ptr)
             res_val = add_funcfn(builder, (
                 context.data_model_manager[ret_dtype].from_data(builder, builder.load(acc_ptr)),
-                context.data_model_manager[ret_dtype].from_data(builder, context.cast(builder, val, aryty.dtype, sig.return_type.dtype))))
-            builder.store(context.data_model_manager[ret_dtype].as_data(builder, res_val), acc_ptr)
-            builder.store(builder.load(acc_ptr), res_ptr)
+                context.cast(builder, val, aryty.dtype, sig.return_type.dtype)))
+            store_item(context, builder, acc_type, res_val, acc_ptr)
+            store_item(context, builder, sig.return_type, builder.load(acc_ptr), res_ptr)
 
         context.nrt.decref(builder, acc_type, acc._getvalue())
 
@@ -753,7 +753,7 @@ def array_cumsum(a, axis=None, dtype=None):
                         f"axis {axis} is out of bounds for "
                         f"array of dimension {a.ndim}"
                     )
-                return _numpy_cumsum(a, axis, dtype)
+                return _numpy_cumsum(a, axis, dtype).reshape(a.size)
         else:
             def array_cumsum_impl(a, axis=None, dtype=None):
                 if axis is not None and (axis < -a.ndim or axis >= a.ndim):

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -721,11 +721,11 @@ def _numpy_cumsum_axis(typingctx, aryty, axisty, dtype):
             res_ptr, acc_ptr = res_ptr_tup
             val = load_item(context, builder, aryty, ary_iter_ptr)
             res_val = add_funcfn(builder, (
-                load_item(context, builder, sig.return_type, acc_ptr),
+                load_item(context, builder, acc_type, acc_ptr),
                 context.cast(builder, val, aryty.dtype, sig.return_type.dtype)))
             store_item(context, builder, acc_type, res_val, acc_ptr)
             store_item(context, builder, sig.return_type,
-                       builder.load(acc_ptr), res_ptr)
+                       load_item(context, builder, acc_type, acc_ptr), res_ptr)
 
         context.nrt.decref(builder, acc_type, acc._getvalue())
 

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -205,6 +205,9 @@ def array_sum_dtype_kws(a, dtype):
 def array_sum_axis_dtype_kws(a, dtype, axis):
     return a.sum(axis=axis, dtype=dtype)
 
+def array_cumsum_axis_dtype_kws(a, dtype, axis):
+    return a.cumsum(axis=axis, dtype=dtype)
+
 def array_sum_axis_dtype_pos(a, a1, a2):
     return a.sum(a1, a2)
 
@@ -1579,19 +1582,35 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         )
 
     def test_cumsum(self):
-        pyfunc = array_cumsum
+        """ test cumsum with axis and dtype parameters over a whole range of dtypes """
+        pyfunc = array_cumsum_axis_dtype_kws
         cfunc = jit(nopython=True)(pyfunc)
-        # OK
-        a = np.ones((2, 3))
-        self.assertPreciseEqual(pyfunc(a), cfunc(a))
-        # BAD: with axis
-        with self.assertRaises(TypingError):
-            cfunc(a, 1)
-        # BAD: with kw axis
-        pyfunc = array_cumsum_kws
-        cfunc = jit(nopython=True)(pyfunc)
-        with self.assertRaises(TypingError):
-            cfunc(a, axis=1)
+        signed_dtypes = [np.float64, np.float32, np.int64, np.int32,
+                      np.complex64, np.complex128]
+
+        unsigned_dtypes = [np.uint32, np.uint64, np.bool_]
+
+        out_dtypes = {np.dtype('float64'): [np.float64],
+                      np.dtype('float32'): [np.float64, np.float32],
+                      np.dtype('int64'): [np.float64, np.int64, np.float32],
+                      np.dtype('int32'): [np.float64, np.int64, np.float32, np.int32],
+                      np.dtype('uint32'): [np.float64, np.int64, np.float32],
+                      np.dtype('uint64'): [np.float64, np.uint64],
+                      np.dtype('bool'): [np.float64, np.int64, np.float32, np.int32, np.bool_],
+                      np.dtype('complex64'): [np.complex64, np.complex128],
+                      np.dtype('complex128'): [np.complex128]}
+
+        for arr in self.gen_sum_array_cases(signed_dtypes, unsigned_dtypes):
+            for out_dtype in out_dtypes[arr.dtype]:
+                for axis in (0, 1, 2):
+                    if axis > len(arr.shape) - 1:
+                        continue
+                    subtest_str = ("Testing np.cumsum with {} input and {} output "
+                                    .format(arr.dtype, out_dtype))
+                    with self.subTest(subtest_str):
+                        py_res = pyfunc(arr, axis=axis, dtype=out_dtype)
+                        nb_res = cfunc(arr, axis=axis, dtype=out_dtype)
+                        self.assertPreciseEqual(py_res, nb_res)
 
     def test_take(self):
         pyfunc = array_take


### PR DESCRIPTION
Resolves: #4624 

As titled, 

This PR attempts to use the `ArrayIterator` interface to implement `np.cumsum`, this will allow us to have `axis`  and `dtype` support in `np.cumsum`.

Depends on #10625