### PR TITLE
Fix #10705: Guard against unrelated 'coverage' modules on sys.path

### DIFF
--- a/numba/misc/coverage_support.py
+++ b/numba/misc/coverage_support.py
@@ -15,6 +15,8 @@ from numba.core import ir, config
 
 try:
     import coverage
+    if not (hasattr(coverage, 'types') and hasattr(coverage, 'Coverage')):
+        raise ImportError
 except ImportError:
     coverage_available = False
 else:

--- a/numba/tests/test_misc_coverage_support.py
+++ b/numba/tests/test_misc_coverage_support.py
@@ -93,5 +93,33 @@ class TestNumbaTracerToolId(TestCase):
         NotifyCompilerCoverage(collector)
 
 
+class TestCoverageAvailableFakeModule(TestCase):
+    def test_fake_coverage_module_not_detected(self):
+        """Regression test for https://github.com/numba/numba/issues/10705.
+        An unrelated module named 'coverage' on sys.path (e.g. a directory
+        named 'coverage' in cwd) should not set coverage_available = True.
+        """
+        import importlib
+        import types
+        import sys
+        import numba.misc.coverage_support as cs
+
+        # Create a fake coverage module without the expected attributes
+        fake_coverage = types.ModuleType("coverage")
+
+        saved = sys.modules.get("coverage")
+        sys.modules["coverage"] = fake_coverage
+        try:
+            importlib.reload(cs)
+            self.assertFalse(cs.coverage_available)
+        finally:
+            # Restore original state
+            if saved is not None:
+                sys.modules["coverage"] = saved
+            else:
+                sys.modules.pop("coverage", None)
+            importlib.reload(cs)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fix `AttributeError: module 'coverage' has no attribute 'types'` when an unrelated module named `coverage` exists on `sys.path` (e.g. a directory named `coverage/` in the current working directory).

## Root Cause

In `numba/misc/coverage_support.py`, the import guard only caught `ImportError`:

```python
try:
    import coverage
except ImportError:
    coverage_available = False
else:
    coverage_available = True
```

If `sys.path` contains a directory or unrelated module named `coverage`, `import coverage` succeeds without raising `ImportError`, setting `coverage_available = True`. The code then attempts to use `coverage.types.Tracer` (line 114), which fails with an `AttributeError` because the imposter module lacks the expected attributes.

## Solution

After importing `coverage`, validate that the module has the attributes Numba actually uses (`coverage.types` and `coverage.Coverage`). If either is missing, treat it as unavailable:

```python
try:
    import coverage
    if not (hasattr(coverage, 'types') and hasattr(coverage, 'Coverage')):
        raise ImportError
except ImportError:
    coverage_available = False
else:
    coverage_available = True
```

This is the smallest correct fix — two `hasattr` checks that exactly match the attributes consumed downstream.

## Testing

Added `TestCoverageAvailableFakeModule.test_fake_coverage_module_not_detected` which:
1. Injects a fake `coverage` module (a bare `types.ModuleType` with no attributes) into `sys.modules`
2. Reloads `coverage_support`
3. Asserts `coverage_available` is `False`
4. Restores original state in `finally`

## Checklist

- [x] Minimal fix — 2 lines added to source
- [x] Regression test added
- [x] No API or public behavior changes
- [x] Follows existing code style
- [x] Does not break existing `coverage` integration (the real `coverage` package has both attributes)