### PR TITLE
Fix: add scalar support for np.nanprod

### DIFF
--- a/docs/upcoming_changes/10778.bug_fix.rst
+++ b/docs/upcoming_changes/10778.bug_fix.rst
@@ -1,0 +1,6 @@
+Fix scalar handling in``np.nanprod``
+-------------------------------------------------------
+
+Fix scalar handling in the ``np.nanprod`` function. Previously,
+this function would fail when called with scalar inputs. It now properly
+handles scalar and array inputs.

--- a/docs/upcoming_changes/10778.bug_fix.rst
+++ b/docs/upcoming_changes/10778.bug_fix.rst
@@ -1,5 +1,5 @@
 Fix scalar handling in``np.nanprod``
--------------------------------------------------------
+------------------------------------
 
 Fix scalar handling in the ``np.nanprod`` function. Previously,
 this function would fail when called with scalar inputs. It now properly

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -1781,7 +1781,8 @@ def np_nanprod(a):
 
         if isinstance(a, (types.Integer, types.Boolean)):
             # No NaN type possible for Integers and Booleans
-            retty = types.intp # upcast to intp
+            retty = types.intp # to platform default
+
             def nanprod_int_scalar_impl(a):
                 return retty(a)
             return nanprod_int_scalar_impl
@@ -1791,6 +1792,7 @@ def np_nanprod(a):
             retty = a
             one = retty(1)
             isnan = get_isnan(a)
+
             def nanprod_float_scalar_impl(a):
                 if isnan(a):
                     return one

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -1776,12 +1776,36 @@ def np_nansum(a):
 
 @overload(np.nanprod)
 def np_nanprod(a):
+
     if not isinstance(a, types.Array):
-        return
+
+        if isinstance(a, (types.Integer, types.Boolean)):
+            # No NaN type possible for Integers and Booleans
+            retty = types.intp # upcast to intp
+            def nanprod_int_scalar_impl(a):
+                return retty(a)
+            return nanprod_int_scalar_impl
+
+        elif isinstance(a,(types.Complex, types.Float)):
+            # NaN return 1, others return the value
+            retty = a
+            one = retty(1)
+            isnan = get_isnan(a)
+            def nanprod_float_scalar_impl(a):
+                if isnan(a):
+                    return one
+                else:
+                    return retty(a)
+            return nanprod_float_scalar_impl
+
+        else:
+            return None
+
     if isinstance(a.dtype, types.Integer):
         retty = types.intp
     else:
         retty = a.dtype
+
     one = retty(1)
     isnan = get_isnan(a.dtype)
 
@@ -1792,7 +1816,6 @@ def np_nanprod(a):
             if not isnan(v):
                 c *= v
         return c
-
     return nanprod_impl
 
 

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -616,6 +616,29 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
     def test_nanprod_basic(self):
         self.check_reduction_basic(array_nanprod)
 
+    def test_nanprod_scalar(self):
+        self.check_scalar_basic(array_nanprod)
+
+        cfunc = jit(nopython=True)(array_nanprod)
+
+        def check(arg):
+            expected = array_nanprod(arg)
+            got = cfunc(arg)
+            self.assertPreciseEqual(got, expected)
+
+        # check less precise integer cases are upcasted
+        check(np.int8(2))
+        check(np.uint8(2))
+        check(np.int16(3))
+        check(np.uint16(3))
+        check(np.int32(4))
+        check(np.uint32(4))
+
+        # complex cases
+        check(np.complex64(0j))
+        check(np.complex128(1j))
+
+
     def test_nanstd_basic(self):
         self.check_reduction_basic(array_nanstd)
 
@@ -956,6 +979,10 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
         # handle complex cases not tested in self.check_scalar_basic
         check(np.complex64(1j))
         check(np.complex128(0j))
+        check(np.complex128(complex(np.nan, 1.0)))
+        check(np.complex128(complex(1.0, np.nan)))
+        check(np.complex128('nan'))
+
 
     def check_cumulative(self, pyfunc):
         arr = np.arange(2, 10, dtype=np.int16)

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -637,6 +637,9 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
         # complex cases
         check(np.complex64(0j))
         check(np.complex128(1j))
+        check(np.complex128(complex(np.nan, 1.0)))
+        check(np.complex128(complex(1.0, np.nan)))
+        check(np.complex128('nan'))
 
 
     def test_nanstd_basic(self):
@@ -979,9 +982,7 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
         # handle complex cases not tested in self.check_scalar_basic
         check(np.complex64(1j))
         check(np.complex128(0j))
-        check(np.complex128(complex(np.nan, 1.0)))
-        check(np.complex128(complex(1.0, np.nan)))
-        check(np.complex128('nan'))
+
 
 
     def check_cumulative(self, pyfunc):


### PR DESCRIPTION
Added scalar support for np.nanprod - It now supports types.Integer, types.Boolean, types.Float, and types.Complex,  and upcasts integers to to types.intp. 

Test cases have also been added. :)