### PR TITLE
Make .nbi files reproducible

### DIFF
--- a/docs/upcoming_changes/10659.bug_fix.rst
+++ b/docs/upcoming_changes/10659.bug_fix.rst
@@ -1,0 +1,10 @@
+Make ``.nbi`` cache index files reproducible
+--------------------------------------------
+
+Source freshness stamps in the on-disk cache (``.nbi`` files) now use a
+content hash of the source instead of the file's modification time. The
+modification time varies across hosts and filesystems (and its precision
+differs between filesystems), which made cache index files
+non-reproducible. Using a content hash makes the stamps deterministic and
+filesystem-agnostic. As a result, ``InTreeCacheLocatorFsAgnostic`` is now
+deprecated in favour of ``InTreeCacheLocator``.

--- a/maint/stubtest/allowlist.txt
+++ b/maint/stubtest/allowlist.txt
@@ -5,6 +5,7 @@ numba\.core\.boxing\..*
 numba\.core\.bytecode\..*
 numba\.core\.byteflow\..*
 numba\.core\.caching\._hash_source_file
+numba\.core\.caching\._hash_zipped_source_file
 numba\.core\.compiler\..*
 numba\.core\.compiler_machinery\..*
 numba\.core\.config\..*

--- a/maint/stubtest/allowlist.txt
+++ b/maint/stubtest/allowlist.txt
@@ -4,6 +4,7 @@ numba\.cloudpickle\..*
 numba\.core\.boxing\..*
 numba\.core\.bytecode\..*
 numba\.core\.byteflow\..*
+numba\.core\.caching\._hash_source_file
 numba\.core\.compiler\..*
 numba\.core\.compiler_machinery\..*
 numba\.core\.config\..*

--- a/numba/core/caching.py
+++ b/numba/core/caching.py
@@ -10,7 +10,6 @@ import hashlib
 import importlib
 import inspect
 import itertools
-from math import floor
 import os
 import pickle
 import sys
@@ -23,7 +22,7 @@ import zipfile
 from pathlib import Path
 
 import numba
-from numba.core.errors import NumbaWarning
+from numba.core.errors import NumbaWarning, NumbaDeprecationWarning
 from numba.core.base import BaseContext
 from numba.core.codegen import CodeLibrary
 from numba.core.compiler import CompileResult
@@ -229,11 +228,21 @@ class InTreeCacheLocatorFsAgnostic(InTreeCacheLocator):
     A locator for functions backed by a regular Python module with a
     writable __pycache__ directory. This version is agnostic to filesystem differences,
     e.g. timestamp precision with milliseconds.
+
+    .. deprecated::
+        Source stamps are now content hashes, which are already
+        filesystem-agnostic. Use :class:`InTreeCacheLocator` instead.
     """
 
-    def get_source_stamp(self):
-        st = super().get_source_stamp()
-        return floor(st[0]), st[1]
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "InTreeCacheLocatorFsAgnostic is deprecated; source stamps are "
+            "now content hashes, which are already filesystem-agnostic. "
+            "Use InTreeCacheLocator instead.",
+            NumbaDeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
 
 
 class UserWideCacheLocator(_SourceFileBackedLocatorMixin, _CacheLocator):

--- a/numba/core/caching.py
+++ b/numba/core/caching.py
@@ -165,12 +165,10 @@ class _SourceFileBackedLocatorMixin(object):
 
     def get_source_stamp(self):
         if getattr(sys, 'frozen', False):
-            st = os.stat(sys.executable)
-        else:
-            st = os.stat(self._py_file)
-        # We use both timestamp and size as some filesystems only have second
-        # granularity.
-        return st.st_mtime, st.st_size
+            with open(sys.executable, 'rb') as f:
+                return hashlib.sha256(f.read()).digest()
+        with open(self._py_file, 'rb') as f:
+            return hashlib.sha256(f.read()).digest()
 
     def get_disambiguator(self):
         return str(self._lineno)
@@ -356,8 +354,9 @@ class ZipCacheLocator(_SourceFileBackedLocatorMixin, _CacheLocator):
         return self._cache_path
 
     def get_source_stamp(self):
-        st = os.stat(self._zip_path)
-        return st.st_mtime, st.st_size
+        with zipfile.ZipFile(self._zip_path) as zf:
+            with zf.open(self._internal_path) as f:
+                return hashlib.sha256(f.read()).digest()
 
     @classmethod
     def from_function(cls, py_func, py_file):

--- a/numba/core/caching.py
+++ b/numba/core/caching.py
@@ -6,6 +6,7 @@ Caching mechanism for compiled functions.
 from abc import ABCMeta, abstractmethod
 import contextlib
 import errno
+import functools
 import hashlib
 import importlib
 import inspect
@@ -156,6 +157,15 @@ class _CacheLocator(metaclass=ABCMeta):
         return '_'.join([parentdir, hashed])
 
 
+@functools.lru_cache(maxsize=None)
+def _hash_source_file(path, st_mtime, st_size):
+    # Note: keep the arguments to this function so that the memoization key is
+    # based on the file's mtime and size, so that if the file changes while
+    # the process is running, it will be re-hashed.
+    with open(path, 'rb') as f:
+        return hashlib.sha256(f.read()).digest()
+
+
 class _SourceFileBackedLocatorMixin(object):
     """
     A cache locator mixin for functions which are backed by a well-known
@@ -164,10 +174,11 @@ class _SourceFileBackedLocatorMixin(object):
 
     def get_source_stamp(self):
         if getattr(sys, 'frozen', False):
-            with open(sys.executable, 'rb') as f:
-                return hashlib.sha256(f.read()).digest()
-        with open(self._py_file, 'rb') as f:
-            return hashlib.sha256(f.read()).digest()
+            path = sys.executable
+        else:
+            path = self._py_file
+        st = os.stat(path)
+        return _hash_source_file(path, st.st_mtime, st.st_size)
 
     def get_disambiguator(self):
         return str(self._lineno)

--- a/numba/core/caching.py
+++ b/numba/core/caching.py
@@ -166,6 +166,16 @@ def _hash_source_file(path, st_mtime, st_size):
         return hashlib.sha256(f.read()).digest()
 
 
+@functools.lru_cache(maxsize=None)
+def _hash_zipped_source_file(zip_path, internal_path, st_mtime, st_size):
+    # Note: keep the arguments to this function so that the memoization key is
+    # based on the zip file's mtime and size, so that if the file changes
+    # while the process is running, it will be re-hashed.
+    with zipfile.ZipFile(zip_path) as zf:
+        with zf.open(internal_path) as f:
+            return hashlib.sha256(f.read()).digest()
+
+
 class _SourceFileBackedLocatorMixin(object):
     """
     A cache locator mixin for functions which are backed by a well-known
@@ -374,9 +384,9 @@ class ZipCacheLocator(_SourceFileBackedLocatorMixin, _CacheLocator):
         return self._cache_path
 
     def get_source_stamp(self):
-        with zipfile.ZipFile(self._zip_path) as zf:
-            with zf.open(self._internal_path) as f:
-                return hashlib.sha256(f.read()).digest()
+        st = os.stat(self._zip_path)
+        return _hash_zipped_source_file(self._zip_path, self._internal_path,
+                                        st.st_mtime, st.st_size)
 
     @classmethod
     def from_function(cls, py_func, py_file):

--- a/numba/tests/test_caching.py
+++ b/numba/tests/test_caching.py
@@ -1,11 +1,13 @@
 import importlib
 import inspect
+import hashlib
 import multiprocessing
 import os
 import shutil
 import stat
 import subprocess
 import sys
+import time
 import traceback
 import unittest
 import warnings
@@ -583,6 +585,38 @@ class TestCache(DispatcherCacheUsecasesTest):
         # The __pycache__ is empty (otherwise the test's preconditions
         # wouldn't be met)
         self.check_pycache(0)
+
+    def test_nbi_reproducible_after_touch(self):
+        def nbi_hashes():
+            return {
+                fn: hashlib.md5(
+                    open(os.path.join(self.cache_dir, fn), "rb").read()
+                ).hexdigest()
+                for fn in self.cache_contents()
+                if fn.endswith(".nbi")
+            }
+
+        # Compile and cache
+        mod = self.import_module()
+        mod.add_usecase(2, 3)
+        h1 = nbi_hashes()
+        self.assertTrue(h1, "No .nbi files found after compilation")
+
+        # Touch source file (mtime changes, content unchanged), clear cache
+        time.sleep(1)
+        os.utime(self.modfile, None)
+        shutil.rmtree(self.cache_dir)
+
+        # Recompile — same source content, new mtime
+        mod = self.import_module()
+        mod.add_usecase(2, 3)
+        h2 = nbi_hashes()
+
+        self.assertEqual(
+            h1, h2,
+            ".nbi file differs after touch with unchanged content — "
+            "source stamp embeds mtime instead of content hash"
+        )
 
     @skip_bad_access
     @unittest.skipIf(os.name == "nt",

--- a/numba/tests/test_caching.py
+++ b/numba/tests/test_caching.py
@@ -16,7 +16,6 @@ from pathlib import Path
 
 import llvmlite.binding as ll
 import numpy as np
-from math import floor
 
 from numba import njit
 from numba.core import codegen
@@ -27,7 +26,7 @@ from numba.core.caching import (
     InTreeCacheLocator,
     InTreeCacheLocatorFsAgnostic,
 )
-from numba.core.errors import NumbaWarning
+from numba.core.errors import NumbaWarning, NumbaDeprecationWarning
 from numba.parfors import parfor
 from numba.tests.support import (
     SerialMixin,
@@ -1293,66 +1292,27 @@ class TestCacheLocatorEnvironmentIntegration(TestCase):
 
 
 class TestInTreeCacheLocatorFsAgnostic(TestCase):
-    """Test _InTreeCacheLocatorFsAgnostic class functionality."""
+    """Test InTreeCacheLocatorFsAgnostic deprecation."""
 
-    def test_source_stamp_precision(self):
-        """Test that FsAgnostic locator floors timestamp to seconds."""
+    def test_deprecation_warning(self):
+        """Instantiating the locator emits a NumbaDeprecationWarning."""
         from .dummy_module import function
 
         source = inspect.getfile(function)
 
-        # Create regular and FsAgnostic locators
+        with self.assertWarns(NumbaDeprecationWarning) as cm:
+            locator = InTreeCacheLocatorFsAgnostic.from_function(
+                function, source
+            )
+
+        self.assertIsNotNone(locator)
+        self.assertIn("InTreeCacheLocatorFsAgnostic is deprecated",
+                      str(cm.warning))
+
+        # Despite deprecation, the stamp must match the parent (content hash).
         regular_locator = InTreeCacheLocator.from_function(function, source)
-        fs_agnostic_locator = InTreeCacheLocatorFsAgnostic.from_function(
-            function, source
-        )
-
-        # Both should be valid locators
-        self.assertIsNotNone(regular_locator)
-        self.assertIsNotNone(fs_agnostic_locator)
-
-        # Get source stamps
-        regular_stamp = regular_locator.get_source_stamp()
-        fs_agnostic_stamp = fs_agnostic_locator.get_source_stamp()
-
-        # Verify structure: (timestamp, size)
-        self.assertEqual(len(regular_stamp), 2)
-        self.assertEqual(len(fs_agnostic_stamp), 2)
-
-        # The second element (size) should be the same
-        self.assertEqual(regular_stamp[1], fs_agnostic_stamp[1])
-
-        # The first element (timestamp) in fs_agnostic should be floored
-        self.assertEqual(fs_agnostic_stamp[0], floor(regular_stamp[0]))
-
-        # Verify that fs_agnostic timestamp is always <= regular timestamp
-        self.assertLessEqual(fs_agnostic_stamp[0], regular_stamp[0])
-
-    def test_timestamp_precision_on_fs(self):
-        """Test FsAgnostic timestamp handling using filesystem mtime."""
-
-        from .dummy_module import function
-
-        source = inspect.getfile(function)
-
-        # Test with a file that has a precise timestamp
-        fs_agnostic_locator = InTreeCacheLocatorFsAgnostic.from_function(
-            function, source
-        )
-
-        # Get file stat
-        stat_result = os.stat(source)
-        original_mtime = stat_result.st_mtime
-
-        # Get stamp from locator
-        stamp = fs_agnostic_locator.get_source_stamp()
-
-        # Verify that the timestamp is floored
-        expected_timestamp = floor(original_mtime)
-        self.assertEqual(stamp[0], expected_timestamp)
-
-        # Verify size is correct
-        self.assertEqual(stamp[1], stat_result.st_size)
+        self.assertEqual(locator.get_source_stamp(),
+                         regular_locator.get_source_stamp())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR replaces the mtime-based source stamp with a sha256 digest of the file's content. Two consecutive builds of would produce different nbi hash files as `get_source_stamp` was using `os.stat`.