### PR TITLE
Revert skipping tests on `win-arm64` 40args problem

### DIFF
--- a/.github/workflows/numba_win-arm64_conda_builder.yml
+++ b/.github/workflows/numba_win-arm64_conda_builder.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
@@ -116,7 +116,7 @@ jobs:
 
     steps:
       - name: Clone repository (ci_artifacts only)
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # sparse checkout so the numba source tree cannot shadow the
           # installed package during tests

--- a/.github/workflows/numba_win-arm64_wheel_builder.yml
+++ b/.github/workflows/numba_win-arm64_wheel_builder.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/docs/upcoming_changes/10664.infrastructure.rst
+++ b/docs/upcoming_changes/10664.infrastructure.rst
@@ -1,0 +1,9 @@
+Re-enable win-arm64 tests after LLVM FrameLowering fix
+------------------------------------------------------
+
+Several tests that were temporarily skipped on ``win-arm64`` due to an LLVM 22
+AArch64 frame lowering assertion when JIT-compiling functions with 40 or more
+arguments are now run again. The ``win-arm64`` CI workflows use a patched
+LLVM build that includes the upstream fix (`llvm/llvm-project#204347
+<https://github.com/llvm/llvm-project/pull/204347>`_;
+`numba/llvmlite#1439 <https://github.com/numba/llvmlite/pull/1439>`_).

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -232,13 +232,8 @@ skip_macos_fenv_errors = unittest.skipIf(IS_MACOS,
     "fenv.h-like functionality unreliable on macOS")
 IS_MACOS_ARM64 = IS_MACOS and _uname.machine == 'arm64'
 IS_WIN_ARM64 = _uname.system == 'Windows' and _uname.machine == 'ARM64'
-# LLVM 22 AArch64 FrameLowering assertion on win-arm64 when >=40 LLVM args
-# are passed (llvm/llvm-project#204060).
-skip_win_arm64_40args_problem = unittest.skipIf(
-    IS_WIN_ARM64,
-    "LLVM >=40-arg calls crash AArch64 frame lowering on win-arm64 "
-    "(llvm/llvm-project#204060)",
-)
+skip_if_win_arm64 = unittest.skipIf(IS_WIN_ARM64,
+                                    "Not supported on Windows arm64")
 
 try:
     import scipy.linalg.cython_lapack

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -232,8 +232,6 @@ skip_macos_fenv_errors = unittest.skipIf(IS_MACOS,
     "fenv.h-like functionality unreliable on macOS")
 IS_MACOS_ARM64 = IS_MACOS and _uname.machine == 'arm64'
 IS_WIN_ARM64 = _uname.system == 'Windows' and _uname.machine == 'ARM64'
-skip_if_win_arm64 = unittest.skipIf(IS_WIN_ARM64,
-                                    "Not supported on Windows arm64")
 
 try:
     import scipy.linalg.cython_lapack

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -232,6 +232,13 @@ skip_macos_fenv_errors = unittest.skipIf(IS_MACOS,
     "fenv.h-like functionality unreliable on macOS")
 IS_MACOS_ARM64 = IS_MACOS and _uname.machine == 'arm64'
 IS_WIN_ARM64 = _uname.system == 'Windows' and _uname.machine == 'ARM64'
+# AArch64 uimm12 fixup failure on win-arm64 for large UniTuple(unicode)
+# arguments. https://github.com/numba/numba/issues/10619
+skip_win_arm64_unittuple_uimm12 = unittest.skipIf(
+    IS_WIN_ARM64,
+    "AArch64 uimm12 fixup failure on win-arm64 for large UniTuple(unicode) "
+    "arguments",
+)
 
 try:
     import scipy.linalg.cython_lapack

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -5,7 +5,7 @@ import numpy as np
 from numba import jit, njit, typeof, types
 from numba.np.numpy_support import numpy_version
 from numba.tests.support import (TestCase, MemoryLeakMixin, tag,
-                                 skip_if_numpy_2, skip_win_arm64_40args_problem)
+                                 skip_if_numpy_2, skip_if_win_arm64)
 import unittest
 
 
@@ -919,24 +919,24 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
     # tuple input crashes LLVM 22 AArch64 frame lowering on win-arm64
     # (llvm/llvm-project#204060); extracted from check_percentile_and_quantile
     # so it can be skipped on that target.
-    @skip_win_arm64_40args_problem
+    @skip_if_win_arm64
     def test_percentile_tuple_input(self):
         pyfunc = array_percentile_global
         self.check_percentile_and_quantile_tuple_input(pyfunc,
                                                         q_upper_bound=100)
 
-    @skip_win_arm64_40args_problem
+    @skip_if_win_arm64
     def test_nanpercentile_tuple_input(self):
         pyfunc = array_nanpercentile_global
         self.check_percentile_and_quantile_tuple_input(pyfunc,
                                                         q_upper_bound=100)
 
-    @skip_win_arm64_40args_problem
+    @skip_if_win_arm64
     def test_quantile_tuple_input(self):
         pyfunc = array_quantile_global
         self.check_percentile_and_quantile_tuple_input(pyfunc, q_upper_bound=1)
 
-    @skip_win_arm64_40args_problem
+    @skip_if_win_arm64
     def test_nanquantile_tuple_input(self):
         pyfunc = array_nanquantile_global
         self.check_percentile_and_quantile_tuple_input(pyfunc, q_upper_bound=1)

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -4,8 +4,7 @@ import numpy as np
 
 from numba import jit, njit, typeof, types
 from numba.np.numpy_support import numpy_version
-from numba.tests.support import (TestCase, MemoryLeakMixin, tag,
-                                 skip_if_numpy_2, skip_if_win_arm64)
+from numba.tests.support import TestCase, MemoryLeakMixin, tag, skip_if_numpy_2
 import unittest
 
 
@@ -740,6 +739,7 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
         a = a.flatten().tolist()
         q = q.flatten().tolist()
         check(a, q)
+        check(tuple(a), tuple(q))
 
         a = self.random.choice([1, 2, 3, 4], 10)
         q = np.linspace(0, q_upper_bound, 5)
@@ -772,27 +772,6 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
         a = np.array([2, 3, 4, 1])
         cfunc(a, [q_upper_bound / 2])
         np.testing.assert_equal(a, np.array([2, 3, 4, 1]))
-
-    def check_percentile_and_quantile_tuple_input(self, pyfunc, q_upper_bound):
-        cfunc = jit(nopython=True)(pyfunc)
-
-        def check(a, q, abs_tol=1e-12):
-            expected = pyfunc(a, q)
-            got = cfunc(a, q)
-            # NOTE: inf/nan is not checked, seems to be susceptible to upstream
-            # changes
-            finite = np.isfinite(expected)
-            if np.all(finite):
-                self.assertPreciseEqual(got, expected, abs_tol=abs_tol)
-            else:
-                self.assertPreciseEqual(got[finite], expected[finite],
-                                        abs_tol=abs_tol)
-
-        a = self.random.randn(27).reshape(3, 3, 3)
-        q = np.linspace(0, q_upper_bound, 14)[::-1]
-        a = a.flatten().tolist()
-        q = q.flatten().tolist()
-        check(tuple(a), tuple(q))
 
     def check_percentile_edge_cases(self, pyfunc, q_upper_bound=100):
         cfunc = jit(nopython=True)(pyfunc)
@@ -915,31 +894,6 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
         self.check_percentile_and_quantile(pyfunc, q_upper_bound=1)
         self.check_percentile_edge_cases(pyfunc, q_upper_bound=1)
         self.check_quantile_exceptions(pyfunc)
-
-    # tuple input crashes LLVM 22 AArch64 frame lowering on win-arm64
-    # (llvm/llvm-project#204060); extracted from check_percentile_and_quantile
-    # so it can be skipped on that target.
-    @skip_if_win_arm64
-    def test_percentile_tuple_input(self):
-        pyfunc = array_percentile_global
-        self.check_percentile_and_quantile_tuple_input(pyfunc,
-                                                        q_upper_bound=100)
-
-    @skip_if_win_arm64
-    def test_nanpercentile_tuple_input(self):
-        pyfunc = array_nanpercentile_global
-        self.check_percentile_and_quantile_tuple_input(pyfunc,
-                                                        q_upper_bound=100)
-
-    @skip_if_win_arm64
-    def test_quantile_tuple_input(self):
-        pyfunc = array_quantile_global
-        self.check_percentile_and_quantile_tuple_input(pyfunc, q_upper_bound=1)
-
-    @skip_if_win_arm64
-    def test_nanquantile_tuple_input(self):
-        pyfunc = array_nanquantile_global
-        self.check_percentile_and_quantile_tuple_input(pyfunc, q_upper_bound=1)
 
     def test_nanmedian_basic(self):
         pyfunc = array_nanmedian_global

--- a/numba/tests/test_interpreter.py
+++ b/numba/tests/test_interpreter.py
@@ -10,7 +10,6 @@ from numba.tests.support import (
     TestCase,
     MemoryLeakMixin,
     skip_unless_py10_or_later,
-    skip_if_win_arm64,
 )
 
 
@@ -187,9 +186,6 @@ class TestCallFunctionExPeepHole(MemoryLeakMixin, TestCase):
         b = cfunc(*total_args)
         self.assertEqual(a, b)
 
-    # >= 40-arg calls crash LLVM 22 AArch64 frame lowering on win-arm64
-    # (llvm/llvm-project#204060).
-    @skip_if_win_arm64
     @skip_unless_py10_or_later
     def test_small_args_small_kws(self):
         """
@@ -206,7 +202,6 @@ class TestCallFunctionExPeepHole(MemoryLeakMixin, TestCase):
         b = cfunc(*total_args)
         self.assertEqual(a, b)
 
-    @skip_if_win_arm64
     @skip_unless_py10_or_later
     def test_small_args_large_kws(self):
         """
@@ -223,7 +218,6 @@ class TestCallFunctionExPeepHole(MemoryLeakMixin, TestCase):
         b = cfunc(*total_args)
         self.assertEqual(a, b)
 
-    @skip_if_win_arm64
     @skip_unless_py10_or_later
     def test_large_args_small_kws(self):
         """
@@ -240,7 +234,6 @@ class TestCallFunctionExPeepHole(MemoryLeakMixin, TestCase):
         b = cfunc(*total_args)
         self.assertEqual(a, b)
 
-    @skip_if_win_arm64
     @skip_unless_py10_or_later
     def test_large_args_large_kws(self):
         """
@@ -402,7 +395,6 @@ class TestCallFunctionExPeepHole(MemoryLeakMixin, TestCase):
             str(raises.exception)
         )
 
-    @skip_if_win_arm64
     @skip_unless_py10_or_later
     def test_large_args_noninlined_controlflow(self):
         """

--- a/numba/tests/test_interpreter.py
+++ b/numba/tests/test_interpreter.py
@@ -10,7 +10,7 @@ from numba.tests.support import (
     TestCase,
     MemoryLeakMixin,
     skip_unless_py10_or_later,
-    skip_win_arm64_40args_problem,
+    skip_if_win_arm64,
 )
 
 
@@ -189,7 +189,7 @@ class TestCallFunctionExPeepHole(MemoryLeakMixin, TestCase):
 
     # >= 40-arg calls crash LLVM 22 AArch64 frame lowering on win-arm64
     # (llvm/llvm-project#204060).
-    @skip_win_arm64_40args_problem
+    @skip_if_win_arm64
     @skip_unless_py10_or_later
     def test_small_args_small_kws(self):
         """
@@ -206,7 +206,7 @@ class TestCallFunctionExPeepHole(MemoryLeakMixin, TestCase):
         b = cfunc(*total_args)
         self.assertEqual(a, b)
 
-    @skip_win_arm64_40args_problem
+    @skip_if_win_arm64
     @skip_unless_py10_or_later
     def test_small_args_large_kws(self):
         """
@@ -223,7 +223,7 @@ class TestCallFunctionExPeepHole(MemoryLeakMixin, TestCase):
         b = cfunc(*total_args)
         self.assertEqual(a, b)
 
-    @skip_win_arm64_40args_problem
+    @skip_if_win_arm64
     @skip_unless_py10_or_later
     def test_large_args_small_kws(self):
         """
@@ -240,7 +240,7 @@ class TestCallFunctionExPeepHole(MemoryLeakMixin, TestCase):
         b = cfunc(*total_args)
         self.assertEqual(a, b)
 
-    @skip_win_arm64_40args_problem
+    @skip_if_win_arm64
     @skip_unless_py10_or_later
     def test_large_args_large_kws(self):
         """
@@ -402,7 +402,7 @@ class TestCallFunctionExPeepHole(MemoryLeakMixin, TestCase):
             str(raises.exception)
         )
 
-    @skip_win_arm64_40args_problem
+    @skip_if_win_arm64
     @skip_unless_py10_or_later
     def test_large_args_noninlined_controlflow(self):
         """

--- a/numba/tests/test_mixed_tuple_unroller.py
+++ b/numba/tests/test_mixed_tuple_unroller.py
@@ -2,8 +2,7 @@ from collections import namedtuple
 import numpy as np
 
 from numba.tests.support import (TestCase, MemoryLeakMixin,
-                                 skip_parfors_unsupported, captured_stdout,
-                                 skip_if_win_arm64)
+                                 skip_parfors_unsupported, captured_stdout)
 from numba import njit, typed, literal_unroll, prange
 from numba.core import types, errors, ir
 from numba.testing import unittest
@@ -579,9 +578,6 @@ class TestMixedTupleUnroll(MemoryLeakMixin, TestCase):
         tup = ('a', 12)
         self.assertEqual(foo(tup), foo.py_func(tup))
 
-    # >= 40-arg calls crash LLVM 22 AArch64 frame lowering on win-arm64
-    # (llvm/llvm-project#204060).
-    @skip_if_win_arm64
     def test_07(self):
         # A mix bag of stuff as an arg to a function that unifies as `intp`.
         @njit
@@ -805,7 +801,6 @@ class TestMixedTupleUnroll(MemoryLeakMixin, TestCase):
 
         self.assertEqual(foo(), foo.py_func())
 
-    @skip_if_win_arm64
     def test_15(self):
         # mixed tuple unroll cannot return derivative of the induction var
 

--- a/numba/tests/test_mixed_tuple_unroller.py
+++ b/numba/tests/test_mixed_tuple_unroller.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from numba.tests.support import (TestCase, MemoryLeakMixin,
                                  skip_parfors_unsupported, captured_stdout,
-                                 skip_win_arm64_40args_problem)
+                                 skip_if_win_arm64)
 from numba import njit, typed, literal_unroll, prange
 from numba.core import types, errors, ir
 from numba.testing import unittest
@@ -581,7 +581,7 @@ class TestMixedTupleUnroll(MemoryLeakMixin, TestCase):
 
     # >= 40-arg calls crash LLVM 22 AArch64 frame lowering on win-arm64
     # (llvm/llvm-project#204060).
-    @skip_win_arm64_40args_problem
+    @skip_if_win_arm64
     def test_07(self):
         # A mix bag of stuff as an arg to a function that unifies as `intp`.
         @njit
@@ -805,9 +805,7 @@ class TestMixedTupleUnroll(MemoryLeakMixin, TestCase):
 
         self.assertEqual(foo(), foo.py_func())
 
-    # >= 40-arg calls crash LLVM 22 AArch64 frame lowering on win-arm64
-    # (llvm/llvm-project#204060).
-    @skip_win_arm64_40args_problem
+    @skip_if_win_arm64
     def test_15(self):
         # mixed tuple unroll cannot return derivative of the induction var
 

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -22,7 +22,7 @@ from numba.tests.support import (TestCase, MemoryLeakMixin,
                                  needs_blas, run_in_subprocess,
                                  skip_if_numpy_2, IS_NUMPY_2,
                                  IS_MACOS_ARM64, IS_WIN_ARM64,
-                                 skip_win_arm64_40args_problem,
+                                 skip_if_win_arm64,
                                  REDUCED_TESTING,
                                  skip_if_reduced_testing)
 import unittest
@@ -2784,7 +2784,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
 
     # large tuple input crashes LLVM 22 AArch64 frame lowering on win-arm64
     # (llvm/llvm-project#204060)
-    @skip_win_arm64_40args_problem
+    @skip_if_win_arm64
     def test_partition_tuple_input(self):
         self._check_partition_tuple_input(partition)
 
@@ -2909,7 +2909,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
 
     # large tuple input crashes LLVM 22 AArch64 frame lowering on win-arm64
     # (llvm/llvm-project#204060)
-    @skip_win_arm64_40args_problem
+    @skip_if_win_arm64
     def test_argpartition_tuple_input(self):
         self._check_argpartition_tuple_input(argpartition)
 
@@ -3972,11 +3972,11 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
 
     # large tuple input crashes LLVM 22 AArch64 frame lowering on win-arm64
     # (llvm/llvm-project#204060); extracted from _check_split.
-    @skip_win_arm64_40args_problem
+    @skip_if_win_arm64
     def test_split_tuple_input(self):
         self._check_split_tuple_input(split)
 
-    @skip_win_arm64_40args_problem
+    @skip_if_win_arm64
     def test_array_split_tuple_input(self):
         self._check_split_tuple_input(array_split)
 

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -22,7 +22,6 @@ from numba.tests.support import (TestCase, MemoryLeakMixin,
                                  needs_blas, run_in_subprocess,
                                  skip_if_numpy_2, IS_NUMPY_2,
                                  IS_MACOS_ARM64, IS_WIN_ARM64,
-                                 skip_if_win_arm64,
                                  REDUCED_TESTING,
                                  skip_if_reduced_testing)
 import unittest
@@ -2657,16 +2656,6 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         for arr in a, (), np.array([]):
             check(arr)
 
-    def _check_partition_tuple_input(self, pyfunc):
-        cfunc = jit(nopython=True)(pyfunc)
-        d = np.arange(47)[::-1]
-        a = tuple(d.tolist())
-        self.assertEqual(cfunc(a, 6)[6], 6)
-        self.assertEqual(cfunc(a, 16)[16], 16)
-        self.assertPreciseEqual(cfunc(a, -6), cfunc(a, 41))
-        self.assertPreciseEqual(cfunc(a, -16), cfunc(a, 31))
-        self.partition_sanity_check(pyfunc, cfunc, d, -16)
-
     def test_partition_basic(self):
         # inspired by the test of the same name in:
         # https://github.com/numpy/numpy/blob/043a840/numpy/core/tests/test_multiarray.py    # noqa: E501
@@ -2711,9 +2700,9 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             self.assertEqual(cfunc(d, k)[k], k)
             self.partition_sanity_check(pyfunc, cfunc, d, k)
 
-        # rsorted, with input flavours: array and list
+        # rsorted, with input flavours: array, list and tuple
         d = np.arange(47)[::-1]
-        for a in d, d.tolist():
+        for a in d, d.tolist(), tuple(d.tolist()):
             self.assertEqual(cfunc(a, 6)[6], 6)
             self.assertEqual(cfunc(a, 16)[16], 16)
             self.assertPreciseEqual(cfunc(a, -6), cfunc(a, 41))
@@ -2782,12 +2771,6 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
                 # sanity check
                 self.partition_sanity_check(pyfunc, cfunc, d, i)
 
-    # large tuple input crashes LLVM 22 AArch64 frame lowering on win-arm64
-    # (llvm/llvm-project#204060)
-    @skip_if_win_arm64
-    def test_partition_tuple_input(self):
-        self._check_partition_tuple_input(partition)
-
     def test_argpartition_basic(self):
         # inspired by the test of the same name in:
         # https://github.com/numpy/numpy/blob/043a840/numpy/core/tests/test_multiarray.py    # noqa: E501
@@ -2834,9 +2817,9 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             self.assertEqual(cfunc(d, k)[k], k)
             self.partition_sanity_check(pyfunc, cfunc, d, k)
 
-        # rsorted, with input flavours: array and list
+        # rsorted, with input flavours: array, list and tuple
         d = np.arange(47)[::-1]
-        for a in d, d.tolist():
+        for a in d, d.tolist(), tuple(d.tolist()):
             self.assertEqual(cfunc(a, 6)[6], 40)
             self.assertEqual(cfunc(a, 16)[16], 30)
             self.assertPreciseEqual(cfunc(a, -6), cfunc(a, 41))
@@ -2896,22 +2879,6 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
                 np.testing.assert_array_less(p[i], p[i + 1:])
                 # sanity check
                 self.argpartition_sanity_check(pyfunc, cfunc, d, i)
-
-    def _check_argpartition_tuple_input(self, pyfunc):
-        cfunc = jit(nopython=True)(pyfunc)
-        d = np.arange(47)[::-1]
-        a = tuple(d.tolist())
-        self.assertEqual(cfunc(a, 6)[6], 40)
-        self.assertEqual(cfunc(a, 16)[16], 30)
-        self.assertPreciseEqual(cfunc(a, -6), cfunc(a, 41))
-        self.assertPreciseEqual(cfunc(a, -16), cfunc(a, 31))
-        self.argpartition_sanity_check(pyfunc, cfunc, d, -16)
-
-    # large tuple input crashes LLVM 22 AArch64 frame lowering on win-arm64
-    # (llvm/llvm-project#204060)
-    @skip_if_win_arm64
-    def test_argpartition_tuple_input(self):
-        self._check_argpartition_tuple_input(argpartition)
 
     def assert_partitioned(self, pyfunc, cfunc, d, kth):
         prev = 0
@@ -3878,8 +3845,10 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             yield a, 2, 0
             yield a, [1, 4, 72]
             yield list(a), [1, 4, 72]
+            yield tuple(a), [1, 4, 72]
             yield a, [1, 4, 72], 0
             yield list(a), [1, 4, 72], 0
+            yield tuple(a), [1, 4, 72], 0
 
             a = np.arange(64).reshape(4, 4, 4)
             yield a, 2
@@ -3923,16 +3892,6 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
 
             np.testing.assert_equal(expected, list(got))
 
-    def _check_split_tuple_input(self, func):
-        pyfunc = func
-        cfunc = jit(nopython=True)(pyfunc)
-        a = np.arange(100)
-        for args in ((tuple(a), [1, 4, 72]),
-                     (tuple(a), [1, 4, 72], 0)):
-            expected = pyfunc(*args)
-            got = cfunc(*args)
-            np.testing.assert_equal(expected, list(got))
-
     def _check_array_split(self, func):
         # array_split specific checks, mainly dealing with `int`s
         pyfunc = func
@@ -3969,16 +3928,6 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             njit(split)(np.ones(5), [3], axis=-3)
         self.assertIn("np.split: Argument axis out of bounds",
                       str(raises.exception))
-
-    # large tuple input crashes LLVM 22 AArch64 frame lowering on win-arm64
-    # (llvm/llvm-project#204060); extracted from _check_split.
-    @skip_if_win_arm64
-    def test_split_tuple_input(self):
-        self._check_split_tuple_input(split)
-
-    @skip_if_win_arm64
-    def test_array_split_tuple_input(self):
-        self._check_split_tuple_input(array_split)
 
     def test_vhdsplit_basic(self):
         # split and array_split have more comprehensive tests of splitting.

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -48,7 +48,7 @@ from numba.tests.support import (TestCase, captured_stdout, MemoryLeakMixin,
                                  needs_lapack, disabled_test, skip_unless_scipy,
                                  needs_subprocess,
                                  skip_ppc64le_invalid_ctr_loop,
-                                 skip_win_arm64_40args_problem)
+                                 skip_if_win_arm64)
 from numba.core.extending import register_jitable
 from numba.core.bytecode import _fix_LOAD_GLOBAL_arg
 from numba.core import utils
@@ -1325,7 +1325,7 @@ class TestParfors(TestParforsBase):
 
     # crashes LLVM 22 AArch64 frame lowering on win-arm64
     # (llvm/llvm-project#204060).
-    @skip_win_arm64_40args_problem
+    @skip_if_win_arm64
     def test_arraymap(self):
         def test_impl(a, x, y):
             return a * x + y
@@ -1609,7 +1609,7 @@ class TestParfors(TestParforsBase):
 
     # crashes LLVM 22 AArch64 frame lowering on win-arm64
     # (llvm/llvm-project#204060).
-    @skip_win_arm64_40args_problem
+    @skip_if_win_arm64
     @needs_blas
     def test_parfor_generate_fuse(self):
         # issue #2857
@@ -1967,7 +1967,7 @@ class TestParfors(TestParforsBase):
 
     # crashes LLVM 22 AArch64 frame lowering on win-arm64
     # (llvm/llvm-project#204060).
-    @skip_win_arm64_40args_problem
+    @skip_if_win_arm64
     def test_high_dimension1(self):
         # issue6749
         def test_impl(x):

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -47,8 +47,7 @@ from numba.tests.support import (TestCase, captured_stdout, MemoryLeakMixin,
                                  skip_parfors_unsupported, _32bit, needs_blas,
                                  needs_lapack, disabled_test, skip_unless_scipy,
                                  needs_subprocess,
-                                 skip_ppc64le_invalid_ctr_loop,
-                                 skip_if_win_arm64)
+                                 skip_ppc64le_invalid_ctr_loop)
 from numba.core.extending import register_jitable
 from numba.core.bytecode import _fix_LOAD_GLOBAL_arg
 from numba.core import utils
@@ -1323,9 +1322,6 @@ class TestParforsUnsupported(TestCase):
 class TestParfors(TestParforsBase):
     """ Tests cpython, reduction and various parfors features"""
 
-    # crashes LLVM 22 AArch64 frame lowering on win-arm64
-    # (llvm/llvm-project#204060).
-    @skip_if_win_arm64
     def test_arraymap(self):
         def test_impl(a, x, y):
             return a * x + y
@@ -1607,9 +1603,6 @@ class TestParfors(TestParforsBase):
         out = np.ones(1)
         self.check(test_impl, out)
 
-    # crashes LLVM 22 AArch64 frame lowering on win-arm64
-    # (llvm/llvm-project#204060).
-    @skip_if_win_arm64
     @needs_blas
     def test_parfor_generate_fuse(self):
         # issue #2857
@@ -1965,9 +1958,6 @@ class TestParfors(TestParforsBase):
         x = np.ones((3,3))
         self.check(test_impl, x)
 
-    # crashes LLVM 22 AArch64 frame lowering on win-arm64
-    # (llvm/llvm-project#204060).
-    @skip_if_win_arm64
     def test_high_dimension1(self):
         # issue6749
         def test_impl(x):

--- a/numba/tests/test_parfors_passes.py
+++ b/numba/tests/test_parfors_passes.py
@@ -20,8 +20,7 @@ from numba.core import (
     errors
 )
 from numba.core.registry import cpu_target
-from numba.tests.support import (TestCase, is_parfors_unsupported,
-                                 skip_if_win_arm64)
+from numba.tests.support import (TestCase, is_parfors_unsupported)
 
 
 class MyPipeline(object):
@@ -308,9 +307,6 @@ class TestConvertNumpyPass(BaseTest):
 
         self.run_parallel(test_impl, *args)
 
-    # crashes LLVM 22 AArch64 frame lowering on win-arm64
-    # (llvm/llvm-project#204060).
-    @skip_if_win_arm64
     def test_numpy_arrayexpr_boardcast(self):
         def test_impl(a, b):
             return a + b + np.array(1)

--- a/numba/tests/test_parfors_passes.py
+++ b/numba/tests/test_parfors_passes.py
@@ -21,7 +21,7 @@ from numba.core import (
 )
 from numba.core.registry import cpu_target
 from numba.tests.support import (TestCase, is_parfors_unsupported,
-                                 skip_win_arm64_40args_problem)
+                                 skip_if_win_arm64)
 
 
 class MyPipeline(object):
@@ -310,7 +310,7 @@ class TestConvertNumpyPass(BaseTest):
 
     # crashes LLVM 22 AArch64 frame lowering on win-arm64
     # (llvm/llvm-project#204060).
-    @skip_win_arm64_40args_problem
+    @skip_if_win_arm64
     def test_numpy_arrayexpr_boardcast(self):
         def test_impl(a, b):
             return a + b + np.array(1)

--- a/numba/tests/test_sets.py
+++ b/numba/tests/test_sets.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from numba import jit, njit
 from numba.tests.support import (TestCase, enable_pyobj_flags, MemoryLeakMixin,
-                                 compile_function, skip_if_win_arm64)
+                                 compile_function)
 
 
 Point = namedtuple('Point', ('a', 'b'))
@@ -623,20 +623,6 @@ class TestUnicodeSets(TestSets):
     """
     def _range(self, stop):
         return ['A{}'.format(i) for i in range(int(stop))]
-
-    # UniTuple[unicode, 3] unpacks to >=40 LLVM args; crashes frame lowering
-    # on win-arm64 (llvm/llvm-project#204060).
-    @skip_if_win_arm64
-    def test_isdisjoint(self):
-        super().test_isdisjoint()
-
-    @skip_if_win_arm64
-    def test_issubset(self):
-        super().test_issubset()
-
-    @skip_if_win_arm64
-    def test_issuperset(self):
-        super().test_issuperset()
 
 
 class TestSetsInvalidDtype(TestSets):

--- a/numba/tests/test_sets.py
+++ b/numba/tests/test_sets.py
@@ -10,7 +10,8 @@ import numpy as np
 
 from numba import jit, njit
 from numba.tests.support import (TestCase, enable_pyobj_flags, MemoryLeakMixin,
-                                 compile_function)
+                                 compile_function,
+                                 skip_win_arm64_unittuple_uimm12)
 
 
 Point = namedtuple('Point', ('a', 'b'))
@@ -623,6 +624,19 @@ class TestUnicodeSets(TestSets):
     """
     def _range(self, stop):
         return ['A{}'.format(i) for i in range(int(stop))]
+
+    # https://github.com/numba/numba/issues/10619
+    @skip_win_arm64_unittuple_uimm12
+    def test_isdisjoint(self):
+        super().test_isdisjoint()
+
+    @skip_win_arm64_unittuple_uimm12
+    def test_issubset(self):
+        super().test_issubset()
+
+    @skip_win_arm64_unittuple_uimm12
+    def test_issuperset(self):
+        super().test_issuperset()
 
 
 class TestSetsInvalidDtype(TestSets):

--- a/numba/tests/test_sets.py
+++ b/numba/tests/test_sets.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from numba import jit, njit
 from numba.tests.support import (TestCase, enable_pyobj_flags, MemoryLeakMixin,
-                                 compile_function, skip_win_arm64_40args_problem)
+                                 compile_function, skip_if_win_arm64)
 
 
 Point = namedtuple('Point', ('a', 'b'))
@@ -626,15 +626,15 @@ class TestUnicodeSets(TestSets):
 
     # UniTuple[unicode, 3] unpacks to >=40 LLVM args; crashes frame lowering
     # on win-arm64 (llvm/llvm-project#204060).
-    @skip_win_arm64_40args_problem
+    @skip_if_win_arm64
     def test_isdisjoint(self):
         super().test_isdisjoint()
 
-    @skip_win_arm64_40args_problem
+    @skip_if_win_arm64
     def test_issubset(self):
         super().test_issubset()
 
-    @skip_win_arm64_40args_problem
+    @skip_if_win_arm64
     def test_issuperset(self):
         super().test_issuperset()
 

--- a/numba/tests/test_stencils.py
+++ b/numba/tests/test_stencils.py
@@ -13,7 +13,7 @@ from numba.core.compiler import compile_extra, Flags
 from numba.core.cpu import ParallelOptions
 from numba.tests.support import (
     skip_parfors_unsupported,
-    skip_win_arm64_40args_problem,
+    skip_if_win_arm64,
     _32bit,
 )
 from numba.core.errors import LoweringError, TypingError, NumbaValueError
@@ -365,7 +365,7 @@ class TestStencil(TestStencilBase):
     @skip_unsupported
     # crashes LLVM 22 AArch64 frame lowering on win-arm64
     # (llvm/llvm-project#204060).
-    @skip_win_arm64_40args_problem
+    @skip_if_win_arm64
     def test_stencil_mixed_types(self):
         def test_impl_seq(n):
             A = np.arange(n ** 2).reshape((n, n))
@@ -1917,9 +1917,7 @@ class TestManyStencils(TestStencilBase):
         self.check_exceptions(kernel, a, b, expected_exception=[NumbaValueError,
                                                                 LoweringError])
 
-    # crashes LLVM 22 AArch64 frame lowering on win-arm64
-    # (llvm/llvm-project#204060).
-    @skip_win_arm64_40args_problem
+    @skip_if_win_arm64
     def test_basic47(self):
         """3 args"""
         def kernel(a, b, c):
@@ -2013,9 +2011,7 @@ class TestManyStencils(TestStencilBase):
                               options={'standard_indexing': ['a', 'b']},
                               expected_exception=[ValueError, NumbaValueError])
 
-    # crashes LLVM 22 AArch64 frame lowering on win-arm64
-    # (llvm/llvm-project#204060).
-    @skip_win_arm64_40args_problem
+    @skip_if_win_arm64
     def test_basic52(self):
         """3 args, standard_indexing on middle arg """
         def kernel(a, b, c):

--- a/numba/tests/test_stencils.py
+++ b/numba/tests/test_stencils.py
@@ -11,11 +11,7 @@ from numba import njit, stencil
 from numba.core import types, registry
 from numba.core.compiler import compile_extra, Flags
 from numba.core.cpu import ParallelOptions
-from numba.tests.support import (
-    skip_parfors_unsupported,
-    skip_if_win_arm64,
-    _32bit,
-)
+from numba.tests.support import skip_parfors_unsupported, _32bit
 from numba.core.errors import LoweringError, TypingError, NumbaValueError
 import unittest
 
@@ -363,9 +359,6 @@ class TestStencil(TestStencilBase):
         self.check(test_impl_seq, test_seq, n)
 
     @skip_unsupported
-    # crashes LLVM 22 AArch64 frame lowering on win-arm64
-    # (llvm/llvm-project#204060).
-    @skip_if_win_arm64
     def test_stencil_mixed_types(self):
         def test_impl_seq(n):
             A = np.arange(n ** 2).reshape((n, n))
@@ -1917,7 +1910,6 @@ class TestManyStencils(TestStencilBase):
         self.check_exceptions(kernel, a, b, expected_exception=[NumbaValueError,
                                                                 LoweringError])
 
-    @skip_if_win_arm64
     def test_basic47(self):
         """3 args"""
         def kernel(a, b, c):
@@ -2011,7 +2003,6 @@ class TestManyStencils(TestStencilBase):
                               options={'standard_indexing': ['a', 'b']},
                               expected_exception=[ValueError, NumbaValueError])
 
-    @skip_if_win_arm64
     def test_basic52(self):
         """3 args, standard_indexing on middle arg """
         def kernel(a, b, c):


### PR DESCRIPTION
https://github.com/numba/numba/pull/10644 was merged to add support for `win-arm64`. The PR had skip decorators on test to avoid FrameLowering Assertion failures because of an upstream llvm issue (https://github.com/llvm/llvm-project/issues/204060).

This PR reverts the test skips to test against patched llvm build (https://github.com/numba/llvmlite/pull/1439).