### PR TITLE
`jitclass` type stubs

### DIFF
--- a/maint/stubtest/allowlist.txt
+++ b/maint/stubtest/allowlist.txt
@@ -23,7 +23,7 @@ numba\.core\.untyped_passes\..*
 numba\.core\.utils\..*
 numba\.cpython\..*
 numba\.cuda\..*
-numba\.experimental\..*
+numba\.experimental\.structref
 numba\.misc\..*
 numba\.mviewbuf
 numba\.np\.(arraymath|arrayobj|linalg|npyimpl|numpy_support|random|types|ufunc_db|unsafe)\..*

--- a/maint/stubtest/allowlist.txt
+++ b/maint/stubtest/allowlist.txt
@@ -23,7 +23,7 @@ numba\.core\.untyped_passes\..*
 numba\.core\.utils\..*
 numba\.cpython\..*
 numba\.cuda\..*
-numba\.experimental\..*
+numba\.experimental\.structref
 numba\.misc\.POST
 numba\.misc\.appdirs\..*
 numba\.misc\.coverage_support\..*

--- a/numba/experimental/jitclass/decorators.pyi
+++ b/numba/experimental/jitclass/decorators.pyi
@@ -1,0 +1,25 @@
+from collections.abc import Mapping, Sequence
+from typing import Protocol, TypeAlias, overload, type_check_only
+
+from typing_extensions import TypeVar
+
+from numba.core import types
+
+###
+
+_ToSpec: TypeAlias = Mapping[str, types.Type] | Sequence[tuple[str, types.Type]]
+
+_ClsT = TypeVar("_ClsT", bound=type)
+
+@type_check_only
+class _Wrap(Protocol):
+    def __call__(self, cls: _ClsT) -> _ClsT: ...
+
+###
+
+@overload
+def jitclass(cls_or_spec: None = None, spec: _ToSpec | None = None) -> _Wrap: ...
+@overload
+def jitclass(cls_or_spec: _ToSpec, spec: None = None) -> _Wrap: ...
+@overload
+def jitclass(cls_or_spec: _ClsT, spec: _ToSpec | None = None) -> _ClsT: ...


### PR DESCRIPTION
This was more straightforward that I originally thought it would be, because `@jitclass` either returns the decorated class as-is, or it returns an identity function constrained to `type`.  This means that the overloads are fully disjoint (i.e. non-overlapping), so it's all nice and deterministic.

I wrote everything by hand, and had Claude Fable 5 review it for correctness and completeness.