### PR TITLE
`numba.core.types` stubs missing re-exports

### DIFF
--- a/numba/core/types/__init__.pyi
+++ b/numba/core/types/__init__.pyi
@@ -10,28 +10,29 @@ from typing import Any as Any_py
 
 import numpy as np
 
+from numba.np.types import NPDatetime as NPDatetime
+from numba.np.types import NPTimedelta as NPTimedelta
+
 from .abstract import *
-from .common import Opaque
+from .common import Opaque as Opaque
 from .containers import *
 from .function_type import *
 from .functions import *
 from .iterators import *
 from .misc import *
 from .npytypes import *
-from .scalars import (
-    Boolean,
-    BooleanLiteral as BooleanLiteral,
-    Complex,
-    EnumClass as EnumClass,
-    EnumMember as EnumMember,
-    Float,
-    IntEnumClass as IntEnumClass,
-    IntEnumMember as IntEnumMember,
-    Integer,
-    IntegerLiteral as IntegerLiteral,
-    parse_integer_bitwidth as parse_integer_bitwidth,
-    parse_integer_signed as parse_integer_signed,
-)
+from .scalars import Boolean as Boolean
+from .scalars import BooleanLiteral as BooleanLiteral
+from .scalars import Complex as Complex
+from .scalars import EnumClass as EnumClass
+from .scalars import EnumMember as EnumMember
+from .scalars import Float as Float
+from .scalars import Integer as Integer
+from .scalars import IntegerLiteral as IntegerLiteral
+from .scalars import IntEnumClass as IntEnumClass
+from .scalars import IntEnumMember as IntEnumMember
+from .scalars import parse_integer_bitwidth as parse_integer_bitwidth
+from .scalars import parse_integer_signed as parse_integer_signed
 
 __all__ = [
     "b1",


### PR DESCRIPTION
The stubs for `numba.core.types` were missing several re-exports, causing type-checkers to complain about non-existent names when doing e.g. `from numba.core.types import `Boolean`. Specifically, these ones were missing:

- `NPDatetime`
- `NPTimedelta`
- `Opaque`
- `Boolean`
- `Complex`
- `Float`
- `Integer`

The `from _ import {} as {}` ensures that type-checkers treat these as implicit re-exports, regardless the `__all__`. See the typing spec for details: https://typing.python.org/en/latest/spec/distributing.html#import-conventions.

And as I always do, I verified that this is now correct using AI (verification only; I never let it touch the code). I also checked using several other type-checkers besides Pyrefly that even the `*` imports are understood in general.

Related (non-blocking): https://github.com/numba/numba/pull/10731