### PR TITLE
Fix sphinx docutils CI error

### DIFF
--- a/buildscripts/incremental/setup_conda_environment.sh
+++ b/buildscripts/incremental/setup_conda_environment.sh
@@ -91,7 +91,7 @@ fi
 $CONDA_INSTALL -c numba/label/dev llvmlite=0.49
 
 # Install dependencies for building the documentation
-if [ "$BUILD_DOC" == "yes" ]; then $CONDA_INSTALL sphinx docutils sphinx_rtd_theme pygments numpydoc; fi
+if [ "$BUILD_DOC" == "yes" ]; then $CONDA_INSTALL sphinx sphinx_rtd_theme pygments numpydoc; fi
 if [ "$BUILD_DOC" == "yes" ]; then $PIP_INSTALL rstcheck; fi
 # Install dependencies for code coverage
 if [ "$RUN_COVERAGE" == "yes" ]; then $CONDA_INSTALL coverage; fi


### PR DESCRIPTION
When spelled with installing both packages, the docutils is pulling a much older version of sphinx that doesn't have `types.Union`.

Sphinx already install docutils internally so nothing is affected.