### PR TITLE
Add tuple axis support for array sum

### DIFF
--- a/docs/upcoming_changes/10661.improvement.rst
+++ b/docs/upcoming_changes/10661.improvement.rst
@@ -1,0 +1,6 @@
+Enable tuple types in ``np.sum`` function.
+------------------------------------------
+
+The ``np.sum`` function now supports tuple types for the ``axis`` argument,
+allowing users to specify multiple axes along which to perform the operation
+at runtime.

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -279,58 +279,39 @@ def get_accumulator(dtype, value):
 
 def get_spliced_tuple(context, builder, tuplety, tupleval, axis):
     # Return a tuple with the same values as tupleval but with the
-    # axis dimension removed. Axis is a runtime value.
+    # axis dimension(s) removed. Axis is a runtime value.
 
     ll_intp = context.get_value_type(types.intp)
 
-    # Wraparound for negative axis, convert to positive axis
-    axis = builder.add(
-        axis,
-        builder.select(
-            builder.icmp_signed('<', axis, Constant(ll_intp, 0)),
-            Constant(ll_intp, tuplety.count), Constant(ll_intp, 0)
-        )
-    )
-    # Check if axis is valid for the given array
-    is_not_valid = builder.or_(
-        builder.icmp_signed('>=', axis, Constant(ll_intp, tuplety.count)),
-        builder.icmp_signed('<', axis, Constant(ll_intp, 0))
-    )
-    with builder.if_then(is_not_valid, likely=True):
-        context.call_conv.return_user_exc(
-            builder, ValueError,
-            ("Axis out of bounds.",))
+    if not isinstance(axis, (list, tuple)):
+        axis = [axis]
+    mask = get_mask(context, builder, tuplety.count, axis)
 
     # Create an empty tuple to hold the result, the resulting tuple
     # has one less dimension than the original tuple, initilize it with zeros.
 
     # Create resulting tuple type
-    result_tuple_ty = types.UniTuple(types.intp, tuplety.count - 1)
+    result_tuple_ty = types.UniTuple(types.intp, tuplety.count - len(axis))
     result_tuple = cgutils.get_null_value(
         context.get_value_type(result_tuple_ty)
     )
     stack = cgutils.alloca_once(builder, result_tuple.type)
     builder.store(result_tuple, stack)
 
+    idx = cgutils.alloca_once(builder, ll_intp)
+    zero = Constant(ll_intp, 0)
+    builder.store(zero, idx)
+
     # Loop through the original tuple and copy values to the resulting tuple
     # skipping the axis dimension.
     for i in range(tuplety.count):
-        idx = Constant(ll_intp, i)
-        # Get the value at the current index in the original tuple.
-        with builder.if_then(builder.icmp_signed('<', idx, axis)):
-            val = builder.extract_value(tupleval, i)
-            # Unsafe load on unchecked bounds.  Poison value maybe returned.
-            offptr = builder.gep(stack, [idx.type(0), idx], inbounds=True)
-            builder.store(val, offptr)
-        with builder.if_then(builder.icmp_signed('>', idx, axis)):
-            idx = Constant(ll_intp, i)
-            val = builder.extract_value(tupleval, i)
-            res_idx = builder.sub(idx, Constant(ll_intp, 1))
-            # Unsafe load on unchecked bounds.  Poison value maybe returned.
-            offptr = builder.gep(
-                stack, [res_idx.type(0), res_idx], inbounds=True
-            )
-            builder.store(val, offptr)
+        with builder.if_then(builder.extract_value(mask, i)):
+            val_i = builder.extract_value(tupleval, i)
+            offptr = builder.gep(stack, [zero.type(0), builder.load(idx)],
+                                 inbounds=True)
+            builder.store(val_i, offptr)
+            builder.store(builder.add(builder.load(idx), Constant(ll_intp, 1)),
+                          idx)
     return builder.load(stack)
 
 
@@ -394,6 +375,12 @@ def get_mask(context, builder, mask_length, axis, inverted=False):
     stack = cgutils.alloca_once(builder, result_tuple.type)
     builder.store(result_tuple, stack)
 
+    for i in range(mask_length):
+        idx = Constant(ll_intp, i)
+        val = Constant(ll_bool, 1)
+        offptr = builder.gep(stack, [idx.type(0), idx], inbounds=True)
+        builder.store(val, offptr)
+
     for _axis in axis:
         if _axis is not None:
             # Wraparound for negative axis, convert to positive axis
@@ -418,13 +405,21 @@ def get_mask(context, builder, mask_length, axis, inverted=False):
                     ("Axis out of bounds.",))
         for i in range(mask_length):
             idx = Constant(ll_intp, i)
+            offptr = builder.gep(stack, [idx.type(0), idx], inbounds=True)
+
             if _axis is not None:
                 val = builder.icmp_signed('!=', idx, _axis)
             else:
                 val = Constant(ll_bool, 1)
-            if inverted:
-                val = builder.not_(val)
+
+            val = builder.and_(builder.load(offptr), val)
+            builder.store(val, offptr)
+
+    if inverted:
+        for i in range(mask_length):
+            idx = Constant(ll_intp, i)
             offptr = builder.gep(stack, [idx.type(0), idx], inbounds=True)
+            val = builder.not_(builder.load(offptr))
             builder.store(val, offptr)
 
     return builder.load(stack)
@@ -492,15 +487,16 @@ def _numpy_sum(typingctx, aryty, axisty, dtype):
 def _numpy_sum_axis(typingctx, aryty, axisty, dtype):
     ret_dtype = get_ret_dtype_if_any(aryty, dtype)
 
-    assert aryty.ndim > 0, \
-        "Array must have at least 1 dimension for sum with axis"
-    ret = types.Array(ret_dtype, aryty.ndim - 1, layout='C')
+    axis_length = axisty.count if isinstance(axisty, types.UniTuple) else 1
+    ret = types.Array(ret_dtype, aryty.ndim - axis_length, layout='C')
     sig = ret(aryty, axisty, dtype)
 
     def codegen(context, builder, sig, args):
         ary, axis, _ = args
 
         ary = make_array(aryty)(context, builder, ary)
+        if isinstance(axisty, types.UniTuple):
+            axis = cgutils.unpack_tuple(builder, axis)
 
         # Res shape will be a tuple one axis less than
         # ndim and need appropriate shape calculations.
@@ -554,7 +550,7 @@ def array_sum(a, axis=None, dtype=None):
             "NumPy sum only suppports integer axis value"
         )
     if isinstance(a, types.Array):
-        axis_length = 1
+        axis_length = axis.count if isinstance(axis, types.UniTuple) else 1
         if is_nonelike(axis) or a.ndim == axis_length:
             def array_sum_impl(a, axis=None, dtype=None):
                 if axis is not None and (axis < -a.ndim or axis >= a.ndim):

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -542,30 +542,40 @@ def _numpy_sum_axis(typingctx, aryty, axisty, dtype):
     return sig, codegen
 
 
+@register_jitable
+def check_axis_bounds(a, axis):
+    if axis is not None:
+        if isinstance(axis, tuple):
+            for ax in axis:
+                if ax < -a.ndim or ax >= a.ndim:
+                    raise ValueError(
+                        f"axis {ax} is out of bounds for "
+                        f"array of dimension {a.ndim}"
+                    )
+        elif axis < -a.ndim or axis >= a.ndim:
+            raise ValueError(
+                f"axis {axis} is out of bounds for "
+                f"array of dimension {a.ndim}"
+            )
+
+
 @overload(np.sum)
 @overload_method(types.Array, "sum")
 def array_sum(a, axis=None, dtype=None):
-    if not (isinstance(axis, types.Integer) or is_nonelike(axis)):
+    if not (isinstance(axis, types.Integer) or
+            is_nonelike(axis) or isinstance(axis, types.UniTuple)):
         raise TypingError(
-            "NumPy sum only suppports integer axis value"
+            "NumPy sum only supports integer axis value or tuple of integers"
         )
     if isinstance(a, types.Array):
         axis_length = axis.count if isinstance(axis, types.UniTuple) else 1
         if is_nonelike(axis) or a.ndim == axis_length:
             def array_sum_impl(a, axis=None, dtype=None):
-                if axis is not None and (axis < -a.ndim or axis >= a.ndim):
-                    raise ValueError(
-                        f"axis {axis} is out of bounds for "
-                        f"array of dimension {a.ndim}"
-                    )
+                check_axis_bounds(a, axis)
                 return _numpy_sum(a, axis, dtype)
         else:
             def array_sum_impl(a, axis=None, dtype=None):
-                if axis is not None and (axis < -a.ndim or axis >= a.ndim):
-                    raise ValueError(
-                        f"axis {axis} is out of bounds for "
-                        f"array of dimension {a.ndim}"
-                    )
+                check_axis_bounds(a, axis)
                 return _numpy_sum_axis(a, axis, dtype)
 
         return array_sum_impl

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -352,7 +352,7 @@ def tuple_additem(context, builder, tuplety, tupleval, idx, val):
     return builder.load(stack)
 
 
-def get_mask(context, builder, mask_length, axis, inverted=False):
+def get_mask(context, builder, mask_length, axis):
     # Return a tuple of booleans where the value is True if the
     # dimension is not the axis and False if it is the axis.
     # Axis is a runtime value.
@@ -403,24 +403,16 @@ def get_mask(context, builder, mask_length, axis, inverted=False):
                 context.call_conv.return_user_exc(
                     builder, ValueError,
                     ("Axis out of bounds.",))
-        for i in range(mask_length):
-            idx = Constant(ll_intp, i)
-            offptr = builder.gep(stack, [idx.type(0), idx], inbounds=True)
+            offptr = builder.gep(stack, [idx.type(0), _axis], inbounds=True)
 
-            if _axis is not None:
-                val = builder.icmp_signed('!=', idx, _axis)
-            else:
-                val = Constant(ll_bool, 1)
+            with builder.if_then(
+                builder.icmp_signed('==', builder.load(offptr),
+                                    Constant(ll_bool, 0))):
+                context.call_conv.return_user_exc(
+                    builder, ValueError,
+                    ("duplicate value in 'axis'",))
 
-            val = builder.and_(builder.load(offptr), val)
-            builder.store(val, offptr)
-
-    if inverted:
-        for i in range(mask_length):
-            idx = Constant(ll_intp, i)
-            offptr = builder.gep(stack, [idx.type(0), idx], inbounds=True)
-            val = builder.not_(builder.load(offptr))
-            builder.store(val, offptr)
+            builder.store(Constant(ll_bool, 0), offptr)
 
     return builder.load(stack)
 
@@ -548,30 +540,51 @@ def check_axis_bounds(a, axis):
         if isinstance(axis, tuple):
             for ax in axis:
                 if ax < -a.ndim or ax >= a.ndim:
-                    raise ValueError(
+                    raise np.exceptions.AxisError(
                         f"axis {ax} is out of bounds for "
                         f"array of dimension {a.ndim}"
                     )
         elif axis < -a.ndim or axis >= a.ndim:
-            raise ValueError(
+            raise np.exceptions.AxisError(
                 f"axis {axis} is out of bounds for "
                 f"array of dimension {a.ndim}"
             )
+
+
+@register_jitable
+def check_duplicates(axis, ndim):
+    if axis is not None and isinstance(axis, tuple):
+        if len(axis) != len(np.unique(np.array(axis) % ndim)):
+            raise ValueError("duplicate value in 'axis'")
 
 
 @overload(np.sum)
 @overload_method(types.Array, "sum")
 def array_sum(a, axis=None, dtype=None):
     if not (isinstance(axis, types.Integer) or
-            is_nonelike(axis) or isinstance(axis, types.UniTuple)):
+            is_nonelike(axis) or (
+                isinstance(axis, types.UniTuple) and
+                isinstance(axis.dtype, types.Integer))
+            or (
+                isinstance(axis, types.Tuple) and
+                axis.count == 0)):
         raise TypingError(
             "NumPy sum only supports integer axis value or tuple of integers"
         )
     if isinstance(a, types.Array):
-        axis_length = axis.count if isinstance(axis, types.UniTuple) else 1
-        if is_nonelike(axis) or a.ndim == axis_length:
+        if isinstance(axis, types.Tuple) and axis.count == 0:
+            if is_nonelike(dtype):
+                def array_sum_impl(a, axis=None, dtype=None):
+                    return a
+            else:
+                def array_sum_impl(a, axis=None, dtype=None):
+                    return a.astype(dtype)
+        elif is_nonelike(axis) or a.ndim <= (
+            axis.count if isinstance(
+                axis, (types.Tuple, types.UniTuple)) else 1):
             def array_sum_impl(a, axis=None, dtype=None):
                 check_axis_bounds(a, axis)
+                check_duplicates(axis, a.ndim)
                 return _numpy_sum(a, axis, dtype)
         else:
             def array_sum_impl(a, axis=None, dtype=None):

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -579,7 +579,7 @@ def array_sum(a, axis=None, dtype=None):
         if isinstance(axis, types.Tuple) and axis.count == 0:
             if is_nonelike(dtype):
                 def array_sum_impl(a, axis=None, dtype=None):
-                    return a.copy()
+                    return np.copy(a)
             else:
                 def array_sum_impl(a, axis=None, dtype=None):
                     return a.astype(dtype)

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -540,12 +540,12 @@ def check_axis_bounds(a, axis):
         if isinstance(axis, tuple):
             for ax in axis:
                 if ax < -a.ndim or ax >= a.ndim:
-                    raise np.exceptions.AxisError(
+                    raise ValueError(
                         f"axis {ax} is out of bounds for "
                         f"array of dimension {a.ndim}"
                     )
         elif axis < -a.ndim or axis >= a.ndim:
-            raise np.exceptions.AxisError(
+            raise ValueError(
                 f"axis {axis} is out of bounds for "
                 f"array of dimension {a.ndim}"
             )

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -534,18 +534,22 @@ def _numpy_sum_axis(typingctx, aryty, axisty, dtype):
     return sig, codegen
 
 
+axis_bound_err = ValueError if numpy_version < (1, 25)\
+    else np.exceptions.AxisError
+
+
 @register_jitable
 def check_axis_bounds(a, axis):
     if axis is not None:
         if isinstance(axis, tuple):
             for ax in axis:
                 if ax < -a.ndim or ax >= a.ndim:
-                    raise ValueError(
+                    raise axis_bound_err(
                         f"axis {ax} is out of bounds for "
                         f"array of dimension {a.ndim}"
                     )
         elif axis < -a.ndim or axis >= a.ndim:
-            raise ValueError(
+            raise axis_bound_err(
                 f"axis {axis} is out of bounds for "
                 f"array of dimension {a.ndim}"
             )

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -575,7 +575,7 @@ def array_sum(a, axis=None, dtype=None):
         if isinstance(axis, types.Tuple) and axis.count == 0:
             if is_nonelike(dtype):
                 def array_sum_impl(a, axis=None, dtype=None):
-                    return a
+                    return a.copy()
             else:
                 def array_sum_impl(a, axis=None, dtype=None):
                     return a.astype(dtype)

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -1493,6 +1493,15 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
                         py_res = pyfunc(arr, axis=axis, dtype=out_dtype)
                         nb_res = cfunc(arr, axis=axis, dtype=out_dtype)
                         self.assertPreciseEqual(py_res, nb_res)
+    
+    def test_sum_axis_tuple(self):
+        """ test sum with axis as a tuple """
+        pyfunc = array_sum_axis_kws
+        cfunc = jit(nopython=True)(pyfunc)
+        a = np.ones((2, 3, 4))
+        self.assertPreciseEqual(pyfunc(a, (0, 1)), cfunc(a, (0, 1)))
+        self.assertPreciseEqual(pyfunc(a, (0, 2)), cfunc(a, (0, 2)))
+        self.assertPreciseEqual(pyfunc(a, (1, 2)), cfunc(a, (1, 2)))
 
     def test_sum_axis_dtype_pos_arg(self):
         """ testing that axis and dtype inputs work when passed as positional """

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -278,6 +278,9 @@ def array_dot_chain(a, b):
 def array_ctor(n, dtype):
     return np.ones(n, dtype=dtype)
 
+def nb_sum_empty_axis(a):
+    return a.sum(axis=())
+
 class TestArrayMethods(MemoryLeakMixin, TestCase):
     """
     Test various array methods and array-related functions.
@@ -1504,10 +1507,11 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
             permutations(data, r) for r in range(len(data) + 1)
         ))
         for axes in all_perms:
-            # Check for duplicate axis
-            np_axes = (np.array(axes) % 3)
-            if len(np_axes) == len(np.unique(np_axes)):
-                self.assertPreciseEqual(pyfunc(a, axes), cfunc(a, axes))
+            with self.subTest(axes=axes):
+                # Check for duplicate axis
+                np_axes = (np.array(axes) % 3)
+                if len(np_axes) == len(np.unique(np_axes)):
+                    self.assertPreciseEqual(pyfunc(a, axes), cfunc(a, axes))
 
     def test_sum_axis_tuple_duplicates(self):
         """ test sum with axis as a tuple """
@@ -1522,42 +1526,60 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
             permutations(data, r) for r in range(len(data) + 1)
         ))
         for axes in all_perms:
-            print(f"Testing axes: {axes}")
-            # Check for duplicate axis
-            if 3 in axes:
-                # 3 is out of bounds for an array of dimension 3
-                # but -3 is not.
-                with self.assertRaises(err) as c_raises:
-                    cfunc(a, axes)
-                # This will raise a different exception than the duplicate
-                # axis case, so we need to check for the correct error
-                # message.
-                self.assertIn(
-                    "out of bounds for array of dimension 3",
-                    str(c_raises.exception)
-                )
-                with self.assertRaises(err) as py_raises:
-                    pyfunc(a, axes)
-                self.assertEqual(
-                    str(c_raises.exception),
-                    str(py_raises.exception)
-                )
-                continue
-            np_axes = (np.array(axes) % 3)
-            if len(np_axes) != len(np.unique(np_axes)):
-                with self.assertRaises(ValueError) as c_raises:
-                    cfunc(a, axes)
-                self.assertIn(
-                    "duplicate value in 'axis'",
-                    str(c_raises.exception)
-                )
-                with self.assertRaises(ValueError) as py_raises:
-                    pyfunc(a, axes)
-                self.assertEqual(
-                    str(c_raises.exception),
-                    str(py_raises.exception)
-                )
+            with self.subTest(axes=axes):
+                # Check for duplicate axis
+                if 3 in axes:
+                    # 3 is out of bounds for an array of dimension 3
+                    # but -3 is not.
+                    with self.assertRaises(err) as c_raises:
+                        cfunc(a, axes)
+                    # This will raise a different exception than the duplicate
+                    # axis case, so we need to check for the correct error
+                    # message.
+                    self.assertIn(
+                        "out of bounds for array of dimension 3",
+                        str(c_raises.exception)
+                    )
+                    with self.assertRaises(err) as py_raises:
+                        pyfunc(a, axes)
+                    self.assertEqual(
+                        str(c_raises.exception),
+                        str(py_raises.exception)
+                    )
+                    continue
+                np_axes = (np.array(axes) % 3)
+                if len(np_axes) != len(np.unique(np_axes)):
+                    with self.assertRaises(ValueError) as c_raises:
+                        cfunc(a, axes)
+                    self.assertIn(
+                        "duplicate value in 'axis'",
+                        str(c_raises.exception)
+                    )
+                    with self.assertRaises(ValueError) as py_raises:
+                        pyfunc(a, axes)
+                    self.assertEqual(
+                        str(c_raises.exception),
+                        str(py_raises.exception)
+                    )
 
+    def test_sum_empty_order_layout(self):
+        pyfunc = nb_sum_empty_axis
+        cfunc = jit(nopython=True)(pyfunc)
+
+        # C ordered array
+        a = np.arange(6).reshape(2, 3)
+        self.assertPreciseEqual(pyfunc(a),
+                                cfunc(a))
+
+        # NumPy returns an F-contiguous array here; Numba returns C-order.
+        a = np.asfortranarray(np.arange(6).reshape(2, 3))
+
+        expected = pyfunc(a)
+        got = cfunc(a)
+
+        self.assertEqual(expected.flags.f_contiguous,
+                         got.flags.f_contiguous)
+        
     def test_sum_axis_dtype_pos_arg(self):
         """ testing that axis and dtype inputs work when passed as positional """
         pyfunc = array_sum_axis_dtype_pos

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -1,11 +1,10 @@
-from itertools import product, cycle
+from itertools import product, cycle, permutations, chain
 import gc
 import sys
 import unittest
 import warnings
 
 import numpy as np
-import itertools
 from numba import jit, njit, typeof
 from numba.core import types
 from numba.core.errors import TypingError, NumbaValueError
@@ -1493,16 +1492,18 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
                         py_res = pyfunc(arr, axis=axis, dtype=out_dtype)
                         nb_res = cfunc(arr, axis=axis, dtype=out_dtype)
                         self.assertPreciseEqual(py_res, nb_res)
-    
+
     def test_sum_axis_tuple(self):
         """ test sum with axis as a tuple """
         pyfunc = array_sum_axis_kws
         cfunc = jit(nopython=True)(pyfunc)
         a = np.arange(2 * 3 * 4).reshape(2, 3, 4)
-        
-        my_list = [-2, -1, 0, 1, 2]
-        all_combinations = [tuple(combo) for r in range(0, len(my_list) + 1) for combo in itertools.combinations(my_list, r)]
-        for axes in all_combinations:
+
+        data = [-2, -1, 0, 1, 2]
+        all_perms = list(chain.from_iterable(
+            permutations(data, r) for r in range(len(data) + 1)
+        ))
+        for axes in all_perms:
             # Check for duplicate axis
             np_axes = (np.array(axes) % 3)
             if len(np_axes) == len(np.unique(np_axes)):
@@ -1512,13 +1513,36 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         """ test sum with axis as a tuple """
         self.disable_leak_check()
         pyfunc = array_sum_axis_kws
+        err = ValueError if numpy_version < (1, 25) else np.exceptions.AxisError
         cfunc = jit(nopython=True)(pyfunc)
         a = np.arange(2 * 3 * 4).reshape(2, 3, 4)
-        
-        my_list = [-2, -1, 0, 1, 2]
-        all_combinations = [tuple(combo) for r in range(0, len(my_list) + 1) for combo in itertools.combinations(my_list, r)]
-        for axes in all_combinations:
+
+        data = [-3, -2, -1, 0, 1, 2, 3]
+        all_perms = list(chain.from_iterable(
+            permutations(data, r) for r in range(len(data) + 1)
+        ))
+        for axes in all_perms:
+            print(f"Testing axes: {axes}")
             # Check for duplicate axis
+            if 3 in axes:
+                # 3 is out of bounds for an array of dimension 3
+                # but -3 is not.
+                with self.assertRaises(err) as c_raises:
+                    cfunc(a, axes)
+                # This will raise a different exception than the duplicate
+                # axis case, so we need to check for the correct error
+                # message.
+                self.assertIn(
+                    "out of bounds for array of dimension 3",
+                    str(c_raises.exception)
+                )
+                with self.assertRaises(np.exceptions.AxisError) as py_raises:
+                    pyfunc(a, axes)
+                self.assertEqual(
+                    str(c_raises.exception),
+                    str(py_raises.exception)
+                )
+                continue
             np_axes = (np.array(axes) % 3)
             if len(np_axes) != len(np.unique(np_axes)):
                 with self.assertRaises(ValueError) as c_raises:
@@ -1529,7 +1553,10 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
                 )
                 with self.assertRaises(ValueError) as py_raises:
                     pyfunc(a, axes)
-                self.assertEqual(str(c_raises.exception), str(py_raises.exception))
+                self.assertEqual(
+                    str(c_raises.exception),
+                    str(py_raises.exception)
+                )
 
     def test_sum_axis_dtype_pos_arg(self):
         """ testing that axis and dtype inputs work when passed as positional """

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -1536,7 +1536,7 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
                     "out of bounds for array of dimension 3",
                     str(c_raises.exception)
                 )
-                with self.assertRaises(np.exceptions.AxisError) as py_raises:
+                with self.assertRaises(err) as py_raises:
                     pyfunc(a, axes)
                 self.assertEqual(
                     str(c_raises.exception),

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -5,7 +5,7 @@ import unittest
 import warnings
 
 import numpy as np
-
+import itertools
 from numba import jit, njit, typeof
 from numba.core import types
 from numba.core.errors import TypingError, NumbaValueError
@@ -1498,10 +1498,38 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         """ test sum with axis as a tuple """
         pyfunc = array_sum_axis_kws
         cfunc = jit(nopython=True)(pyfunc)
-        a = np.ones((2, 3, 4))
-        self.assertPreciseEqual(pyfunc(a, (0, 1)), cfunc(a, (0, 1)))
-        self.assertPreciseEqual(pyfunc(a, (0, 2)), cfunc(a, (0, 2)))
-        self.assertPreciseEqual(pyfunc(a, (1, 2)), cfunc(a, (1, 2)))
+        a = np.arange(2 * 3 * 4).reshape(2, 3, 4)
+        
+        my_list = [-2, -1, 0, 1, 2]
+        all_combinations = [tuple(combo) for r in range(0, len(my_list) + 1) for combo in itertools.combinations(my_list, r)]
+        for axes in all_combinations:
+            # Check for duplicate axis
+            np_axes = (np.array(axes) % 3)
+            if len(np_axes) == len(np.unique(np_axes)):
+                self.assertPreciseEqual(pyfunc(a, axes), cfunc(a, axes))
+
+    def test_sum_axis_tuple_duplicates(self):
+        """ test sum with axis as a tuple """
+        self.disable_leak_check()
+        pyfunc = array_sum_axis_kws
+        cfunc = jit(nopython=True)(pyfunc)
+        a = np.arange(2 * 3 * 4).reshape(2, 3, 4)
+        
+        my_list = [-2, -1, 0, 1, 2]
+        all_combinations = [tuple(combo) for r in range(0, len(my_list) + 1) for combo in itertools.combinations(my_list, r)]
+        for axes in all_combinations:
+            # Check for duplicate axis
+            np_axes = (np.array(axes) % 3)
+            if len(np_axes) != len(np.unique(np_axes)):
+                with self.assertRaises(ValueError) as c_raises:
+                    cfunc(a, axes)
+                self.assertIn(
+                    "duplicate value in 'axis'",
+                    str(c_raises.exception)
+                )
+                with self.assertRaises(ValueError) as py_raises:
+                    pyfunc(a, axes)
+                self.assertEqual(str(c_raises.exception), str(py_raises.exception))
 
     def test_sum_axis_dtype_pos_arg(self):
         """ testing that axis and dtype inputs work when passed as positional """


### PR DESCRIPTION
As titled, 

This PR allows for `axis` to be tuples (both compile time and runtime constants) as arguments to `np.sum`.

Depends on #10657 