### PR TITLE
Dynamic raise collapse

### DIFF
--- a/docs/upcoming_changes/10702.bug_fix.rst
+++ b/docs/upcoming_changes/10702.bug_fix.rst
@@ -1,0 +1,5 @@
+Fix Dynamic Raise Exception Message Handling
+--------------------------------------------
+
+Raising a dynamic exception with a literal message stored in a variable could cause the compiled code to display a different literal value.
+Numba now handles dynamic exception message variables self-consistently, and prevents message collisions between variables with the same underlying storage representation.

--- a/numba/core/callconv.py
+++ b/numba/core/callconv.py
@@ -557,7 +557,7 @@ class CPUCallConv(BaseCallConv):
         #                          ^ Number of dynamic arguments = 2
         #
 
-        _hash = hashlib.sha1(str(st_type).encode()).hexdigest()
+        _hash = hashlib.sha1(str((st_type, nb_types)).encode()).hexdigest()
         name = f'__excinfo_unwrap_args{_hash}'
         if name in module.globals:
             return module.globals.get(name)

--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -304,6 +304,8 @@ def visit_vars_stmt(stmt, callback, cbdata):
         stmt.value = visit_vars_inner(stmt.value, callback, cbdata)
     elif isinstance(stmt, ir.Raise):
         stmt.exception = visit_vars_inner(stmt.exception, callback, cbdata)
+    elif isinstance(stmt, (ir.DynamicRaise, ir.DynamicTryRaise)):
+        stmt.exc_args = visit_vars_inner(stmt.exc_args, callback, cbdata)
     elif isinstance(stmt, ir.Branch):
         stmt.cond = visit_vars_inner(stmt.cond, callback, cbdata)
     elif isinstance(stmt, ir.Jump):

--- a/numba/tests/test_exceptions.py
+++ b/numba/tests/test_exceptions.py
@@ -434,6 +434,36 @@ class TestRaising(TestCase):
                     raise_literal_message(i)
                 self.assertEqual(str(raises.exception), f"A was {i}")
 
+    def test_dynamic_raise_single_literal_message(self):
+        @njit
+        def raise_single_literal_message(arg):
+            msg = "False"
+            if arg:
+                msg = "True"
+            raise ValueError(msg)
+
+        for arg in (False, True):
+            with self.subTest(arg=arg):
+                with self.assertRaises(ValueError) as raises:
+                    raise_single_literal_message(arg)
+                self.assertEqual(str(raises.exception), str(arg))
+
+    def test_dynamic_raise_mixed_int_width(self):
+        @njit
+        def raise_mixed_int_width(a):
+            if a == 0:
+                value = np.int64(-7)
+                raise ValueError(value)
+            value = np.uint64(2 ** 63)
+            raise ValueError(value)
+
+        cases = [(0, "-7"), (1, str(2 ** 63))]
+        for arg, expected in cases:
+            with self.subTest(arg=arg):
+                with self.assertRaises(ValueError) as raises:
+                    raise_mixed_int_width(arg)
+                self.assertEqual(str(raises.exception), expected)
+
     def test_disable_nrt(self):
         @njit(_nrt=False)
         def raise_with_no_nrt(i):

--- a/numba/tests/test_exceptions.py
+++ b/numba/tests/test_exceptions.py
@@ -415,6 +415,25 @@ class TestRaising(TestCase):
         with self.assertRaisesRegex(ValueError, msg):
             raise_literal_dict2()
 
+    def test_dynamic_raise_literal_message(self):
+        @njit
+        def raise_literal_message(a):
+            if a == 0:
+                msg = "A was 0"
+                raise ValueError(msg)
+            if a == 1:
+                msg = "A was 1"
+                raise ValueError(msg)
+            if a == 2:
+                msg = "A was 2"
+                raise ValueError(msg)
+
+        for i in range(3):
+            with self.subTest(i=i):
+                with self.assertRaises(ValueError) as raises:
+                    raise_literal_message(i)
+                self.assertEqual(str(raises.exception), f"A was {i}")
+
     def test_disable_nrt(self):
         @njit(_nrt=False)
         def raise_with_no_nrt(i):


### PR DESCRIPTION
Closes #10693. The issue appears to be two separate bugs, which both must be separately fixed for the original reproducer to pass:
1. `RewriteDynamicRaises` runs before SSA, but SSA `visit_vars_stmt` did not have a case that would allow a `ir.DynamicRaise` instance to visit `exc_args`, so `msg` did not get renamed everywhere it needed to be. 
***Fix:*** Visit `exc_args` for `ir.DynamicRaise`
***Regression Test:*** `test_dynamic_raise_single_literal_message` should isolate this fix, because it only has one raise statement, but still requires the dynamic raise argument to be SSA-renamed.
2. `emit_unwrap_dynamic_exception_fn` keyed unwrap helpers solely based on the hash of `st_type`, such that every string literal with the same native storage type got the same hash value.  Also affects non-string literal cases with the same LLVM storage type, such as signed and unsigned ints
***Fix:*** include `nb_types` in the hash.
***Regression Test:*** `test_dynamic_raise_mixed_int_width`: should isolate this fix, verifies that `np.int64` and `np.uint64` exception messages (which both have `st_type` of `{i64}`) no longer collide.

With both fixes, the original reproducer also passes, and is codified as `test_dynamic_raise_literal_message`

