### PR TITLE
Fix incorrect handling of jitclass kwonly arguments

### DIFF
--- a/numba/core/typing/templates.py
+++ b/numba/core/typing/templates.py
@@ -200,7 +200,7 @@ def fold_arguments(pysig, args, kws, normal_handler, default_handler,
         # Normalize dict kws
         kws = dict(kws)
 
-    # deal with kwonly args
+    # deal with kwonly args that might appear as the last positional arguments
     params = pysig.parameters
     kwonly = []
     for name, p in params.items():
@@ -214,7 +214,7 @@ def fold_arguments(pysig, args, kws, normal_handler, default_handler,
     bind_kws = kws.copy()
     if kwonly:
         for idx, n in enumerate(kwonly):
-            bind_kws[n] = args[len(kwonly) + idx]
+            bind_kws[n] = args[-len(kwonly) + idx]
 
     # now bind
     try:

--- a/numba/tests/test_jitclasses.py
+++ b/numba/tests/test_jitclasses.py
@@ -718,7 +718,7 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         spec = [("x", int32),
                 ("y", int32),
                 ("z", int32),
-                ("a", int32)]
+                ("a", float32)]
 
         TestClass = jitclass(TestClass1, spec)
 
@@ -734,11 +734,11 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         self.assertEqual(tc.z, 100)
         self.assertEqual(tc.a, 42)
 
-        tc = TestClass(y=4, x=2, a=42)
+        tc = TestClass(y=4, x=2, a=3.14)
         self.assertEqual(tc.x, 2)
         self.assertEqual(tc.y, 4)
         self.assertEqual(tc.z, 1)
-        self.assertEqual(tc.a, 42)
+        self.assertAlmostEqual(tc.a, 3.14, places=6)
 
         tc = TestClass(y=4, x=2)
         self.assertEqual(tc.x, 2)


### PR DESCRIPTION
0fb1aefad6f introduced (partial) support for kwonly args in jitclass.

templates.py fold_arguments will get the function profile with separate args and kws. But confusingly, keyword arguments will appear as (the last) positional arguments (if "possible"). fold_arguments will fix that up. It would correctly remove the kwonly arguments from the list of positional arguments. But when adding them to the kws dict, it got the indexing wrong, as if the kwonly arguments came first but had to be skipped.

fold_arguments would thus fail with IndexError for methods with more kwonly args than positional args. It would also generally incorrectly "coerce" arguments to the type of the wrong argument.

The fix is trivial: Index from the end, both for the args fixup and for the kws fixup.

test_default_args_keyonly did not expose the problem because it had enough non-kwonly arguments to avoid IndexError, and all arguments had the same type so it didn't matter that the wrong argument was used. Changing the kwonly argument to float would have triggered the problem ... but now it works.

--

Just a drive-by contribution. Feel free to hijack and edit the commit.