### PR TITLE
Bump `mypy` to `>=2.3, <2.4`

### DIFF
--- a/maint/stubtest/allowlist.txt
+++ b/maint/stubtest/allowlist.txt
@@ -20,13 +20,14 @@ numba\.core\.tracing\..*
 numba\.core\.typeconv\..*
 numba\.core\.typing\..*
 numba\.core\.unsafe\..*
+numba\.core\.untyped_passes\..*
 numba\.core\.utils\..*
 numba\.cpython\..*
 numba\.cuda\..*
 numba\.experimental\..*
 numba\.misc\..*
 numba\.mviewbuf
-numba\.np\.(arraymath|arrayobj|linalg|npyimpl|random|types|ufunc_db|unsafe)\..*
+numba\.np\.(arraymath|arrayobj|linalg|npyimpl|numpy_support|random|types|ufunc_db|unsafe)\..*
 numba\.np\.extensions
 numba\.np\.polynomial\.polynomial_core\.type_polynomial
 numba\.np\.ufunc\.parallel\..*

--- a/maint/stubtest/requirements_stubtest.txt
+++ b/maint/stubtest/requirements_stubtest.txt
@@ -1,4 +1,4 @@
-mypy >=2, <2.2
+mypy >=2.3, <2.4
 scipy-stubs
 types-cffi
 types-psutil


### PR DESCRIPTION
Apparently there's a regression in mypy 2.2 that causes `stubtest` to report false positive errors for inline `namedtuple` declaration in source files without stubs. The workaround is simple: adding those modules to the allowlist (stubtest blacklist). This is not problem because these modules have no stubs anyway.

Supplants #10692