### PR TITLE
Fix typeof() support for ctypes values and pointers (#10501)

### DIFF
--- a/docs/upcoming_changes/10501.bugfix
+++ b/docs/upcoming_changes/10501.bugfix
@@ -1,0 +1,5 @@
+Fixes an issue where ``typeof()`` failed when passed primitive ctypes values or
+ctypes pointers.
+
+The ``typeof()`` typing mechanism now correctly maps these ctypes instances
+to their corresponding Numba type representations.

--- a/docs/upcoming_changes/10501.bugfix.rst
+++ b/docs/upcoming_changes/10501.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed typeof() support for ctypes values and pointers.

--- a/docs/upcoming_changes/10501.bugfix.rst
+++ b/docs/upcoming_changes/10501.bugfix.rst
@@ -1,1 +1,5 @@
-Fixed typeof() support for ctypes values and pointers.
+Fixes an issue where ``typeof()`` failed when passed primitive ctypes values or
+ctypes pointers.
+
+The ``typeof()`` typing mechanism now correctly maps these ctypes instances
+to their corresponding Numba type representations.

--- a/numba/core/typing/typeof.py
+++ b/numba/core/typing/typeof.py
@@ -298,3 +298,14 @@ def typeof_numpy_polynomial(val, c):
     domain = typeof(val.domain)
     window = typeof(val.window)
     return types.PolynomialType(coef, domain, window)
+
+
+@typeof_impl.register(ctypes._SimpleCData)
+@typeof_impl.register(ctypes._Pointer)
+def _typeof_ctypes_data(val, c):
+    from numba.core.typing import ctypes_utils
+    try:
+        return ctypes_utils.from_ctypes(type(val))
+    except (TypeError, ValueError):
+        return None
+    

--- a/numba/core/typing/typeof.py
+++ b/numba/core/typing/typeof.py
@@ -308,4 +308,3 @@ def _typeof_ctypes_data(val, c):
         return ctypes_utils.from_ctypes(type(val))
     except (TypeError, ValueError):
         return None
-    

--- a/numba/tests/test_ctypes.py
+++ b/numba/tests/test_ctypes.py
@@ -60,6 +60,20 @@ class TestCTypesTypes(TestCase):
         self.assertIn("Cannot convert Numba type '...' to ctypes type",
                       str(raises.exception))
 
+    def test_typeof_ctypes(self):
+        """
+        Test typeof() support for ctypes values and pointers (#10501).
+        """
+        from numba import typeof
+
+        # Primitive ctypes value test
+        val = c_int(42)
+        self.assertEqual(typeof(val), types.intc)
+
+        # Ctypes pointer test
+        ptr = POINTER(c_int)(val)
+        self.assertEqual(typeof(ptr), types.CPointer(types.intc))
+
 
 class TestCTypesUseCases(MemoryLeakMixin, TestCase):
 


### PR DESCRIPTION
## Description
This PR addresses issue #10501 by adding support for `typeof()` on primitive `ctypes` values and `ctypes` pointers.

## Changes Made
- Updated `numba/core/typing/typeof.py` to correctly resolve types for `ctypes` values and pointer instances.
- Added unit test `test_typeof_ctypes` in `numba/tests/test_ctypes.py` under `TestCTypesTypes` class to verify type resolution for primitive ctypes and pointers.

## Issues Fixed
Fixes #10501

## AI Usage Disclosure
In accordance with Numba's Generative AI policy:
- **Generative AI Tool Used:** Google Gemini
- **Scope of Assistance:** Assisted in code formatting, reviewing test implementation against PEP 8 standards, and drafting this PR description. All generated code has been manually inspected, validated, and tested locally.