### PR TITLE
Fix cross-target loss of @intrinsic lowering

### DIFF
--- a/docs/upcoming_changes/10699.bug_fix.rst
+++ b/docs/upcoming_changes/10699.bug_fix.rst
@@ -1,0 +1,9 @@
+Fix loss of ``@intrinsic`` lowering across compilation targets
+--------------------------------------------------------------
+
+An intrinsic typed on a second target (for example CUDA after the CPU)
+replaced the shared implementation cache entry with a closure whose lowering
+was registered only on that target, so a later compilation on the first
+target failed with ``NotImplementedError: No definition for lowering``. The
+implementation cache is now keyed by the typing context as well as the
+argument types.

--- a/numba/core/typing/templates.py
+++ b/numba/core/typing/templates.py
@@ -978,7 +978,7 @@ class _IntrinsicTemplate(_TemplateTargetHelperMixin, AbstractTemplate):
         parameters = list(pysig.parameters.values())[1:]
         sig = sig.replace(pysig=pysig.replace(parameters=parameters))
         self._impl_cache[cache_key] = sig
-        self._overload_cache[sig.args] = imp
+        self._overload_cache[(self.context, sig.args)] = imp
         # register the lowering
         lower_builtin(imp, *sig.args)(imp)
         return sig
@@ -988,7 +988,7 @@ class _IntrinsicTemplate(_TemplateTargetHelperMixin, AbstractTemplate):
         Return the key for looking up the implementation for the given
         signature on the target context.
         """
-        return self._overload_cache[sig.args]
+        return self._overload_cache[(self.context, sig.args)]
 
     def get_template_info(self):
         basepath = os.path.dirname(os.path.dirname(numba.__file__))

--- a/numba/tests/test_target_extension.py
+++ b/numba/tests/test_target_extension.py
@@ -641,6 +641,47 @@ class TestTargetHierarchySelection(TestCase):
         for msg in msgs:
             self.assertIn(msg, str(raises.exception))
 
+    def test_intrinsic_generic_shared_across_targets(self):
+        """
+        Checks that a 'generic' intrinsic typed on more than one target
+        keeps its lowering on each of them. See issue #10688.
+        """
+
+        # NOTE: The actual operation performed by the intrinsic is
+        # irrelevant, the test is about the compilation sequence.
+        @intrinsic
+        def intrin_identity(tyctx, x):
+            sig = x(x)
+
+            def codegen(cgctx, builder, tyargs, llargs):
+                return llargs[0]
+
+            return sig, codegen
+
+        # Compile on the CPU: types the intrinsic in the CPU typing context
+        # and registers its lowering on the CPU target.
+        @njit
+        def cpu_first(x):
+            return intrin_identity(x)
+
+        self.assertPreciseEqual(cpu_first(3.14), 3.14)
+
+        # Compile on the DPU: types the intrinsic again, in the DPU typing
+        # context. This must not clobber the CPU target's implementation.
+        @djit(nopython=True)
+        def dpu_func(x):
+            return intrin_identity(x)
+
+        self.assertPreciseEqual(dpu_func(3.14), 3.14)
+
+        # A fresh CPU compile hits the per-context typing cache; lowering
+        # must still resolve to the impl registered on the CPU target.
+        @njit
+        def cpu_second(x):
+            return intrin_identity(x)
+
+        self.assertPreciseEqual(cpu_second(3.14), 3.14)
+
     def test_overload_allocation(self):
         def cast_integer(context, builder, val, fromty, toty):
             # XXX Shouldn't require this.


### PR DESCRIPTION
Fixes #10688

`_IntrinsicTemplate` cached the impl of an `@intrinsic` in `_overload_cache`, keyed by argument types alone and shared across all targets, while the lowering registration goes only into the active target's registry. Compiling the same intrinsic on a second target re-ran the definition (the signature cache is per typing context), created a new impl closure, and overwrote the shared entry. The next compile on the first target hit its typing cache, so nothing was re-registered, and lowering resolved to the second target's closure: `NotImplementedError: No definition for lowering`.

This is how 0.66.0 broke `int()` inside numba's `np.linalg` impls for CPU compiles that follow a CUDA compile (diagnosis in #10688; the int constructor moved onto this machinery in #10544).

Changes:

- key `_overload_cache` by `(typing context, argument types)` in `generic()` and `get_impl_key()`
- add a regression test replaying the sequence with the DPU example target, so it runs without a GPU

Verified locally: the new test fails on main and passes with the fix; the standalone CUDA reproducer from #10688 passes on an RTX 4080; `test_target_extension`, `test_extending`, and `numba.cuda.tests.cudapy.test_intrinsics` pass. A towncrier fragment named with this PR's number follows as a second commit.
