### PR TITLE
docs: add CUDA driver cache FAQ

### DIFF
--- a/docs/source/user/faq.rst
+++ b/docs/source/user/faq.rst
@@ -286,7 +286,8 @@ How do I clear the CUDA driver JIT cache?
 
 The NVIDIA CUDA driver may cache JIT-compiled PTX under ``~/.nv/`` on Linux.
 This cache is separate from the cache created by Numba CPU compilation. If a
-CUDA linker error persists after changing a kernel or updating the CUDA toolchain,
+CUDA linker error persists after changing a kernel or updating the CUDA
+toolchain,
 removing the contents of ``~/.nv/ComputeCache`` allows the driver to rebuild the
 cache the next time the kernel is compiled.
 

--- a/docs/source/user/faq.rst
+++ b/docs/source/user/faq.rst
@@ -281,6 +281,15 @@ A more radical alternative is :ref:`ahead-of-time compilation <pycc>`.
 GPU Programming
 ===============
 
+How do I clear the CUDA driver JIT cache?
+----------------------------------------------
+
+The NVIDIA CUDA driver may cache JIT-compiled PTX under ``~/.nv/`` on Linux.
+This cache is separate from the cache created by Numba CPU compilation. If a
+CUDA linker error persists after changing a kernel or updating the CUDA toolchain,
+removing the contents of ``~/.nv/ComputeCache`` allows the driver to rebuild the
+cache the next time the kernel is compiled.
+
 How do I work around the ``CUDA initialized before forking`` error?
 -------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #3458.

Add a FAQ entry explaining the CUDA driver JIT cache, how it differs from Numba CPU caching, and when clearing `~/.nv/ComputeCache` can help.