### PR TITLE
Fix: Numpy 1.24 sincos followup

### DIFF
--- a/docs/upcoming_changes/10786.change.rst
+++ b/docs/upcoming_changes/10786.change.rst
@@ -1,6 +1,7 @@
 Relax NumPy ``sin``/``cos`` test comparisons on Linux x86_64 with NumPy < 1.25
 ------------------------------------------------------------------------------
 
-Apply the missing 4-ULP allowance in remaining ``sin``/``cos`` tests, and
-skip tests where NumPy < 1.25 error cannot be matched by relative ULP
-comparison.
+Follow-up to PR #10572, which added a 4-ULP allowance for NumPy < 1.25
+``sin``/``cos`` on Linux x86_64. Apply that allowance in the remaining tests
+that were missed, and skip tests where the NumPy < 1.25 error cannot be
+matched by relative ULP comparison.

--- a/docs/upcoming_changes/10786.change.rst
+++ b/docs/upcoming_changes/10786.change.rst
@@ -1,0 +1,6 @@
+Relax NumPy ``sin``/``cos`` test comparisons on Linux x86_64 with NumPy < 1.25
+------------------------------------------------------------------------------
+
+Apply the missing 4-ULP allowance in remaining ``sin``/``cos`` tests, and
+skip tests where NumPy < 1.25 error cannot be matched by relative ULP
+comparison.

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -687,7 +687,9 @@ class TestPandasLike(TestCase):
         self.assertIsInstance(ss, Series)
         self.assertIsInstance(ss._index, Index)
         self.assertIs(ss._index._data, i._data)
-        self.assertPreciseEqual(ss._values, np.cos(np.sin(s._values)))
+        ulps = 4 if numpy_sincos_low_precision else 1
+        self.assertPreciseEqual(ss._values, np.cos(np.sin(s._values)),
+                                prec='double', ulps=ulps)
 
     def test_series_constructor(self):
         i = Index(np.int32([42, 8, -5]))

--- a/numba/tests/test_looplifting.py
+++ b/numba/tests/test_looplifting.py
@@ -534,7 +534,9 @@ class TestLoopLiftingInAction(MemoryLeakMixin, TestCase):
         # Ensure that is really a new overload for the lifted loop
         self.assertEqual(len(lifted.signatures), 2)
 
-
+    # Repeated sin/cos in this loop lets NumPy<1.25 error grow past ULP tolerance.
+    @unittest.skipIf(numpy_sincos_low_precision,
+                     "NumPy<1.25 sincos vs libm")
     def test_lift_objectmode_issue_4223(self):
         from numba import jit
 
@@ -551,13 +553,8 @@ class TestLoopLiftingInAction(MemoryLeakMixin, TestCase):
         kwargs = dict(a=1.7, b=1.7, c=0.6, d=1.2, x0=0, y0=0, n=200)
         got = foo(**kwargs)
         expected = foo.py_func(**kwargs)
-        ulps = 4 if numpy_sincos_low_precision else 1
-        self.assertPreciseEqual(
-            got[0], expected[0], prec='double', ulps=ulps,
-        )
-        self.assertPreciseEqual(
-            got[1], expected[1], prec='double', ulps=ulps,
-        )
+        self.assertPreciseEqual(got[0], expected[0])
+        self.assertPreciseEqual(got[1], expected[1])
         [lifted] = foo.overloads[foo.signatures[0]].lifted
         self.assertEqual(len(lifted.nopython_signatures), 1)
 

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -5732,17 +5732,17 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
                 np_nbfunc(condlist, choicelist, default)
             self.assertIn(expected_text, str(e.exception))
 
+    # Near-zero window endpoints differ in sign under NumPy<1.25 sincos.
+    @unittest.skipIf(numpy_sincos_low_precision,
+                     "NumPy<1.25 sincos vs libm")
     def test_windowing(self):
         def check_window(func):
             np_pyfunc = func
             np_nbfunc = njit(func)
-            ulps = 4 if numpy_sincos_low_precision else 1
-
             for M in [0, 1, 5, 12]:
                 expected = np_pyfunc(M)
                 got = np_nbfunc(M)
-                self.assertPreciseEqual(expected, got, prec='double',
-                                        ulps=ulps)
+                self.assertPreciseEqual(expected, got, prec='double')
 
             for M in ['a', 1.1, 1j]:
                 with self.assertRaises(TypingError) as raises:

--- a/numba/tests/test_target_extension.py
+++ b/numba/tests/test_target_extension.py
@@ -888,7 +888,9 @@ class TestTargetOffload(TestCase):
         def foo(x):
             return np.sin(x), np.cos(x)  # np.sin is DPU, np.cos is CPU
 
-        self.assertPreciseEqual(foo(5), (314159.0, np.cos(5)))
+        self.assertPreciseEqual(
+            foo(5), (314159.0, np.cos(5)), prec='double', ulps=ulps,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #10572 for remaining CI failures on Linux x86_64 with NumPy < 1.25.

#10572 added a 4-ULP allowance for `numpy_sincos_low_precision`, but two asserts were missed and two tests still fail under that budget:

- `test_series_ufunc` and `test_basic_offload` now use the same `ulps = 4 if numpy_sincos_low_precision else 1` check.
- `test_windowing` is skipped: near-zero blackman endpoints differ in sign (`4e-17` vs `-1e-17`), which relative ULP comparison cannot match.
- `test_lift_objectmode_issue_4223` is skipped: repeated sin/cos in that loop lets the NumPy < 1.25 error grow past ULP tolerance.

Strict comparison is unchanged everywhere else.

Fixes #10571

Assisted-by: Kilo (Grok 4.6)