### PR TITLE
Fix np.clip writing past the end of a caller-provided out= array

### DIFF
--- a/docs/upcoming_changes/10761.bug_fix.rst
+++ b/docs/upcoming_changes/10761.bug_fix.rst
@@ -1,0 +1,7 @@
+Fix ``np.clip`` writing past the end of a caller-provided ``out`` array
+-----------------------------------------------------------------------
+
+``np.clip`` did not check the shape of an explicit ``out`` argument, so an
+``out`` that did not match the shape of the result was written past its end
+and a wrong array was returned with no error. The shape is now validated and
+a mismatch raises ``ValueError``, matching NumPy.

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -2645,10 +2645,25 @@ def array_flatten(context, builder, sig, args):
 
 
 @register_jitable
+def _np_clip_prepare_out(a, shape, out):
+    # Returns the array the result is written into. NumPy broadcasts the
+    # inputs onto a caller-provided output but never stretches the output
+    # itself, so its shape has to match the shape of the result exactly.
+    # Without this check the callers loop over the result shape and write
+    # past the end of a too-small `out` (issue #10682).
+    if out is None:
+        return np.empty_like(a)
+    if out.shape != shape:
+        raise ValueError("clip: the shape of the 'out' array does not "
+                         "match the shape of the result")
+    return out
+
+
+@register_jitable
 def _np_clip_impl(a, a_min, a_max, out):
     # Both a_min and a_max are numpy arrays
-    ret = np.empty_like(a) if out is None else out
     a_b, a_min_b, a_max_b = np.broadcast_arrays(a, a_min, a_max)
+    ret = _np_clip_prepare_out(a, a_b.shape, out)
     for index in np.ndindex(a_b.shape):
         val_a = a_b[index]
         val_a_min = a_min_b[index]
@@ -2689,6 +2704,14 @@ def np_clip(a, a_min, a_max, out=None):
         msg = 'The argument "out" must be an array if it is provided'
         raise errors.TypingError(msg)
 
+    # The result has as many dimensions as the widest operand, and `out` is
+    # never broadcast, so a mismatch here can be reported at compile time.
+    result_ndim = max(getattr(t, 'ndim', 0) for t in (a, a_min, a_max))
+    if isinstance(out, types.Array) and out.ndim != result_ndim:
+        msg = ('The argument "out" must have the same number of dimensions '
+               'as the result')
+        raise errors.TypingError(msg)
+
     # TODO: support scalar a (issue #3469)
     a_min_is_none = a_min is None or isinstance(a_min, types.NoneType)
     a_max_is_none = a_max is None or isinstance(a_max, types.NoneType)
@@ -2708,7 +2731,7 @@ def np_clip(a, a_min, a_max, out=None):
             # a_min and a_max are scalars
             # since their shape will be empty
             # so broadcasting is not needed at all
-            ret = np.empty_like(a) if out is None else out
+            ret = _np_clip_prepare_out(a, a.shape, out)
             for index in np.ndindex(a.shape):
                 val_a = a[index]
                 ret[index] = min(max(val_a, a_min), a_max)
@@ -2722,7 +2745,7 @@ def np_clip(a, a_min, a_max, out=None):
                 # a_min is a scalar
                 # since its shape will be empty
                 # so broadcasting is not needed at all
-                ret = np.empty_like(a) if out is None else out
+                ret = _np_clip_prepare_out(a, a.shape, out)
                 for index in np.ndindex(a.shape):
                     val_a = a[index]
                     ret[index] = max(val_a, a_min)
@@ -2746,7 +2769,7 @@ def np_clip(a, a_min, a_max, out=None):
                 # a_max is a scalar
                 # since its shape will be empty
                 # so broadcasting is not needed at all
-                ret = np.empty_like(a) if out is None else out
+                ret = _np_clip_prepare_out(a, a.shape, out)
                 for index in np.ndindex(a.shape):
                     val_a = a[index]
                     ret[index] = min(val_a, a_max)
@@ -2769,16 +2792,16 @@ def np_clip(a, a_min, a_max, out=None):
         if a_min_is_none:
             def np_clip_na(a, a_min, a_max, out=None):
                 # a_max is a numpy array but a_min is None
-                ret = np.empty_like(a) if out is None else out
                 a_b, a_max_b = np.broadcast_arrays(a, a_max)
+                ret = _np_clip_prepare_out(a, a_b.shape, out)
                 return _np_clip_impl_none(a_b, a_max_b, True, ret)
 
             return np_clip_na
         elif a_max_is_none:
             def np_clip_an(a, a_min, a_max, out=None):
                 # a_min is a numpy array but a_max is None
-                ret = np.empty_like(a) if out is None else out
                 a_b, a_min_b = np.broadcast_arrays(a, a_min)
+                ret = _np_clip_prepare_out(a, a_b.shape, out)
                 return _np_clip_impl_none(a_b, a_min_b, False, ret)
 
             return np_clip_an

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -1820,6 +1820,56 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
                         with self.assertRaisesRegex(ValueError, msg):
                             cfunc(a, None, None)
 
+    def test_clip_out_shape_mismatch(self):
+        # Issue #10682: an `out` that does not match the shape of the result
+        # used to be written past its end, silently returning a wrong array.
+        # NumPy raises instead, because it never broadcasts `out` itself.
+        # Disable leak check since we expect an error to be raised
+        self.disable_leak_check()
+
+        has_out = (np_clip, np_clip_kwargs, array_clip, array_clip_kwargs)
+
+        a = np.linspace(-10, 10, 5)
+        a_min_arr = np.zeros_like(a)
+        a_max_arr = np.full_like(a, 5)
+        # covers every implementation branch: scalar/scalar, scalar/None,
+        # None/scalar, scalar/array, array/scalar, None/array, array/None
+        # and array/array
+        min_max = ((-5, 5), (-5, None), (None, 5), (-5, a_max_arr),
+                   (a_min_arr, 5), (None, a_max_arr), (a_min_arr, None),
+                   (a_min_arr, a_max_arr))
+
+        msg = "clip: the shape of the 'out' array does not match"
+        for pyfunc in has_out:
+            cfunc = jit(nopython=True)(pyfunc)
+            for a_min, a_max in min_max:
+                # too small, and too large: NumPy rejects both
+                for bad in (np.empty(a.size - 1), np.empty(a.size + 1)):
+                    with self.assertRaisesRegex(ValueError, msg):
+                        cfunc(a, a_min, a_max, bad)
+
+    def test_clip_out_no_out_of_bounds_write(self):
+        # Issue #10682: writing past the end of a too-small `out` corrupted
+        # whatever followed it in memory. Clip into a view of a larger
+        # buffer and check the rest of that buffer is left alone.
+        # Disable leak check since we expect an error to be raised
+        self.disable_leak_check()
+
+        cfunc = jit(nopython=True)(np_clip)
+
+        a = np.arange(5.0)
+        buf = np.full(8, 999.0)
+        with self.assertRaises(ValueError):
+            cfunc(a, 0.0, 3.0, buf[:3])
+
+        np.testing.assert_equal(buf, np.full(8, 999.0))
+
+    def test_clip_out_bad_ndim(self):
+        cfunc = jit(nopython=True)(np_clip)
+        msg = '.*The argument "out" must have the same number of dimensions.*'
+        with self.assertRaisesRegex(TypingError, msg):
+            cfunc(np.arange(5.0), 0.0, 3.0, np.empty((2, 5)))
+
     def test_clip_bad_array(self):
         cfunc = jit(nopython=True)(np_clip)
         msg = '.*The argument "a" must be array-like.*'


### PR DESCRIPTION
## Problem

`np.clip` with an explicit `out=` never checked that `out` matches the shape of the result. The loop runs over the shape of the result and writes into `out` regardless of its size, so a too-small `out` is written past its end.
NumPy raises a `ValueError` for the same call, because it broadcasts the inputs onto the output but never stretches the output itself.

```python
a = np.arange(5.0)
buf = np.full(8, 999.0)

@njit
def clip_out(a, a_min, a_max, out):
    return np.clip(a, a_min, a_max, out)

clip_out(a, 0.0, 3.0, buf[:3])
# buf is now [0. 1. 2. 3. 3. 999. 999. 999.]
#                     ^^^^^^ written outside the 3-element `out`
```

The returned array is also wrong, and nothing is raised. An `out` that is too large is accepted as well, where NumPy raises.

This is the same class of defect as #9166, fixed for the ufunc path in #10671. `np.clip` has its own implementation and does not go through `_build_array`, so that fix does not cover it.

Closes #10682.

## What changed

`out` is now validated against the shape of the result before anything is written, and a mismatch raises `ValueError`. The check is in a small helper that replaces the `np.empty_like(a) if out is None else out` line repeated across the implementation branches, so all of them are covered: both scalar bounds, either bound `None`, either or both bounds arrays, and the `np.clip`, `out=` keyword and `ndarray.clip` spellings.

A mismatch in the number of dimensions is reported at typing time instead, since `out` is never broadcast. That case already failed to compile, but with `No implementation of function clip` rather than anything pointing at `out`.

Allocation is unchanged: when `out` is None the result still comes from `np.empty_like(a)`, so the layout of the returned array is the same as before.

## Verification

* Three regression tests in `numba/tests/test_array_methods.py`, covering every implementation branch through all four call spellings, `out` both too small and too large, the dimension mismatch, and a check that a buffer adjacent to a too-small `out` is left untouched. All three fail on `main` and pass with the change.
* `numba.tests.test_array_methods` (83 tests) and `numba.tests.test_ufuncs.TestUFuncs` (87 tests) pass.
* `flake8` clean on both changed files.
* Run on Windows, Python 3.13, NumPy 2.4.6, llvmlite 0.50.0dev0.

## Notes for the reviewer

* The issue reports that `boundscheck=True` changes the result. On `main` it does not raise at all: the indices are generated inside the `@overload` implementation, which the flag does not reach. Worth knowing when reading the original report, but out of scope here.
* This touches the same lines as #10594. The changes are independent and the textual conflict is small, but whichever lands second will need a rebase.
* `np.clip` has a second, related defect on the `out=None` path: the result is allocated with `np.empty_like(a)` while the loop runs over the broadcast shape, which can be larger. Reported separately in #10760 and deliberately left out of this PR, because fixing it changes the layout and shape of returned arrays.

Assisted-by: Claude Code (Claude Opus 5, model ID claude-opus-5[1m])
