### PR TITLE
add win-arm64 workflows to upload config

### DIFF
--- a/buildscripts/github/workflow_groups.json
+++ b/buildscripts/github/workflow_groups.json
@@ -4,13 +4,15 @@
       "numba_linux-64_conda_builder.yml",
       "numba_linux-aarch64_conda_builder.yml",
       "numba_osx-arm64_conda_builder.yml",
-      "numba_win-64_conda_builder.yml"
+      "numba_win-64_conda_builder.yml",
+      "numba_win-arm64_conda_builder.yml"
     ],
     "wheel": [
       "numba_linux-64_wheel_builder.yml",
       "numba_linux-aarch64_wheel_builder.yml",
       "numba_osx-arm64_wheel_builder.yml",
-      "numba_win-64_wheel_builder.yml"
+      "numba_win-64_wheel_builder.yml",
+      "numba_win-arm64_wheel_builder.yml"
     ]
   }
 }


### PR DESCRIPTION
This PR adds `win-arm64` workflows to be discovered by upload workflow by adding them to config json. This will allow discovery and upload of `win-arm64` artifacts to anaconda.org and PyPI.