### PR TITLE
Fix false NumbaPerformanceWarning when indexing with newaxis

### DIFF
--- a/docs/upcoming_changes/10684.bug_fix.rst
+++ b/docs/upcoming_changes/10684.bug_fix.rst
@@ -1,5 +1,5 @@
 Fix false ``NumbaPerformanceWarning`` when indexing with ``newaxis``
----------------------------------------------------------------------
+--------------------------------------------------------------------
 
 Indexing a contiguous array with ``np.newaxis`` (for example
 ``x[:, None]``) was incorrectly treated as breaking contiguity, since the

--- a/docs/upcoming_changes/10684.bug_fix.rst
+++ b/docs/upcoming_changes/10684.bug_fix.rst
@@ -1,0 +1,10 @@
+Fix false ``NumbaPerformanceWarning`` when indexing with ``newaxis``
+---------------------------------------------------------------------
+
+Indexing a contiguous array with ``np.newaxis`` (for example
+``x[:, None]``) was incorrectly treated as breaking contiguity, since the
+slice preceding the ``newaxis`` was no longer considered the innermost
+index. This caused a spurious ``NumbaPerformanceWarning`` to be raised
+from ``np.dot()``, ``np.vdot()``, and ``@`` when one of their operands had
+been reshaped with ``newaxis``, even though the array was still
+contiguous (`#10086 <https://github.com/numba/numba/issues/10086>`_).

--- a/numba/core/typing/arraydecl.py
+++ b/numba/core/typing/arraydecl.py
@@ -138,8 +138,11 @@ def get_array_index_type(ary, idx):
 
         def keeps_contiguity(ty, is_innermost):
             # A slice can only keep an array contiguous if it is the
-            # innermost index and it is not strided
+            # innermost index and it is not strided. A newaxis (None)
+            # index never affects contiguity, as it just inserts a new
+            # dimension of size 1 without touching the underlying data.
             return (ty is types.ellipsis or isinstance(ty, types.Integer)
+                    or is_nonelike(ty)
                     or (is_innermost and isinstance(ty, types.SliceType)
                         and not ty.has_step))
 
@@ -148,8 +151,14 @@ def get_array_index_type(ary, idx):
             Whether indexing with the given indices (from outer to inner in
             physical layout order) can keep an array contiguous.
             """
-            for ty in outer_indices[:-1]:
-                if not keeps_contiguity(ty, False):
+            for i, ty in enumerate(outer_indices[:-1]):
+                # An index is still "innermost" for contiguity purposes if
+                # every index after it is a newaxis, since those don't
+                # correspond to any physical dimension of the source array.
+                is_innermost = all(
+                    is_nonelike(t) for t in outer_indices[i + 1:]
+                )
+                if not keeps_contiguity(ty, is_innermost):
                     return False
             if outer_indices and not keeps_contiguity(outer_indices[-1], True):
                 return False

--- a/numba/tests/test_linalg.py
+++ b/numba/tests/test_linalg.py
@@ -328,6 +328,25 @@ class TestProduct(EnableNRTStatsMixin, TestCase):
         with self.check_contiguity_warning(cfunc.py_func):
             cfunc(a, b)
 
+    @needs_blas
+    def test_no_contiguity_warning_with_newaxis(self):
+        # See issue #10086: indexing with np.newaxis (None) only inserts a
+        # size-1 dimension and does not make an otherwise-contiguous array
+        # non-contiguous, so it should not trigger a NumbaPerformanceWarning.
+        def dot_with_newaxis(a, x):
+            return np.dot(a, x[:, None])
+
+        m, n = 5, 5
+        dtype = np.float64
+        a = self.sample_matrix(m, n, dtype)
+        x = self.sample_vector(n, dtype)
+
+        cfunc = jit(nopython=True)(dot_with_newaxis)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always', errors.NumbaPerformanceWarning)
+            cfunc(a, x)
+        self.assertEqual(len(w), 0)
+
 
 # Implementation definitions for the purpose of jitting.
 


### PR DESCRIPTION
Fixes #10086.

`get_array_index_type()`'s `check_contiguity()` marks every index except the very last one as non-innermost. That means a contiguous slice like `x[:, None]` gets flagged as breaking contiguity, purely because it's followed by a `None` (newaxis) in the index tuple — even though newaxis just inserts a size-1 dimension and never touches strides or the underlying buffer. That's what causes the spurious `NumbaPerformanceWarning` from `np.dot`/`np.vdot`/`@` in the repro from the issue.

This picks up the starter patch @gmarkall posted in the issue thread (there was an earlier attempt at #10470, but it only applied half of it, which is why @kc611 flagged that `is_innermost` could still end up wrong):

- `keeps_contiguity()` now also treats newaxis as contiguity-preserving, via `is_nonelike()` (already used elsewhere in this same file for the same check).
- `check_contiguity()` now computes `is_innermost` per-index by checking whether everything *after* that index is a newaxis, instead of hardcoding `False` for every index but the last.

Added a test in `test_linalg.py` that reproduces the exact case from the issue (`np.dot(A, x[:, None])`) and asserts no `NumbaPerformanceWarning` is raised. Confirmed it fails on main and passes with this change.

I built numba locally against llvmlite 0.48.0 and ran the full `test_linalg.py::TestProduct`, `test_indexing.py`, `test_fancy_indexing.py`, and `test_array_manipulation.py` suites — all passing (138 tests / 475 subtests across the latter three, no regressions from the `check_contiguity` change).