### PR TITLE
Fix #6270. Fix `is_serializable()`

### DIFF
--- a/numba/core/serialize.py
+++ b/numba/core/serialize.py
@@ -152,7 +152,7 @@ def custom_rebuild(custom_pickled):
     return cls._rebuild(**states)
 
 
-def is_serialiable(obj):
+def is_serialiable(obj) -> bool:
     """Check if *obj* can be serialized.
 
     Parameters
@@ -164,10 +164,12 @@ def is_serialiable(obj):
     can_serialize : bool
     """
     with io.BytesIO() as fout:
-        pickler = NumbaPickler(fout)
+        dump = NumbaPickler(fout).dump
         try:
-            pickler.dump(obj)
-        except pickle.PicklingError:
+            dump(obj)
+        except Exception:
+            # Dill simply catches everything in safe mode
+            # https://github.com/uqfoundation/dill/blob/aa4409a06b908cb018936ba160de5a75b418c03f/dill/_dill.py#L2168-L2180
             return False
         else:
             return True

--- a/numba/tests/test_serialize.py
+++ b/numba/tests/test_serialize.py
@@ -1,4 +1,5 @@
 import contextlib
+
 import gc
 import pickle
 import runpy
@@ -6,12 +7,14 @@ import subprocess
 import sys
 import unittest
 from multiprocessing import get_context
+import threading
 
 import numba
 from numba.core.errors import TypingError
 from numba.tests.support import TestCase
 from numba.core.target_extension import resolve_dispatcher_from_str
 from numba.cloudpickle import dumps, loads
+from numba.core.serialize import is_serialiable
 
 
 class TestDispatcherPickling(TestCase):
@@ -214,6 +217,47 @@ class TestSerializationMisc(TestCase):
         got2 = _numba_unpickle(id(random_obj), bytebuf, hashed)
         # unpickled results are the same objects
         self.assertIs(got1, got2)
+
+    def test_is_serializable(self):
+        # Regular objects should work
+        self.assertTrue(is_serialiable({'key': 'value'}))
+        self.assertTrue(is_serialiable([1, 2, 3]))
+        self.assertTrue(is_serialiable("string"))
+
+    def test_is_serializable_unpicklable_threading_lock(self):
+        """
+        Test that is_serialiable correctly handles unpicklable objects
+        like thread locks that raise TypeError (issue #6270)
+        """
+        # Thread locks cannot be pickled and raise TypeError
+        lock = threading.Lock()
+
+        # Test our assumption
+        with self.assertRaises(TypeError) as raises:
+            pickle.dumps(lock)
+        self.assertIn("cannot pickle", str(raises.exception))
+
+        # Test is_serializable()
+        self.assertFalse(is_serialiable(lock))
+
+    def test_is_serializable_custom_unpicklable(self):
+        """
+        Test that is_serialiable handles objects that raise TypeError
+        in their __reduce__ or __getstate__ methods
+        """
+        # Object that raises TypeError in __reduce__
+        class RejectReduce:
+            def __reduce__(self):
+                raise TypeError('Cannot pickle this object')
+
+        # Object that raises TypeError in __getstate__
+        class RejectGetstate:
+            def __getstate__(self):
+                raise TypeError('Cannot serialize state')
+
+        # Both should be detected as unpicklable
+        self.assertFalse(is_serialiable(RejectReduce()))
+        self.assertFalse(is_serialiable(RejectGetstate()))
 
 
 class TestCloudPickleIssues(TestCase):


### PR DESCRIPTION
Catch all exceptions in `is_serializable` so that the function always return bool.

Closes: https://github.com/numba/numba/issues/6270