### PR TITLE
typing: allow nopython for cfunc

### DIFF
--- a/numba/core/decorators.pyi
+++ b/numba/core/decorators.pyi
@@ -36,6 +36,7 @@ _FunctionT = TypeVar("_FunctionT", bound=Callable[..., object])
 
 @type_check_only
 class _JITOptions(TypedDict, total=False):
+    nopython: bool
     looplift: bool
     nogil: bool
     parallel: bool


### PR DESCRIPTION
Fixes #10679

The runtime `cfunc` decorator accepts the `nopython` option, but the type stub only exposed it for `jit`. Add it to the shared options TypedDict so mypy and other type checkers accept documented `@cfunc(..., nopython=True)` usage.