### PR TITLE
FIX release0.66: remove redundant numpy version requirement from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -384,7 +384,6 @@ build_requires = ['numpy >={},<{}'.format(min_numpy_build_version,
                                           max_numpy_run_version)]
 install_requires = [
     'llvmlite >={},<{}'.format(min_llvmlite_version, max_llvmlite_version),
-    'numpy >={}'.format(min_numpy_run_version),
     'numpy >={},<{}'.format(min_numpy_run_version, max_numpy_run_version),
 ]
 


### PR DESCRIPTION
The numpy version requirement pin had 2 specification when it should only have min and max on release branch.