### PR TITLE
ENH: enable ILP64 linear algebra

### DIFF
--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -151,6 +151,23 @@ otherwise build by default along with information on configuration options.
   variable to provide the location of the TBB installation. For more
   information about setting ``TBBROOT`` see the `Intel documentation <https://software.intel.com/content/www/us/en/develop/documentation/advisor-user-guide/top/appendix/adding-parallelism-to-your-program/adding-the-parallel-framework-to-your-build-environment/defining-the-tbbroot-environment-variable.html>`_.
 
+.. envvar:: NUMBA_LAPACK_ILP64 (default: not set)
+
+  Selects, at build time, whether Numba's BLAS/LAPACK C wrappers are built
+  to call through to a 64-bit ("ILP64") Fortran integer ABI rather than the
+  usual 32-bit ("LP64") one. This must match the ABI of
+  ``scipy.linalg.cython_blas`` / ``cython_lapack`` at *runtime*, not just at
+  build time -- a mismatch produces wrong results or a crash rather than a
+  clean error, so Numba checks this the first time BLAS/LAPACK support is
+  used and raises if the two disagree.
+
+  The default is to use LP64 ABI, which matches SciPy's default. To override
+  the default, set ``NUMBA_LAPACK_ILP64=1`` when building numba.
+
+  The choice made is recorded in the built package (it cannot drift from
+  the compiled binary independently) and can be inspected via ``numba -s``,
+  under "SciPy / LAPACK Information".
+
 .. _numba-source-install-check:
 
 Dependency List

--- a/docs/upcoming_changes/10784.improvement.rst
+++ b/docs/upcoming_changes/10784.improvement.rst
@@ -1,0 +1,7 @@
+Enable using ILP64 BLAS and LAPACK.
+-----------------------------------
+
+Users can opt in to using ILP64 (64-bit integer) LAPACK ABI. To opt in, define
+the ``NUMBA_LAPACK_ILP64=1`` environment variable at numba build time, and
+make sure that SciPy available at run time exports the ILP64 ``cython_lapack`` ABI
+(this currently requires SciPy >= 1.18, built from source).

--- a/numba/_helpermod.c
+++ b/numba/_helpermod.c
@@ -94,7 +94,11 @@ build_c_helpers_dict(void)
     declmethod(set_pyobject_private_data);
     declmethod(reset_pyobject_private_data);
 
-    /* BLAS / LAPACK */
+    /*
+     * BLAS / LAPACK
+     * Compiled for a single Fortran integer width, fixed at build time --
+     * see NUMBA_LAPACK_BUILD_ILP64 below and numba/_lapack.c.
+     */
     declmethod(xxgemm);
     declmethod(xxgemv);
     declmethod(xxdot);
@@ -274,6 +278,20 @@ MOD_INIT(_helperlib) {
     import_array();
 
     PyModule_AddObject(m, "c_helpers", build_c_helpers_dict());
+#ifndef NUMBA_LAPACK_BUILD_ILP64
+#define NUMBA_LAPACK_BUILD_ILP64 0
+#endif
+    /*
+     * Which Fortran integer width numba/_lapack.c was built to target (see
+     * NUMBA_LAPACK_ILP64 in setup.py and the "Build time environment
+     * variables" docs). Baked in as a compile-time macro (set via
+     * Extension(define_macros=...) in setup.py, and used directly by
+     * numba/_lapack.c to fix F_INT) rather than a loose generated .py
+     * file, so it can't drift from the actual compiled binary.
+     * numba.np.linalg reads this once and checks it against the scipy
+     * actually installed at runtime.
+     */
+    PyModule_AddIntConstant(m, "LAPACK_BUILD_ILP64", NUMBA_LAPACK_BUILD_ILP64);
     PyModule_AddIntConstant(m, "long_min", LONG_MIN);
     PyModule_AddIntConstant(m, "long_max", LONG_MAX);
     PyModule_AddIntConstant(m, "py_buffer_size", sizeof(Py_buffer));

--- a/numba/_lapack.c
+++ b/numba/_lapack.c
@@ -238,12 +238,31 @@ if (check_func(__FUNC))                   \
 
 
 /*
- * Define what a Fortran "int" is, some LAPACKs have 64 bit integer support
- * numba presently opts for a 32 bit C int.
- * This definition allows scope for later configuration time magic to adjust
- * the size of int at all the call sites.
+ * Define what a Fortran "int" is. The width is a *build-time* decision,
+ * fixed by NUMBA_LAPACK_BUILD_ILP64 -- a macro baked in via
+ * Extension(define_macros=...) in setup.py, driven by the
+ * NUMBA_LAPACK_ILP64 build-time environment variable (see the "Build time
+ * environment variables" section of the install docs). It is not
+ * re-probed or chosen at runtime.
+ *
+ * Which width is *correct* to call through is a property of the scipy
+ * actually installed: scipy.linalg.cython_blas/cython_lapack are compiled
+ * for exactly one ABI, LP64 or ILP64, recorded in
+ * scipy.__config__.CONFIG['Build Dependencies']['blas']['cython blas
+ * ilp64']. numba.np.linalg._check_lapack_int_width() compares the
+ * build-time choice made here against the scipy actually present at
+ * runtime, and raises if they disagree, rather than silently doing the
+ * wrong thing.
  */
-#define F_INT int
+#ifndef NUMBA_LAPACK_BUILD_ILP64
+#define NUMBA_LAPACK_BUILD_ILP64 0
+#endif
+
+#if NUMBA_LAPACK_BUILD_ILP64
+typedef npy_int64 F_INT;
+#else
+typedef npy_int32 F_INT;
+#endif
 
 
 typedef float (*sdot_t)(F_INT *n, void *dx, F_INT *incx, void *dy, F_INT *incy);
@@ -1090,7 +1109,7 @@ numba_ez_rsyevd(char kind, char jobz, char uplo, Py_ssize_t n, void *a, Py_ssize
     void *work = NULL;
     F_INT *iwork = NULL;
     all_dtypes stack_slot;
-    int stack_int = -1;
+    F_INT stack_int = -1;
 
     ENSURE_VALID_REAL_KIND(kind)
 
@@ -1173,7 +1192,7 @@ numba_ez_cheevd(char kind, char jobz, char uplo, Py_ssize_t n, void *a, Py_ssize
     F_INT *iwork = NULL;
     all_dtypes stack_slot1, stack_slot2;
     char uf_kind;
-    int stack_int = -1;
+    F_INT stack_int = -1;
 
     ENSURE_VALID_COMPLEX_KIND(kind)
 
@@ -1941,6 +1960,5 @@ numba_xgesv(char kind, Py_ssize_t n, Py_ssize_t nrhs, void *a, Py_ssize_t lda,
 #undef ENSURE_VALID_REAL_KIND
 #undef ENSURE_VALID_COMPLEX_KIND
 #undef ENSURE_VALID_FUNC
-#undef F_INT
 #undef EMIT_GET_CLAPACK_FUNC
 #undef CATCH_LAPACK_INVALID_ARG

--- a/numba/misc/numba_sysinfo.py
+++ b/numba/misc/numba_sysinfo.py
@@ -70,6 +70,11 @@ _numpy_version = 'NumPy Version'
 _numpy_supported_simd_features = 'NumPy Supported SIMD features'
 _numpy_supported_simd_dispatch = 'NumPy Supported SIMD dispatch'
 _numpy_supported_simd_baseline = 'NumPy Supported SIMD baseline'
+# SciPy / LAPACK info
+_scipy_version = 'SciPy Version'
+_lapack_build_ilp64 = 'LAPACK Numba Built ILP64'
+_lapack_runtime_ilp64 = 'LAPACK SciPy Runtime ILP64'
+_lapack_int_width_match = 'LAPACK Int Width Match'
 # SVML info
 _svml_state, _svml_loaded = 'SVML State', 'SVML Lib Loaded'
 _llvm_svml_patched = 'LLVM SVML Patched'
@@ -430,6 +435,27 @@ def get_sysinfo():
         sys_info[_numpy_supported_simd_dispatch] = __cpu_dispatch__
         sys_info[_numpy_supported_simd_baseline] = __cpu_baseline__
 
+    # SciPy / LAPACK information
+    try:
+        from numba.np.linalg import _LAPACK_BUILD_ILP64
+        sys_info[_lapack_build_ilp64] = _LAPACK_BUILD_ILP64
+        try:
+            import scipy
+            import scipy.linalg.cython_lapack  # noqa: F401
+        except ImportError:
+            pass  # no scipy (or too old) -- nothing to compare against
+        else:
+            from numba.np.linalg import _lapack_runtime_is_ilp64
+            sys_info[_scipy_version] = scipy.__version__
+            runtime_ilp64 = _lapack_runtime_is_ilp64()
+            sys_info[_lapack_runtime_ilp64] = runtime_ilp64
+            sys_info[_lapack_int_width_match] = (
+                runtime_ilp64 == _LAPACK_BUILD_ILP64)
+    except Exception as e:
+        _warning_log.append(
+            "Warning (scipy): Probing LAPACK/BLAS integer width failed\n"
+            f"(scipy) {type(e)}: {e}")
+
     # SVML information
     # Replicate some SVML detection logic from numba.__init__ here.
     # If SVML load fails in numba.__init__ the splitting of the logic
@@ -636,6 +662,16 @@ def display_sysinfo(info=None, sep_pos=45):
         ("NumPy Supported SIMD baseline",
          DisplaySeq(info.get(_numpy_supported_simd_baseline, [])
                     or ('None found.',))),
+        ("",),
+        ("__SciPy / LAPACK Information__",),
+        ("SciPy Version", info.get(_scipy_version, 'Not Installed')),
+        ("Numba Built For",
+         'ILP64' if info.get(_lapack_build_ilp64) else 'LP64'),
+        ("SciPy Runtime Provides",
+         ('ILP64' if info[_lapack_runtime_ilp64] else 'LP64')
+         if _lapack_runtime_ilp64 in info else 'Unknown (no SciPy found)'),
+        ("LAPACK Integer Width Matches Build",
+         info.get(_lapack_int_width_match, 'Unknown (no SciPy found)')),
         ("",),
         ("__SVML Information__",),
         ("SVML State, config.USING_SVML", info.get(_svml_state, '?')),

--- a/numba/np/linalg.py
+++ b/numba/np/linalg.py
@@ -20,6 +20,7 @@ from numba.core.errors import TypingError, NumbaTypeError, \
     NumbaPerformanceWarning
 from .arrayobj import make_array, _empty_nd_impl, array_copy
 from numba.np import numpy_support as np_support
+from numba import _helperlib
 
 ll_char = ir.IntType(8)
 ll_char_p = ll_char.as_pointer()
@@ -30,11 +31,68 @@ intp_t = cgutils.intp_t
 ll_intp_p = intp_t.as_pointer()
 
 
-# fortran int type, this needs to match the F_INT C declaration in
-# _lapack.c and is present to accommodate potential future 64bit int
-# based LAPACK use.
-F_INT_nptype = np.int32
-F_INT_nbtype = types.int32
+def _lapack_runtime_is_ilp64():
+    """
+    Whether the scipy actually installed *right now* provides ILP64 (64-bit
+    Fortran integer) scipy.linalg.cython_blas / cython_lapack, as opposed to
+    the usual 32-bit ("LP64") ones. This may differ from what numba's own
+    _lapack.c wrappers were *built* for (see _LAPACK_BUILD_ILP64 below and
+    _check_lapack_int_width()) -- scipy can be upgraded/downgraded/swapped
+    independently of numba. SciPy records which ABI it built for in
+    scipy.__config__ (see scipy.linalg.blas.HAS_LP64, which reads the same
+    flag).
+    """
+    try:
+        from scipy.__config__ import CONFIG
+        return bool(CONFIG['Build Dependencies']['blas']['cython blas ilp64'])
+    except (ImportError, KeyError, TypeError):
+        # scipy predates this __config__ entry (pre-Meson builds); those
+        # releases only ever shipped LP64 cython_blas/cython_lapack.
+        return False
+
+
+# Which Fortran integer width numba/_lapack.c was built to target (see
+# NUMBA_LAPACK_ILP64 in the "Build time environment variables" install
+# docs, and setup.py). numba/_lapack.c is only ever compiled for this one
+# width -- it is fixed at build time, not re-probed on every import, and is
+# compiled into numba._helperlib itself so it can't drift from the actual
+# binary.
+_LAPACK_BUILD_ILP64 = bool(getattr(_helperlib, "LAPACK_BUILD_ILP64", False))
+_LAPACK_ILP64 = _LAPACK_BUILD_ILP64
+
+_LAPACK_INSTALL_DOCS_URL = (
+    "https://numba.readthedocs.io/en/stable/user/installing.html"
+    "#numba-source-install-env_vars"
+)
+
+
+def _check_lapack_int_width():
+    """
+    Guard against a numba built for one Fortran integer width being used
+    against a scipy providing the other one: the compiled numba_* wrappers
+    assume a fixed width, so calling through the wrong one is silent memory
+    corruption or wrong answers, not a clean error -- refuse outright
+    instead. Called from ensure_blas()/ensure_lapack(), once scipy is
+    confirmed importable.
+    """
+    runtime_ilp64 = _lapack_runtime_is_ilp64()
+    if runtime_ilp64 != _LAPACK_BUILD_ILP64:
+        built_as = "ILP64" if _LAPACK_BUILD_ILP64 else "LP64"
+        found_as = "ILP64" if runtime_ilp64 else "LP64"
+        raise RuntimeError(
+            f"This copy of Numba was built for {built_as} BLAS/LAPACK, but "
+            f"the scipy installed now provides {found_as} "
+            f"scipy.linalg.cython_blas/cython_lapack. Numba's compiled "
+            f"BLAS/LAPACK wrappers assume a fixed integer width and will "
+            f"produce wrong results or crash if called against the wrong "
+            f"one. Either install a matching SciPy or rebuild Numba "
+            f"-- see {_LAPACK_INSTALL_DOCS_URL} for details."
+        )
+
+
+# fortran int type, this needs to match the F_INT typedef in _lapack.c.
+F_INT_nptype = np.int64 if _LAPACK_ILP64 else np.int32
+F_INT_nbtype = types.int64 if _LAPACK_ILP64 else types.int32
 
 # BLAS kinds as letters
 _blas_kinds = {
@@ -57,6 +115,7 @@ def ensure_blas():
         import scipy.linalg.cython_blas
     except ImportError:
         raise ImportError("scipy 0.16+ is required for linear algebra")
+    _check_lapack_int_width()
 
 
 def ensure_lapack():
@@ -64,6 +123,7 @@ def ensure_lapack():
         import scipy.linalg.cython_lapack
     except ImportError:
         raise ImportError("scipy 0.16+ is required for linear algebra")
+    _check_lapack_int_width()
 
 
 def make_constant_slot(context, builder, ty, val):

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -209,6 +209,7 @@ def available_memory_bytes():
             pass
     return None
 
+
 _msg = "SciPy needed for test"
 skip_unless_scipy = unittest.skipIf(scipy is None, _msg)
 

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -187,6 +187,28 @@ def expected_failure_np2(fn):
     else:
         return fn
 
+
+def available_memory_bytes():
+    """
+    Best-effort lookup of currently available system memory, in bytes.
+    Returns None if it can't be determined (psutil not installed, and not
+    running on Linux where /proc/meminfo can be read directly).
+    """
+    try:
+        import psutil
+        return psutil.virtual_memory().available
+    except ImportError:
+        pass
+    if sys.platform.startswith("linux"):
+        try:
+            with open("/proc/meminfo") as f:
+                for line in f:
+                    if line.startswith("MemAvailable:"):
+                        return int(line.split()[1]) * 1024
+        except OSError:
+            pass
+    return None
+
 _msg = "SciPy needed for test"
 skip_unless_scipy = unittest.skipIf(scipy is None, _msg)
 

--- a/numba/tests/test_linalg.py
+++ b/numba/tests/test_linalg.py
@@ -12,7 +12,9 @@ from numba import jit, njit, typeof
 from numba.core import errors
 from numba.np.numpy_support import numpy_version
 from numba.tests.support import (TestCase, tag, needs_lapack, needs_blas,
-                                 _is_armv7l, EnableNRTStatsMixin)
+                                 _is_armv7l, EnableNRTStatsMixin, has_lapack,
+                                 available_memory_bytes)
+from numba.np.linalg import _LAPACK_ILP64
 from .matmul_usecase import matmul_usecase
 import unittest
 
@@ -2213,6 +2215,31 @@ class TestLinalgNorm(TestLinalgSystems):
         # assert 2D input raises for an invalid norm kind kwarg
         self.assert_invalid_norm_kind(cfunc, (np.array([[1., 2.], [3., 4.]],
                                                        dtype=np.float64), 6))
+
+    # x below is 2**31 * 8 bytes (~16 GiB); require some headroom on top of
+    # that for the rest of the test process before attempting it.
+    _NORM_ILP64_BYTES_NEEDED = 2 ** 31 * 8 + 2 * 2 ** 30
+
+    # An LP64 nrm2 call can't represent a length of 2**31, so this needs an
+    # ILP64 scipy/BLAS and enough free memory to allocate x.
+    @needs_lapack
+    @unittest.skipIf(
+        not has_lapack or not _LAPACK_ILP64
+        or (available_memory_bytes() or 0) < _NORM_ILP64_BYTES_NEEDED,
+        "requires an ILP64 scipy/BLAS and enough free memory for a "
+        "2**31-element float64 array"
+    )
+    def test_norm_ilp64(self):
+        x = np.zeros(2**31, dtype=np.float64)
+        x[-1] = 1.0
+
+        def func(x):
+            return np.linalg.norm(x)
+
+        cfunc = njit(func)
+
+        np.testing.assert_allclose(func(x), 1.0, atol=1e-14)
+        np.testing.assert_allclose(cfunc(x), 1.0, atol=1e-14)
 
 
 class TestLinalgCond(TestLinalgBase):

--- a/numba/tests/test_linalg.py
+++ b/numba/tests/test_linalg.py
@@ -12,7 +12,7 @@ from numba import jit, njit, typeof
 from numba.core import errors
 from numba.np.numpy_support import numpy_version
 from numba.tests.support import (TestCase, tag, needs_lapack, needs_blas,
-                                 _is_armv7l, EnableNRTStatsMixin, has_lapack,
+                                 _is_armv7l, EnableNRTStatsMixin,
                                  available_memory_bytes)
 from numba.np.linalg import _LAPACK_ILP64
 from .matmul_usecase import matmul_usecase
@@ -2224,7 +2224,7 @@ class TestLinalgNorm(TestLinalgSystems):
     # ILP64 scipy/BLAS and enough free memory to allocate x.
     @needs_lapack
     @unittest.skipIf(
-        not has_lapack or not _LAPACK_ILP64
+        not _LAPACK_ILP64
         or (available_memory_bytes() or 0) < _NORM_ILP64_BYTES_NEEDED,
         "requires an ILP64 scipy/BLAS and enough free memory for a "
         "2**31-element float64 array"

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,20 @@ min_numpy_run_version = "1.22"
 min_llvmlite_version = "0.50.0dev0"
 max_llvmlite_version = "0.51"
 
+
+def _detect_lapack_ilp64():
+    """
+    Decide, at build time, whether to use ILP64 BLAS/LAPACK ABI.
+
+    Set NUMBA_LAPACK_ILP64 environment variable to 1 to enable ILP64, see
+    "Build time environment variables" section of the install docs for
+    details.
+    """
+    return os.environ.get("NUMBA_LAPACK_ILP64") == "1"
+
+
+lapack_build_ilp64 = _detect_lapack_ilp64()
+
 if sys.platform.startswith('linux'):
     # Patch for #2555 to make wheels without libpython
     sysconfig.get_config_vars()['Py_ENABLE_SHARED'] = 0
@@ -174,6 +188,10 @@ def get_ext_modules():
                                        "numba/cext/listobject.c",
                                        "numba/cext/setobject.c",
                                        ],
+                              define_macros=[
+                                  ("NUMBA_LAPACK_BUILD_ILP64",
+                                   int(lapack_build_ilp64)),
+                              ],
                               # numba/_random.c needs pthreads
                               extra_link_args=install_name_tool_fixer +
                               extra_link_args,


### PR DESCRIPTION
Intends to close https://github.com/numba/numba/issues/10777 : enable using ILP64 LAPACK ABI (64-but integers) if scipy exports this ABI. (The latter requires that scipy is built from source.)

User-visible UI largely follows https://github.com/numba/numba/issues/10777#issuecomment-5272029751 : a new `NUMBA_LAPACK_ILP64` environment variable selects the target BLAS/LAPACK ABI; if not set, the build system queries the ABI that `scipy.linalg.cython_blas exports`; if scipy is not available, then falls back to backwards-compatible LP64.

The summary of precise behavior for various combinations is under the fold (Claude generated)

<details>

# Numba LP64/ILP64 build and runtime matrix

## Table 1 — what Numba is built for

`NUMBA_LAPACK_ILP64` (if set) overrides the build-environment scipy outright, so these collapse to one effective build width:

| `NUMBA_LAPACK_ILP64` | scipy present at build time | Numba built for |
|---|---|---|
| `1` (or any value not in `0`/`false`/`no`/empty) | *irrelevant* | **ILP64** |
| `0` / `false` / `no` / empty | *irrelevant* | **LP64** |
| unset | ILP64 | **ILP64** |
| unset | LP64 | **LP64** |
| unset | absent / unimportable | **LP64** (fallback) |

## Table 2 — what happens at runtime, given what Numba was built for

Checked lazily, only the first time a jitted function actually touches `np.linalg`/BLAS (`ensure_lapack()`/`ensure_blas()`) — plain `import numba` and non-linalg jitted code are unaffected in every row below.

| Numba built for | scipy at runtime | Outcome |
|---|---|---|
| LP64 | LP64 | Works -- `numba_*_32` symbols bound, widths match |
| LP64 | ILP64 | `RuntimeError` (clean refusal, no C call made) |
| LP64 | absent | `ImportError: scipy 0.16+ is required for linear algebra` |
| ILP64 | LP64 | `RuntimeError` (clean refusal, no C call made) |
| ILP64 | ILP64 | Works -- `numba_*_64` symbols bound, widths match |
| ILP64 | absent | `ImportError: scipy 0.16+ is required for linear algebra` |

Only the two diagonal cells (build width == runtime width) actually execute BLAS/LAPACK; every off-diagonal case fails loudly and safely before any C call, rather than corrupting memory.

## Caveat

"scipy at runtime" here means what `scipy.__config__` reports, which is scipy's own static self-description -- it's what the mismatch check in Table 2 actually reads. 
That can itself be misleading for an MKL-SDL-linked scipy (`libmkl_rt.so`) if `MKL_INTERFACE_LAYER` is overridden in the environment: MKL's dynamic dispatch can be forced to a different actual width
 than `__config__` reports, and neither Numba nor scipy currently have visibility into that at runtime.
That failure mode sits outside what this table (or the current runtime check) can see.

</details>

The implementation also follows https://github.com/numba/numba/issues/10777#issuecomment-5272029751 : the ABI is decided once at Numba build time, and at runtime the scipy-exported ABI is checked against the build-time expectation. 
Internally, there two symbol sets, suffixed with `_32 / _64`, and the correct one is picked at runtime.

The patch is actually smaller than it looks: there's a large chunk of code moved verbatim from `lapack.c` to `lapack_width.h` to avoid code duplication for the two ABI modes. To ease review, the PR is organized into three commits:

- the first one just moves code from `lapack.c` to `lapack_width.h` 
- the second one implements the details of selecting the integer width
- and the third one adds the build time / run time selection

The patch is generated with heavy assistance from Claude.  That said, there is a human in the loop (me), who read, modified and tweaked claude's generated code, is accountable for the contribution (per the linked AI policy) and is happy to discuss details or modify the PR per review requests.

------------------

What this PR does _not_  fix are OP usage examples from https://github.com/numba/numba/issues/10777. Bear with me: if
- scipy links to `mkl_rt`, and
- the numba build mode is LP64, and
- the user explicitly requests ILP64 via the env variable, `MKL_INTERFACE_LAYER=ILP64,GNU`

then the ABI choice is being made inside MKL itself, and numba has no knowledge of it, thus running into an ABI mismatch. 

I believe this is a user error, and the way to find it is clearly visible from `numba -s` output, which reports LP64:

```
Command:
    MKL_INTERFACE_LAYER=ILP64,GNU python -m numba -s

Relevant section of the output:
    __SciPy / LAPACK Information__
    SciPy Version                                 : 1.18.0
    Numba Built For                               : LP64
    SciPy Runtime Provides                        : LP64
    LAPACK Integer Width Matches Build            : True
```

While this is a footgun, it requires a deliberate user action, and will not happen if scipy is built in the recommended way, against `mkl-ilp64-...` library, as done in e.g. https://github.com/scipy/scipy/blob/main/.github/workflows/linux_blas.yml#L117-L120

Unless the user manually fiddles with `MKL_INTERFACE_LAYER`, everything I believe either just works correctly, or fails with a clear RuntimeError.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
post to the Numba forum https://numba.discourse.group/.

Second, please ensure that you have read and understood Numba's AI tool use
policy: https://numba.readthedocs.io/en/stable/reference/ai_tools_policy.html

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
