### PR TITLE
Fix #10758. Refuse to unify mismatched first-class function types

### DIFF
--- a/docs/upcoming_changes/10763.bug_fix.rst
+++ b/docs/upcoming_changes/10763.bug_fix.rst
@@ -1,0 +1,9 @@
+Fix ``AssertionError`` when unifying mismatched first-class function types
+--------------------------------------------------------------------------
+
+A tuple holding two first-class functions with the same argument count but
+different signatures raised a bare ``AssertionError`` with no message, from
+``typeof`` while typing the argument, so no Numba error context was attached
+either. ``unified_function_type`` now returns ``None`` for that case, as its
+documentation already describes, which lets ``BaseTuple.from_types`` fall back
+to a heterogeneous tuple and the call report the actual mismatch.

--- a/numba/core/utils.py
+++ b/numba/core/utils.py
@@ -652,8 +652,9 @@ def unified_function_type(numba_types, require_precise=True):
             else:
                 if function is None:
                     function = t
-                else:
-                    assert function == t
+                elif function != t:
+                    # Refuse to unify two different function types
+                    return
         else:
             return
     if require_precise and (function is None or undefined_function is not None):

--- a/numba/tests/test_function_type.py
+++ b/numba/tests/test_function_type.py
@@ -1119,6 +1119,33 @@ class TestMiscIssues(TestCase):
         self.assertEqual(bar(((foo1, foo2),)), 4)
         self.assertEqual(bar(((foo1, foo2), (foo1, foo3))), 9)  # reproducer
 
+    def test_issue_10758(self):
+        # See https://github.com/numba/numba/issues/10758
+        # Two functions with different signatures can't be unified. That used
+        # to hit a bare assert and raise an AssertionError with no message.
+
+        @cfunc(float64(float64))
+        def f(x):
+            return x + 1.0
+
+        @cfunc(int64(int64))
+        def g(x):
+            return x + 1
+
+        @cfunc(float64(float64))
+        def h(x):
+            return x + 2.0
+
+        @njit
+        def foo(pair, x):
+            return pair[0](x), pair[1](x)
+
+        with self.assertRaisesRegex(ValueError, 'mismatch of argument types:'):
+            foo((f, g), 1.0)  # reproducer
+
+        # matching signatures still unify
+        self.assertEqual(foo((f, h), 1.0), (2.0, 3.0))
+
 
 class TestBasicSubtyping(TestCase):
     def test_basic(self):


### PR DESCRIPTION
Fixes #10758.

[`unified_function_type`](https://github.com/numba/numba/blob/0d0938a717dbe464dfda3448f3f8571d2c606978/numba/core/utils.py#L597-L602)
documents returning None when the types can't be unified, but two function
types with the same argument count and different signatures hit
[a bare assert](https://github.com/numba/numba/blob/0d0938a717dbe464dfda3448f3f8571d2c606978/numba/core/utils.py#L656)
instead. That gives an AssertionError with no message, raised from `typeof`
while typing the argument, so there's no numba error context either.

Returning None lets
[`BaseTuple.from_types`](https://github.com/numba/numba/blob/0d0938a717dbe464dfda3448f3f8571d2c606978/numba/core/types/containers.py#L145-L161)
fall back to a heterogeneous tuple, and the call then reports the real problem:

    ValueError: mismatch of argument types: float64 vs int64

A few lines up, the
[`UndefinedFunctionType` case](https://github.com/numba/numba/blob/0d0938a717dbe464dfda3448f3f8571d2c606978/numba/core/utils.py#L645-L650)
already returns rather than asserting.

EDIT:
Assisted-by: AI Tools