### PR TITLE
`misc.special` type stubs

### DIFF
--- a/maint/stubtest/allowlist.txt
+++ b/maint/stubtest/allowlist.txt
@@ -24,7 +24,16 @@ numba\.core\.utils\..*
 numba\.cpython\..*
 numba\.cuda\..*
 numba\.experimental\..*
-numba\.misc\..*
+numba\.misc\.POST
+numba\.misc\.appdirs\..*
+numba\.misc\.coverage_support\..*
+numba\.misc\.dump_style.*
+numba\.misc\.gdb_print_extension
+numba\.misc\.help\..*
+numba\.misc\.numba_entry
+numba\.misc\.numba_gdbinfo
+numba\.misc\.numba_sysinfo
+numba\.misc\.timsort
 numba\.mviewbuf
 numba\.np\.(arraymath|arrayobj|linalg|npyimpl|random|types|ufunc_db|unsafe)\..*
 numba\.np\.extensions

--- a/numba/misc/special.pyi
+++ b/numba/misc/special.pyi
@@ -1,0 +1,34 @@
+from builtins import range as prange
+from typing import TypeVar
+
+from _typeshed import Incomplete
+from numpy import ndindex as pndindex
+
+from numba.core.typing.asnumbatype import as_numba_type
+from numba.core.typing.typeof import typeof
+
+__all__ = [
+    "typeof",
+    "as_numba_type",
+    "prange",
+    "pndindex",
+    "gdb",
+    "gdb_breakpoint",
+    "gdb_init",
+    "literally",
+    "literal_unroll",
+]
+
+###
+
+_T = TypeVar("_T")
+
+###
+
+def gdb(*args: Incomplete) -> None: ...
+def gdb_breakpoint() -> None: ...
+def gdb_init(*args: Incomplete) -> None: ...
+
+#
+def literally(obj: _T) -> _T: ...
+def literal_unroll(container: _T) -> _T: ...


### PR DESCRIPTION
This adds type stubs for `numba.misc.special`, which includes `numba.prange` and therefore fixes #10680. 
I've updated the stubtest allowlist so that stubtest accordingly.

Note that #10651 also adds stubs for `misc.special`, but it did not update the stubtest allowlist, and the stubs are therefore not verified by stubtest (if it would, stubtest would report several errors). The custom stubs for `prange` and `pndindex` it adds are also unnecessary, and results in lower-quality type hints, because those stubs aren't as precise as the originals that I've re-exported here.