### PR TITLE
`np.ufunc` type stubs (threading functions and `PyUFunc_*`)

### DIFF
--- a/numba/np/ufunc/__init__.pyi
+++ b/numba/np/ufunc/__init__.pyi
@@ -1,0 +1,24 @@
+from typing import Any, Final, Literal
+
+import numpy as np
+
+# `array_exprs` is `del`ed at runtime but required by stubtest
+from numba.np.ufunc import array_exprs  # noqa: F401
+from numba.np.ufunc.decorators import GUVectorize as GUVectorize
+from numba.np.ufunc.decorators import Vectorize as Vectorize
+from numba.np.ufunc.decorators import guvectorize as guvectorize
+from numba.np.ufunc.decorators import vectorize as vectorize
+
+# originally defined in `numba.np.ufunc._internal`
+PyUFunc_Zero: Final = 0
+PyUFunc_One: Final = 1
+PyUFunc_None: Final = -1
+PyUFunc_ReorderableNone: Final = -2
+
+# originally defined in `numba.np.ufunc.parallel`
+def threading_layer() -> Literal["tbb", "omp", "workqueue"]: ...
+def set_num_threads(n: int | np.integer[Any]) -> None: ...
+def get_num_threads() -> int: ...
+def get_thread_id() -> int: ...
+def set_parallel_chunksize(n: int | np.integer[Any]) -> int: ...
+def get_parallel_chunksize() -> int: ...


### PR DESCRIPTION
A quick code search showed that these threading functions (documented in https://numba.readthedocs.io/en/stable/user/threading-layer.html) are used quite a lot, so I figured it'd help to stub them.

These threading functions actually live in `numba.np.ufunc.parallel`. But that module also contains a bunch of publically-named undocumented functions and classes. If I would've stubbed that module directly, then stubtest would've required me to stub *everything* there, which seemed like a waste of time. 
These functions are re-exported in `__init__.py `, so it's a lot easier to place the stubs in this `__init__.pyi`. However, because this `__init__.py` also re-exports some constants from the C-extension module `numba.np.ufunc._internal`, I also had to stub these constants. 

Anway, the stubs themselves are all very straightforward stuff.

Note that the vectorize/guvectorize re-exports here are not yet typed, see https://github.com/numba/numba/pull/10715. It's fine to merge this before, though.