### PR TITLE
Use gep in `pointer_add`

### DIFF
--- a/docs/upcoming_changes/10696.bug_fix.rst
+++ b/docs/upcoming_changes/10696.bug_fix.rst
@@ -1,0 +1,8 @@
+Fix a miscompile in ``pointer_add``
+-----------------------------------
+
+``pointer_add`` built the offset pointer through a ``ptrtoint``/``inttoptr``
+round-trip, producing a pointer with no provenance that LLVM could miscompile
+once inlined, returning invalid results or raising spurious exceptions.
+It now uses a byte-wise ``getelementptr`` instead, which preserves provenance.
+Fixed spurious errors during element access on non-contiguous (``'A'`` layout) arrays.

--- a/numba/core/cgutils.py
+++ b/numba/core/cgutils.py
@@ -959,14 +959,16 @@ def pointer_add(builder, ptr, offset, return_type=None):
     Add an integral *offset* to pointer *ptr*, and return a pointer
     of *return_type* (or, if omitted, the same type as *ptr*).
 
-    Note the computation is done in bytes, and ignores the width of
-    the pointed item type.
+    The computation is done in bytes (ignoring the width of the pointed
+    item type) via a byte-wise getelementptr, so the result keeps the
+    provenance of *ptr*. Only valid when *offset* stays within the object
+    *ptr* points into.
     """
-    intptr = builder.ptrtoint(ptr, intp_t)
     if isinstance(offset, int):
         offset = intp_t(offset)
-    intptr = builder.add(intptr, offset)
-    return builder.inttoptr(intptr, return_type or ptr.type)
+    base = builder.bitcast(ptr, int8_t.as_pointer())
+    addr = builder.gep(base, [offset])
+    return builder.bitcast(addr, return_type or ptr.type)
 
 
 def memset(builder, ptr, size, value):


### PR DESCRIPTION
Fixes #10695 
Fixes #10605

By avoiding `pointer_add` in favor of a helper that uses gep and keeps pointer provenance. Is there any downside to this approach? I asked the bot to check all other users of pointer_add, and they could use the "in-object" variant (I haven't changed any of them):

```
┌────────────────────────────────────┬──────────────┬───────────────────────────────────┬─────────────────────────────────────────────────────────────────────┐
│                Site                │     ptr      │              offset               │                           within-object?                            │
├────────────────────────────────────┼──────────────┼───────────────────────────────────┼─────────────────────────────────────────────────────────────────────┤
│ cgutils.py:793 get_item_pointer2   │ array data   │ strides·idx                       │ ✅ fixed (the bug)                                                  │
├────────────────────────────────────┼──────────────┼───────────────────────────────────┼─────────────────────────────────────────────────────────────────────┤
│ cpu.py:169 get_env_body            │ Environment* │ offsetof_env_body                 │ ✅                                                                  │
├────────────────────────────────────┼──────────────┼───────────────────────────────────┼─────────────────────────────────────────────────────────────────────┤
│ cpu.py:191 get_generator_state     │ Generator*   │ offsetof_generator_state          │ ✅                                                                  │
├────────────────────────────────────┼──────────────┼───────────────────────────────────┼─────────────────────────────────────────────────────────────────────┤
│ wrappers.py:272 load_direct        │ array data   │ byteoffset                        │ ✅ (sibling load_aligned already uses gep "to help LLVM vectorize") │
├────────────────────────────────────┼──────────────┼───────────────────────────────────┼─────────────────────────────────────────────────────────────────────┤
│ wrappers.py:282 store_direct       │ array data   │ byteoffset                        │ ✅ (same — sibling uses gep)                                        │
├────────────────────────────────────┼──────────────┼───────────────────────────────────┼─────────────────────────────────────────────────────────────────────┤
│ wrappers.py:706 gufunc load        │ core data    │ core_step·ind                     │ ✅                                                                  │
├────────────────────────────────────┼──────────────┼───────────────────────────────────┼─────────────────────────────────────────────────────────────────────┤
│ boxing.py:227 set_member           │ Box*         │ member offset                     │ ✅                                                                  │
├────────────────────────────────────┼──────────────┼───────────────────────────────────┼─────────────────────────────────────────────────────────────────────┤
│ boxing.py:242 access_member        │ instance*    │ member offset                     │ ✅                                                                  │
├────────────────────────────────────┼──────────────┼───────────────────────────────────┼─────────────────────────────────────────────────────────────────────┤
│ arrayobj.py:388 getitem single-int │ array data   │ stride·idx                        │ ✅                                                                  │
├────────────────────────────────────┼──────────────┼───────────────────────────────────┼─────────────────────────────────────────────────────────────────────┤
│ arrayobj.py:3482 record field      │ array data   │ field offset                      │ ✅ (uses return_type=)                                              │
├────────────────────────────────────┼──────────────┼───────────────────────────────────┼─────────────────────────────────────────────────────────────────────┤
│ arrayobj.py:4315 nditer increment  │ array ptr    │ stride (in an if in_bounds block) │ ✅                                                                  │
├────────────────────────────────────┼──────────────┼───────────────────────────────────┼─────────────────────────────────────────────────────────────────────┤
│ arrayobj.py:6286 concatenate bump  │ result data  │ offset                            │ ✅                                                                  │
└────────────────────────────────────┴──────────────┴───────────────────────────────────┴─────────────────────────────────────────────────────────────────────┘
```

The helper could obviously be inlined if we don't want to reuse it.

Also unclear about tests. The repro in #10695 seems too complicated and the one in #10605 would stop being a real repro after the changes in #10625 which sidestep this path.

Apologies if this PR was opened too hastily (original issue was not yet triaged)