### PR TITLE
DOC: Correct jit nopython default

### DIFF
--- a/docs/source/reference/jit-compilation.rst
+++ b/docs/source/reference/jit-compilation.rst
@@ -50,9 +50,10 @@ JIT functions
      exists, a new specialization is compiled on-the-fly, stored for later
      use, and executed with the converted arguments.
 
-   *nopython* defaults to true and compiles the function in :term:`nopython
-   mode`. If compilation in this mode is not possible, an error is raised.
-   Set *forceobj* to true to compile in :term:`object mode` instead.
+   *nopython* defaults to true and compiles the function in :term:`nopython mode`.
+   If compilation in this mode is not possible, an error is raised. Supplying
+   ``nopython=False`` is deprecated and has no effect; set *forceobj* to true to
+   compile in :term:`object mode` instead.
 
    If true, *forceobj* forces the function to be compiled in :term:`object
    mode`.  Since object mode is slower than nopython mode, this is mostly

--- a/docs/source/reference/jit-compilation.rst
+++ b/docs/source/reference/jit-compilation.rst
@@ -7,7 +7,7 @@ JIT functions
 -------------
 
 
-.. decorator:: numba.jit(signature_or_function=None, nopython=False, nogil=False, cache=False, forceobj=False, parallel=False, error_model='python', fastmath=False, locals={}, boundscheck=False, inline="never", forceinline=False)
+.. decorator:: numba.jit(signature_or_function=None, nopython=True, nogil=False, cache=False, forceobj=False, parallel=False, error_model='python', fastmath=False, locals={}, boundscheck=False, inline="never", forceinline=False)
 
    Compile the decorated function on-the-fly to produce efficient machine
    code.  All parameters are optional.
@@ -50,8 +50,9 @@ JIT functions
      exists, a new specialization is compiled on-the-fly, stored for later
      use, and executed with the converted arguments.
 
-   If true, *nopython* forces the function to be compiled in :term:`nopython
-   mode`. If not possible, compilation will raise an error.
+   *nopython* defaults to true and compiles the function in :term:`nopython
+   mode`. If compilation in this mode is not possible, an error is raised.
+   Set *forceobj* to true to compile in :term:`object mode` instead.
 
    If true, *forceobj* forces the function to be compiled in :term:`object
    mode`.  Since object mode is slower than nopython mode, this is mostly

--- a/docs/upcoming_changes/10743.doc.rst
+++ b/docs/upcoming_changes/10743.doc.rst
@@ -1,0 +1,5 @@
+Correct the documented ``jit`` nopython default
+-----------------------------------------------
+
+The reference documentation now shows that ``nopython=True`` is the default
+for :func:`numba.jit` and clarifies how to explicitly select object mode.


### PR DESCRIPTION
## Summary

- Correct the documented `numba.jit` signature to show that `nopython=True` is the default.
- Clarify that failed nopython compilation raises an error and that object mode requires `forceobj=True`.

Closes #10738.

## Validation

- Searched the reference documentation for other `nopython=False` defaults; the remaining occurrence is the valid `numba.cfunc` signature.
- `git diff --check`

The full Sphinx documentation build was not run locally because the documentation dependencies are not installed in this environment.
