### PR TITLE
Add support for math.isclose() in nopython mode

### DIFF
--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -1127,6 +1127,8 @@ The following functions from the :mod:`math` module are supported:
 * :func:`math.gamma`
 * :func:`math.gcd`
 * :func:`math.hypot`
+* :func:`math.isclose`: ``rel_tol`` and ``abs_tol`` may also be passed
+  positionally, whereas CPython requires them to be passed by keyword
 * :func:`math.isfinite`
 * :func:`math.isinf`
 * :func:`math.isnan`

--- a/docs/upcoming_changes/10685.new_feature.rst
+++ b/docs/upcoming_changes/10685.new_feature.rst
@@ -1,0 +1,8 @@
+Add support for ``math.isclose()``
+----------------------------------
+
+``numpy.isclose()`` was already supported, but the standard library
+``math.isclose()`` had no implementation in Numba's ``nopython`` mode.
+This adds an implementation that mirrors CPython's behaviour, including
+handling of NaNs and infinities and validation that ``rel_tol`` and
+``abs_tol`` are non-negative.

--- a/numba/cpython/mathimpl.py
+++ b/numba/cpython/mathimpl.py
@@ -13,6 +13,7 @@ from llvmlite.ir import Constant
 from numba.core.imputils import Registry, impl_ret_untracked
 from numba import typeof
 from numba.core import types, utils, config, cgutils
+from numba.core.errors import TypingError
 from numba.core.extending import overload
 from numba.core.typing import signature
 from numba.cpython.unsafe.numbers import trailing_zeros
@@ -244,6 +245,46 @@ def isfinite_float_impl(context, builder, sig, args):
 def isfinite_int_impl(context, builder, sig, args):
     res = cgutils.true_bit
     return impl_ret_untracked(context, builder, sig.return_type, res)
+
+
+@overload(math.isclose)
+def isclose_impl(a, b, rel_tol=1e-09, abs_tol=0.0):
+    # NOTE: in CPython, rel_tol and abs_tol are keyword-only arguments, but
+    # they are accepted here as regular arguments (i.e. they may also be
+    # passed positionally) since Numba's keyword-only argument handling
+    # does not currently support omitting all of them and relying on the
+    # defaults when the caller itself is jit-compiled code.
+    if not isinstance(a, (types.Float, types.Integer, types.Boolean)):
+        raise TypingError('The first argument "a" must be a number')
+
+    if not isinstance(b, (types.Float, types.Integer, types.Boolean)):
+        raise TypingError('The second argument "b" must be a number')
+
+    if not isinstance(rel_tol, (int, float, types.Float, types.Integer)):
+        raise TypingError('The "rel_tol" argument must be a number')
+
+    if not isinstance(abs_tol, (int, float, types.Float, types.Integer)):
+        raise TypingError('The "abs_tol" argument must be a number')
+
+    def impl(a, b, rel_tol=1e-09, abs_tol=0.0):
+        if rel_tol < 0.0 or abs_tol < 0.0:
+            raise ValueError('tolerances must be non-negative')
+        # Mirrors CPython's implementation (Modules/mathmodule.c): the
+        # equality short-circuit below also handles two infinities of the
+        # same sign, and the isinf() check below it handles two infinities
+        # of opposite sign as well as one infinite and one finite operand.
+        if a == b:
+            return True
+        if math.isinf(a) or math.isinf(b):
+            return False
+        diff = abs(b - a)
+        return (
+            diff <= abs(rel_tol * b)
+            or diff <= abs(rel_tol * a)
+            or diff <= abs_tol
+        )
+
+    return impl
 
 
 @lower(math.copysign, types.Float, types.Float)

--- a/numba/tests/test_mathlib.py
+++ b/numba/tests/test_mathlib.py
@@ -126,6 +126,14 @@ def hypot(x, y):
     return math.hypot(x, y)
 
 
+def isclose(x, y):
+    return math.isclose(x, y)
+
+
+def isclose_tol(x, y, rel_tol, abs_tol):
+    return math.isclose(x, y, rel_tol=rel_tol, abs_tol=abs_tol)
+
+
 def nextafter(x, y):
     return math.nextafter(x, y)
 
@@ -455,6 +463,59 @@ class TestMathLib(TestCase):
                 self.assertRaisesRegex(RuntimeWarning,
                                         'overflow encountered in .*scalar',
                                         naive_hypot, val, val)
+
+    def test_isclose(self):
+        pyfunc = isclose
+        x_types = [types.int64, types.uint64,
+                   types.float32, types.float64]
+        x_values = [1, 2, 3, 4]
+        y_values = [x + 2 for x in x_values]
+        self.run_binary(pyfunc, x_types, x_values, y_values)
+
+        cfunc = njit(pyfunc)
+        inf = float('inf')
+        nan = float('nan')
+        close_cases = [
+            (1.0, 1.0),
+            (1.0, 1.0 + 1e-12),
+            (0.0, 0.0),
+            (inf, inf),
+        ]
+        not_close_cases = [
+            (1.0, 1.1),
+            (inf, -inf),
+            (inf, 5.0),
+            (nan, nan),
+            (nan, 1.0),
+        ]
+        for x, y in close_cases:
+            msg = 'for inputs (%r, %r)' % (x, y)
+            self.assertEqual(cfunc(x, y), pyfunc(x, y), msg=msg)
+            self.assertTrue(cfunc(x, y), msg=msg)
+        for x, y in not_close_cases:
+            msg = 'for inputs (%r, %r)' % (x, y)
+            self.assertEqual(cfunc(x, y), pyfunc(x, y), msg=msg)
+            self.assertFalse(cfunc(x, y), msg=msg)
+
+        tol_pyfunc = isclose_tol
+        tol_cfunc = njit(tol_pyfunc)
+        tol_cases = [
+            (1.0, 1.2, 0.0, 0.5),
+            (1.0, 1.2, 0.0, 0.1),
+            (100.0, 100.5, 0.01, 0.0),
+            (100.0, 105.0, 0.01, 0.0),
+        ]
+        for x, y, rel_tol, abs_tol in tol_cases:
+            msg = 'for inputs (%r, %r, %r, %r)' % (x, y, rel_tol, abs_tol)
+            got = tol_cfunc(x, y, rel_tol, abs_tol)
+            expected = tol_pyfunc(x, y, rel_tol, abs_tol)
+            self.assertEqual(got, expected, msg=msg)
+
+        # negative tolerances are rejected, same as in CPython
+        with self.assertRaises(ValueError):
+            tol_cfunc(1.0, 1.0, -1.0, 0.0)
+        with self.assertRaises(ValueError):
+            tol_cfunc(1.0, 1.0, 0.0, -1.0)
 
     def test_nextafter(self):
         pyfunc = nextafter


### PR DESCRIPTION
## Description

Fixes part of #5977.

numpy.isclose() was added in #7067, but math.isclose() from the
standard library is still unsupported. Calling it inside a jit
compiled function currently raises a TypingError.

This adds an @overload implementation of math.isclose() in
numba/cpython/mathimpl.py that mirrors the behaviour of CPython's
mathmodule.c, including:

- Returning True for two equal values, including two infinities of
  the same sign.
- Returning False when one or both operands are infinite and the
  values are not equal (covers opposite sign infinities, and one
  finite and one infinite operand).
- Raising a ValueError when rel_tol or abs_tol is negative.
- Supporting int, float and bool operands, and int or float
  tolerances.

One difference from CPython: rel_tol and abs_tol are accepted here as
regular optional arguments rather than strictly keyword-only
arguments. This is because a jit compiled function that calls another
jit compiled function while omitting all keyword-only arguments
currently hits an IndexError in
numba.core.typing.templates.fold_arguments. Accepting the tolerances
positionally as well as by keyword works around this limitation while
keeping both common calling styles supported. I have left a comment
in the code explaining this.

## Testing

Added test_isclose to numba/tests/test_mathlib.py, covering plain
values across int/uint/float types, close and not-close boundary
cases (equal values, near-equal values, NaNs, infinities of both
signs), explicit rel_tol/abs_tol combinations, and the ValueError for
negative tolerances. Ran the full test_mathlib suite locally, all 43
tests pass.

Also verified interactively against the actual math.isclose() for a
range of inputs (finite, NaN, infinite, and various tolerance
combinations) to confirm output matches exactly.

Updated docs/source/reference/pysupported.rst to list math.isclose()
as supported, noting the positional-argument difference from CPython.