### PR TITLE
Type None step slices as being 2 parameter

### DIFF
--- a/docs/upcoming_changes/10781.improvement.rst
+++ b/docs/upcoming_changes/10781.improvement.rst
@@ -1,0 +1,5 @@
+Preserve array layout when slicing with a ``None`` step
+-------------------------------------------------------
+
+Previously, a slice with an explicit ``None`` step was typed as a three-member slice,
+so ``x[a:b:None]`` inferred an ``"A"`` layout where ``x[a:b]`` inferred ``"C"``.

--- a/numba/core/typing/builtins.py
+++ b/numba/core/typing/builtins.py
@@ -59,11 +59,12 @@ class Slice(ConcreteTemplate):
         signature(types.slice3_type, types.intp, types.intp, types.intp),
         signature(types.slice3_type, types.none, types.intp, types.intp),
         signature(types.slice3_type, types.intp, types.none, types.intp),
-        signature(types.slice3_type, types.intp, types.intp, types.none),
-        signature(types.slice3_type, types.intp, types.none, types.none),
-        signature(types.slice3_type, types.none, types.intp, types.none),
         signature(types.slice3_type, types.none, types.none, types.intp),
-        signature(types.slice3_type, types.none, types.none, types.none),
+        # A None step is a step of 1, i.e. a two-member slice.
+        signature(types.slice2_type, types.intp, types.intp, types.none),
+        signature(types.slice2_type, types.intp, types.none, types.none),
+        signature(types.slice2_type, types.none, types.intp, types.none),
+        signature(types.slice2_type, types.none, types.none, types.none),
     ]
 
 

--- a/numba/tests/test_slices.py
+++ b/numba/tests/test_slices.py
@@ -140,6 +140,28 @@ class TestSlices(MemoryLeakMixin, TestCase):
             else:
                 self.assertPreciseEqual(expected, cfunc(args, array))
 
+    def test_slice_constructor_layout(self):
+        """
+        Test that a None step keeps an array contiguous, like an omitted one.
+        """
+        def omitted_step(a, i, j):
+            return a[slice(i, j)]
+
+        def none_step(a, i, j):
+            return a[slice(i, j, None)]
+
+        def int_step(a, i, j, k):
+            return a[slice(i, j, k)]
+
+        arr = np.arange(10)
+        for pyfunc, args, layout in [(omitted_step, (arr, 1, 5), 'C'),
+                                     (none_step, (arr, 1, 5), 'C'),
+                                     (int_step, (arr, 1, 5, 2), 'A')]:
+            cfunc = jit(nopython=True)(pyfunc)
+            self.assertPreciseEqual(cfunc(*args), pyfunc(*args))
+            self.assertEqual(cfunc.nopython_signatures[0].return_type.layout,
+                             layout)
+
     def test_slice_indices(self):
         """Test that a numba slice returns same result for .indices as a python one."""
         slices = starmap(


### PR DESCRIPTION
Writing `x[a:b:None]` explicitly caused type inference to pessimize guaranteed C-layout into A-layout.

It would also be helpful if numba typed full slices `slice(None)` distinctly so we don't pessimize in the explicit but redundant `x[a:b, :]` (preserves C-layout) or the needed `x[:, a:b]` (preserves F-layout). Numba does treat ellipsis differently so `x[a:b, ...]` and `x[..., a:b]` keep their layouts but that sounds like somethig users shouldn't have to know about