### PR TITLE
CI: expand `win-arm64` py-version matrix to cover python 3.11-3.14

### DIFF
--- a/.github/workflows/numba_win-arm64_conda_builder.yml
+++ b/.github/workflows/numba_win-arm64_conda_builder.yml
@@ -21,15 +21,19 @@ concurrency:
 env:
   CONDA_CHANNEL_LLVMLITE: numba/label/dev
   WIN_ARM64_CONDA_CHANNEL: bootstrap-win-arm64-round-2-native
-  PYTHON_VERSION: "3.14"
   NUMPY_VERSION: "2.3"
 
 jobs:
   win-arm64-build-conda:
-    name: win-arm64-build-conda (py 3.14, np 2.3)
+    name: win-arm64-build-conda (py ${{ matrix.python_version }}, np 2.3)
     runs-on: windows-11-arm
+    strategy:
+      matrix:
+        python_version: ["3.11", "3.12", "3.13", "3.14"]
+      fail-fast: false
     env:
       EXTRA_CHANNELS: ''
+      PYTHON_VERSION: ${{ matrix.python_version }}
     defaults:
       run:
         shell: bash -elx {0}
@@ -105,11 +109,16 @@ jobs:
           if-no-files-found: error
 
   win-arm64-test:
-    name: win-arm64-test-conda (py 3.14, np 2.3)
+    name: win-arm64-test-conda (py ${{ matrix.python_version }}, np 2.3)
     needs: win-arm64-build-conda
     runs-on: windows-11-arm
+    strategy:
+      matrix:
+        python_version: ["3.11", "3.12", "3.13", "3.14"]
+      fail-fast: false
     env:
       EXTRA_CHANNELS: ''
+      PYTHON_VERSION: ${{ matrix.python_version }}
     defaults:
       run:
         shell: bash -elx {0}

--- a/.github/workflows/numba_win-arm64_wheel_builder.yml
+++ b/.github/workflows/numba_win-arm64_wheel_builder.yml
@@ -24,13 +24,18 @@ env:
   ARTIFACT_RETENTION_DAYS: 7
   WHEELS_INDEX_URL: https://pypi.anaconda.org/numba/label/dev/simple
   WIN_ARM64_CONDA_CHANNEL: bootstrap-win-arm64-round-2-native
-  PYTHON_VERSION: "3.14"
   NUMPY_VERSION: "2.3.5"
 
 jobs:
   win-arm64-build:
-    name: win-arm64-build-wheel (py 3.14, np 2.3.5)
+    name: win-arm64-build-wheel (py ${{ matrix.python_version }}, np 2.3.5)
     runs-on: windows-11-arm
+    strategy:
+      matrix:
+        python_version: ["3.11", "3.12", "3.13", "3.14"]
+      fail-fast: false
+    env:
+      PYTHON_VERSION: ${{ matrix.python_version }}
     defaults:
       run:
         shell: bash -el {0}
@@ -93,9 +98,15 @@ jobs:
           if-no-files-found: error
 
   win-arm64-test:
-    name: win-arm64-test-wheel (py 3.14, np 2.3.5)
+    name: win-arm64-test-wheel (py ${{ matrix.python_version }}, np 2.3.5)
     needs: win-arm64-build
     runs-on: windows-11-arm
+    strategy:
+      matrix:
+        python_version: ["3.11", "3.12", "3.13", "3.14"]
+      fail-fast: false
+    env:
+      PYTHON_VERSION: ${{ matrix.python_version }}
     defaults:
       run:
         shell: bash -el {0}

--- a/numba/_dispatcher.cpp
+++ b/numba/_dispatcher.cpp
@@ -35,7 +35,7 @@
 
 /* Python 3.12 pycore_atomic.h ARM64 MSVC path is invalid C++ (C2664).
  * Skip that header; stubs copy CPython's generic fallback:
- * https://github.com/python/cpython/blob/v3.12.10/Include/internal/pycore_atomic.h#L515-L552
+ * https://github.com/python/cpython/blob/v3.12.14/Include/internal/pycore_atomic.h#L515-L552
  * Broken ARM64 MSVC load (missing casts):
  * https://github.com/python/cpython/blob/v3.12.14/Include/internal/pycore_atomic.h#L437
  */

--- a/numba/_dispatcher.cpp
+++ b/numba/_dispatcher.cpp
@@ -32,6 +32,58 @@
 #ifndef Py_BUILD_CORE
     #define Py_BUILD_CORE 1
 #endif
+
+/* Python 3.12 pycore_atomic.h ARM64 MSVC path is invalid C++ (C2664).
+ * Skip that header; stubs copy CPython's generic fallback:
+ * https://github.com/python/cpython/blob/v3.12.10/Include/internal/pycore_atomic.h#L515-L552
+ * Broken ARM64 MSVC load (missing casts):
+ * https://github.com/python/cpython/blob/v3.12.10/Include/internal/pycore_atomic.h#L437
+ */
+#if (PY_MINOR_VERSION == 12) && defined(_M_ARM64) && defined(_MSC_VER)
+#ifndef Py_ATOMIC_H
+#define Py_ATOMIC_H
+#endif
+#if 1
+typedef enum _Py_memory_order {
+    _Py_memory_order_relaxed,
+    _Py_memory_order_acquire,
+    _Py_memory_order_release,
+    _Py_memory_order_acq_rel,
+    _Py_memory_order_seq_cst
+} _Py_memory_order;
+
+typedef struct _Py_atomic_address {
+    uintptr_t _value;
+} _Py_atomic_address;
+
+typedef struct _Py_atomic_int {
+    int _value;
+} _Py_atomic_int;
+/* Fall back to other compilers and processors by assuming that simple
+   volatile accesses are atomic.  This is false, so people should port
+   this. */
+#define _Py_atomic_signal_fence(/*memory_order*/ ORDER) ((void)0)
+#define _Py_atomic_thread_fence(/*memory_order*/ ORDER) ((void)0)
+#define _Py_atomic_store_explicit(ATOMIC_VAL, NEW_VAL, ORDER) \
+    ((ATOMIC_VAL)->_value = NEW_VAL)
+#define _Py_atomic_load_explicit(ATOMIC_VAL, ORDER) \
+    ((ATOMIC_VAL)->_value)
+#endif
+
+/* Standardized shortcuts. */
+#define _Py_atomic_store(ATOMIC_VAL, NEW_VAL) \
+    _Py_atomic_store_explicit((ATOMIC_VAL), (NEW_VAL), _Py_memory_order_seq_cst)
+#define _Py_atomic_load(ATOMIC_VAL) \
+    _Py_atomic_load_explicit((ATOMIC_VAL), _Py_memory_order_seq_cst)
+
+/* Python-local extensions */
+
+#define _Py_atomic_store_relaxed(ATOMIC_VAL, NEW_VAL) \
+    _Py_atomic_store_explicit((ATOMIC_VAL), (NEW_VAL), _Py_memory_order_relaxed)
+#define _Py_atomic_load_relaxed(ATOMIC_VAL) \
+    _Py_atomic_load_explicit((ATOMIC_VAL), _Py_memory_order_relaxed)
+#endif
+
 #include "internal/pycore_frame.h"
 // This is a fix suggested in the comments in https://github.com/python/cpython/issues/108216
 // specifically https://github.com/python/cpython/issues/108216#issuecomment-1696565797
@@ -46,7 +98,9 @@
  */
 #include "dynamic_annotations.h"
 #if (PY_MINOR_VERSION == 12)
-    #include "internal/pycore_atomic.h"
+    #if !(defined(_M_ARM64) && defined(_MSC_VER))
+        #include "internal/pycore_atomic.h"
+    #endif
 #endif
 #include "internal/pycore_interp.h"
 #include "internal/pycore_pyerrors.h"

--- a/numba/_dispatcher.cpp
+++ b/numba/_dispatcher.cpp
@@ -37,7 +37,7 @@
  * Skip that header; stubs copy CPython's generic fallback:
  * https://github.com/python/cpython/blob/v3.12.10/Include/internal/pycore_atomic.h#L515-L552
  * Broken ARM64 MSVC load (missing casts):
- * https://github.com/python/cpython/blob/v3.12.10/Include/internal/pycore_atomic.h#L437
+ * https://github.com/python/cpython/blob/v3.12.14/Include/internal/pycore_atomic.h#L437
  */
 #if (PY_MINOR_VERSION == 12) && defined(_M_ARM64) && defined(_MSC_VER)
 #ifndef Py_ATOMIC_H


### PR DESCRIPTION
as title.
This PR adds CI support to build win-arm64 llvmlite wheels and conda packages with python versions 3.11-3.14, previously only had 3.14.