### PR TITLE
Fix cfunc type stub to accept nopython keyword argument

### DIFF
--- a/docs/upcoming_changes/10679.bug_fix.rst
+++ b/docs/upcoming_changes/10679.bug_fix.rst
@@ -4,5 +4,5 @@ Fix ``cfunc`` type stub to accept ``nopython`` keyword argument
 The type stub for ``@cfunc`` was missing the ``nopython`` keyword argument that
 the runtime decorator accepts and documents. This caused ``mypy`` to report
 ``Unexpected keyword argument "nopython" for "cfunc"`` on valid code. The stub
-now includes ``nopython: bool = False`` as a keyword-only argument
+now includes ``nopython: bool = False`` as a keyword-only argument.
 (`#10679 <https://github.com/numba/numba/issues/10679>`_).

--- a/docs/upcoming_changes/10679.bug_fix.rst
+++ b/docs/upcoming_changes/10679.bug_fix.rst
@@ -4,5 +4,5 @@ Fix ``cfunc`` type stub to accept ``nopython`` keyword argument
 The type stub for ``@cfunc`` was missing the ``nopython`` keyword argument that
 the runtime decorator accepts and documents. This caused ``mypy`` to report
 ``Unexpected keyword argument "nopython" for "cfunc"`` on valid code. The stub
-now includes ``nopython: bool = False`` as a keyword-only argument.
+now includes ``nopython: bool = False`` as a keyword-only argument
 (`#10679 <https://github.com/numba/numba/issues/10679>`_).

--- a/docs/upcoming_changes/10679.bug_fix.rst
+++ b/docs/upcoming_changes/10679.bug_fix.rst
@@ -1,0 +1,8 @@
+Fix ``cfunc`` type stub to accept ``nopython`` keyword argument
+----------------------------------------------------------------
+
+The type stub for ``@cfunc`` was missing the ``nopython`` keyword argument that
+the runtime decorator accepts and documents. This caused ``mypy`` to report
+``Unexpected keyword argument "nopython" for "cfunc"`` on valid code. The stub
+now includes ``nopython: bool = False`` as a keyword-only argument
+(`#10679 <https://github.com/numba/numba/issues/10679>`_).

--- a/numba/core/decorators.pyi
+++ b/numba/core/decorators.pyi
@@ -107,6 +107,8 @@ def cfunc(
     locals: _ToLocals = ...,
     cache: bool = False,
     pipeline_class: type[compiler.CompilerBase] | None = None,
+    *,
+    nopython: bool = False,
     **options: Unpack[_JITOptions],
 ) -> _CFuncWrapper: ...
 


### PR DESCRIPTION
## Description

The type stub for `@cfunc` (`numba/core/decorators.pyi`) was missing the `nopython` keyword argument that the runtime decorator accepts and documents. This caused `mypy` to report:

```
Unexpected keyword argument "nopython" for "cfunc"
```

on valid code such as:

```python
from numba import cfunc

@cfunc("float64(float64, float64)", nopython=True)
def add(x, y):
    return x + y
```

## Changes

- Added `nopython: bool = False` as a keyword-only argument to the `cfunc` signature in `decorators.pyi`
- Added a newsfragment at `docs/upcoming_changes/10679.bug_fix.rst`

## Testing

Verified with `mypy --follow-imports=skip` on repro code covering `nopython=True`, `nopython=False`, and no kwargs — all pass clean. Runtime behavior is unchanged (`cfunc` always operates in nopython mode via `_CFuncCompiler._customize_flags`; the stub just needs to accept the kwarg without erroring).

Closes #10679