### PR TITLE
Sort cext libs for deterministic AOT builds

### DIFF
--- a/docs/upcoming_changes/10666.bug_fix.rst
+++ b/docs/upcoming_changes/10666.bug_fix.rst
@@ -1,0 +1,8 @@
+Sort ``numba.cext`` C sources for reproducible AOT builds
+---------------------------------------------------------
+
+``numba.pycc`` collected its C mixin sources via ``os.listdir``, whose
+order is filesystem-defined and varies across hosts. This made the source
+(and hence symbol) order of AOT-compiled binaries non-deterministic across
+build machines. The sources are now sorted so independent builds produce
+byte-for-byte identical binaries.

--- a/numba/cext/__init__.py
+++ b/numba/cext/__init__.py
@@ -14,7 +14,7 @@ def get_extension_libs():
         if fn.endswith('.c'):
             fn = os.path.join(base, fn)
             libs.append(fn)
-    return libs
+    return sorted(libs)
 
 
 def get_path():

--- a/numba/tests/test_pycc.py
+++ b/numba/tests/test_pycc.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 import tempfile
 import textwrap
-from unittest import skip
+from unittest import mock
 from ctypes import *
 
 import numpy as np
@@ -14,10 +14,11 @@ import numpy as np
 import llvmlite.binding as ll
 
 from numba.core import utils
-from numba.tests.support import (TestCase, tag, import_dynamic, temp_directory,
-                                 has_blas, needs_setuptools, skip_if_py313plus_on_windows,
+from numba.tests.support import (TestCase, import_dynamic, temp_directory, has_blas,
+                                 needs_setuptools, skip_if_py313plus_on_windows,
                                  skip_if_linux_aarch64, skip_if_freethreading,
                                  skip_if_windows)
+from numba import cext
 
 import unittest
 
@@ -56,6 +57,22 @@ class TestCompilerChecks(TestCase):
         if is_running_conda_build:
             if os.environ.get('VSINSTALLDIR', None) is not None:
                 self.assertTrue(external_compiler_works())
+
+
+class TestExtensionLibs(TestCase):
+
+    def test_get_extension_libs_is_sorted(self):
+        fake_listing = ['setobject.c', 'listobject.c', 'utils.c',
+                        'dictobject.c', 'README.txt']
+        base = cext.get_path()
+        with mock.patch('numba.cext.os.listdir', return_value=fake_listing):
+            libs = cext.get_extension_libs()
+
+        expected = sorted(
+            os.path.join(base, fn) for fn in fake_listing if fn.endswith('.c')
+        )
+        self.assertEqual(libs, expected)
+        self.assertEqual(libs, sorted(libs))
 
 
 @skip_if_freethreading


### PR DESCRIPTION
`get_extension_libs()` returned `os.listdir()` results unsorted. `listdir` order is filesystem-defined and varies across hosts, so the .c source order (and thus symbol order and hash) of AOT-compiled binaries was non-deterministic across build machines.
