### PR TITLE
docs: fix parameter name mismatches in 5 docstrings

### DIFF
--- a/docs/upcoming_changes/10681.doc.rst
+++ b/docs/upcoming_changes/10681.doc.rst
@@ -1,0 +1,7 @@
+Fix parameter name mismatches in docstrings
+-------------------------------------------
+
+Corrected several docstring parameter names that did not match their
+function signatures in ``numba.core.callconv``, ``numba.core.ssa``,
+``numba.core.withcontexts``, ``numba.misc.memoryutils`` and
+``numba.parfors.parfor_lowering_utils``.

--- a/numba/core/callconv.py
+++ b/numba/core/callconv.py
@@ -325,7 +325,7 @@ class _MinimalCallHelper(object):
 
         Parameters
         ----------
-        id : integer
+        exc_id : integer
             The ID of the exception to look up
         """
         try:

--- a/numba/core/ssa.py
+++ b/numba/core/ssa.py
@@ -246,7 +246,7 @@ class _BaseHandler:
         Parameters
         -----------
         states : dict
-        assign : numba.ir.Stmt
+        stmt : numba.ir.Stmt
 
         Returns
         -------

--- a/numba/core/withcontexts.py
+++ b/numba/core/withcontexts.py
@@ -36,7 +36,7 @@ class WithContext(object):
         blocks : dict[ir.Block]
         blk_start, blk_end : int
             labels of the starting and ending block of the context-manager.
-        body_block: sequence[int]
+        body_blocks: sequence[int]
             A sequence of int's representing labels of the with-body
         dispatcher_factory : callable
             A callable that takes a `FunctionIR` and returns a `Dispatcher`.

--- a/numba/misc/memoryutils.py
+++ b/numba/misc/memoryutils.py
@@ -116,10 +116,6 @@ class MemoryTracker:
         Records start/end memory usage and timing, calculates RSS delta,
         and stores all data in instance attributes.
 
-        Args:
-            name (str): Name/identifier for the function or operation being
-                        monitored
-
         Yields:
             self: The MemoryTracker instance for accessing stored data
         """

--- a/numba/parfors/parfor_lowering_utils.py
+++ b/numba/parfors/parfor_lowering_utils.py
@@ -200,7 +200,7 @@ class ParforLoweringBuilder:
             the object being indexed
         index : ir.Var
             the index
-        val : ir.Var
+        typ : ir.Var
             the ty
 
         Returns

--- a/numba/parfors/parfor_lowering_utils.py
+++ b/numba/parfors/parfor_lowering_utils.py
@@ -201,7 +201,7 @@ class ParforLoweringBuilder:
         index : ir.Var
             the index
         typ : ir.Var
-            the ty
+            the return type
 
         Returns
         -------


### PR DESCRIPTION
## Summary

Found 5 places where docstring parameter names don't match the actual function signatures, discovered via AST-based signature-vs-docstring comparison.

| File | Function | Docstring has | Signature has |
|------|----------|--------------|---------------|
| `numba/core/callconv.py` | `get_exception()` | `id` | `exc_id` |
| `numba/core/ssa.py` | `on_other()` | `assign` | `stmt` |
| `numba/core/withcontexts.py` | `mutate_with_body()` | `body_block` | `body_blocks` |
| `numba/parfors/parfor_lowering_utils.py` | `getitem()` | `val` | `typ` |
| `numba/misc/memoryutils.py` | `monitor()` | stale `name` arg | no parameters (context manager, name belongs to `__init__`) |

Each fix is a one-line rename (or removal) to match the actual parameter name in the function signature.