### PR TITLE
Test CUDA datetime/timedelta with more units and document CUDA support

### DIFF
--- a/docs/source/cuda/cudapysupported.rst
+++ b/docs/source/cuda/cudapysupported.rst
@@ -132,12 +132,22 @@ The following built-in types support are inherited from CPU nopython mode.
 * None
 * tuple
 * Enum, IntEnum
+* NumPy scalars, including :class:`numpy.datetime64` and
+  :class:`numpy.timedelta64` of any unit
 
 See :ref:`nopython built-in types <pysupported-builtin-types>`.
 
 There is also some very limited support for character sequences (bytes and
 unicode strings) used in NumPy arrays. Note that this support can only be used
 with CUDA 11.2 onwards.
+
+``datetime64`` and ``timedelta64`` values and arrays can be used in kernels
+and device functions in the same way as on the CPU - arithmetic, comparison
+and viewing the underlying integer representation (via ``.view(np.int64)``)
+are all supported, as are ufuncs and generalized ufuncs (created with
+:func:`numba.vectorize` and :func:`numba.guvectorize`) with ``target='cuda'``
+over ``datetime64`` and ``timedelta64`` operands. See
+:ref:`cuda_numpy_support` for more on NumPy support in CUDA kernels.
 
 Built-in functions
 ==================

--- a/docs/upcoming_changes/10787.doc.rst
+++ b/docs/upcoming_changes/10787.doc.rst
@@ -1,0 +1,7 @@
+Document and test ``datetime64``/``timedelta64`` support on CUDA
+----------------------------------------------------------------
+
+The CUDA documentation now explicitly states that ``datetime64`` and
+``timedelta64`` (of any unit) are supported in kernels, device functions,
+and ``target='cuda'`` ufuncs/gufuncs. The CUDA datetime test suite has also
+been extended to cover more units than just ``datetime64[D]``.

--- a/numba/cuda/tests/cudapy/test_datetime.py
+++ b/numba/cuda/tests/cudapy/test_datetime.py
@@ -6,20 +6,33 @@ from numba.cuda.testing import CUDATestCase, skip_on_cudasim
 import unittest
 
 
+# Datetime/timedelta units exercised by the tests below. This covers both
+# calendar-based units (Y, M) and units with a fixed conversion factor (D
+# and finer) - see issue #5530, which reported that only datetime64[D] was
+# tested on CUDA.
+DATETIME_UNITS = ('Y', 'M', 'D', 'h', 'm', 's', 'ms', 'us', 'ns')
+
+
 class TestCudaDateTime(CUDATestCase):
+    def _datetime_array(self, unit):
+        arr = np.arange('2005-02', '2006-02', dtype='datetime64[D]')
+        return arr.astype('datetime64[%s]' % unit)
+
     def test_basic_datetime_kernel(self):
         @cuda.jit
         def foo(start, end, delta):
             for i in range(cuda.grid(1), delta.size, cuda.gridsize(1)):
                 delta[i] = end[i] - start[i]
 
-        arr1 = np.arange('2005-02', '2006-02', dtype='datetime64[D]')
-        arr2 = arr1 + np.random.randint(0, 10000, arr1.size)
-        delta = np.zeros_like(arr1, dtype='timedelta64[D]')
+        for unit in DATETIME_UNITS:
+            with self.subTest(unit=unit):
+                arr1 = self._datetime_array(unit)
+                arr2 = arr1 + np.random.randint(0, 10000, arr1.size)
+                delta = np.zeros_like(arr1, dtype='timedelta64[%s]' % unit)
 
-        foo[1, 32](arr1, arr2, delta)
+                foo[1, 32](arr1, arr2, delta)
 
-        self.assertPreciseEqual(delta, arr2 - arr1)
+                self.assertPreciseEqual(delta, arr2 - arr1)
 
     def test_scalar_datetime_kernel(self):
         @cuda.jit
@@ -27,67 +40,85 @@ class TestCudaDateTime(CUDATestCase):
             for i in range(cuda.grid(1), matches.size, cuda.gridsize(1)):
                 matches[i] = dates[i] == target
                 outdelta[i] = dates[i] - delta
-        arr1 = np.arange('2005-02', '2006-02', dtype='datetime64[D]')
-        target = arr1[5]           # datetime
-        delta = arr1[6] - arr1[5]  # timedelta
-        matches = np.zeros_like(arr1, dtype=np.bool_)
-        outdelta = np.zeros_like(arr1, dtype='datetime64[D]')
 
-        foo[1, 32](arr1, target, delta, matches, outdelta)
-        where = matches.nonzero()
+        for unit in DATETIME_UNITS:
+            with self.subTest(unit=unit):
+                arr1 = self._datetime_array(unit)
+                target = arr1[5]           # datetime
+                delta = arr1[6] - arr1[5]  # timedelta
+                matches = np.zeros_like(arr1, dtype=np.bool_)
+                outdelta = np.zeros_like(arr1, dtype='datetime64[%s]' % unit)
 
-        self.assertEqual(list(where), [5])
-        self.assertPreciseEqual(outdelta, arr1 - delta)
+                foo[1, 32](arr1, target, delta, matches, outdelta)
+
+                # Coarser units (e.g. Y, M) can map multiple entries of
+                # arr1 onto the same value as target, so compare against
+                # the full expected match array rather than assuming a
+                # single match at index 5.
+                self.assertPreciseEqual(matches, arr1 == target)
+                self.assertPreciseEqual(outdelta, arr1 - delta)
 
     @skip_on_cudasim('ufunc API unsupported in the simulator')
     def test_ufunc(self):
-        datetime_t = from_dtype(np.dtype('datetime64[D]'))
+        for unit in DATETIME_UNITS:
+            with self.subTest(unit=unit):
+                datetime_t = from_dtype(np.dtype('datetime64[%s]' % unit))
 
-        @vectorize([(datetime_t, datetime_t)], target='cuda')
-        def timediff(start, end):
-            return end - start
+                @vectorize([(datetime_t, datetime_t)], target='cuda')
+                def timediff(start, end):
+                    return end - start
 
-        arr1 = np.arange('2005-02', '2006-02', dtype='datetime64[D]')
-        arr2 = arr1 + np.random.randint(0, 10000, arr1.size)
+                arr1 = self._datetime_array(unit)
+                arr2 = arr1 + np.random.randint(0, 10000, arr1.size)
 
-        delta = timediff(arr1, arr2)
+                delta = timediff(arr1, arr2)
 
-        self.assertPreciseEqual(delta, arr2 - arr1)
+                self.assertPreciseEqual(delta, arr2 - arr1)
 
     @skip_on_cudasim('ufunc API unsupported in the simulator')
     def test_gufunc(self):
-        datetime_t = from_dtype(np.dtype('datetime64[D]'))
-        timedelta_t = from_dtype(np.dtype('timedelta64[D]'))
+        for unit in DATETIME_UNITS:
+            with self.subTest(unit=unit):
+                datetime_t = from_dtype(np.dtype('datetime64[%s]' % unit))
+                timedelta_t = from_dtype(np.dtype('timedelta64[%s]' % unit))
 
-        @guvectorize([(datetime_t, datetime_t, timedelta_t[:])], '(),()->()',
-                     target='cuda')
-        def timediff(start, end, out):
-            out[0] = end - start
+                @guvectorize(
+                    [(datetime_t, datetime_t, timedelta_t[:])],
+                    '(),()->()', target='cuda')
+                def timediff(start, end, out):
+                    out[0] = end - start
 
-        arr1 = np.arange('2005-02', '2006-02', dtype='datetime64[D]')
-        arr2 = arr1 + np.random.randint(0, 10000, arr1.size)
+                arr1 = self._datetime_array(unit)
+                arr2 = arr1 + np.random.randint(0, 10000, arr1.size)
 
-        delta = timediff(arr1, arr2)
+                delta = timediff(arr1, arr2)
 
-        self.assertPreciseEqual(delta, arr2 - arr1)
+                self.assertPreciseEqual(delta, arr2 - arr1)
 
     @skip_on_cudasim('no .copy_to_host() in the simulator')
     def test_datetime_view_as_int64(self):
-        arr = np.arange('2005-02', '2006-02', dtype='datetime64[D]')
-        darr = cuda.to_device(arr)
-        viewed = darr.view(np.int64)
-        self.assertPreciseEqual(arr.view(np.int64), viewed.copy_to_host())
-        self.assertEqual(viewed.gpu_data, darr.gpu_data)
+        for unit in DATETIME_UNITS:
+            with self.subTest(unit=unit):
+                arr = self._datetime_array(unit)
+                darr = cuda.to_device(arr)
+                viewed = darr.view(np.int64)
+                self.assertPreciseEqual(
+                    arr.view(np.int64), viewed.copy_to_host())
+                self.assertEqual(viewed.gpu_data, darr.gpu_data)
 
     @skip_on_cudasim('no .copy_to_host() in the simulator')
     def test_timedelta_view_as_int64(self):
-        arr = np.arange('2005-02', '2006-02', dtype='datetime64[D]')
-        arr = arr - (arr - 1)
-        self.assertEqual(arr.dtype, np.dtype('timedelta64[D]'))
-        darr = cuda.to_device(arr)
-        viewed = darr.view(np.int64)
-        self.assertPreciseEqual(arr.view(np.int64), viewed.copy_to_host())
-        self.assertEqual(viewed.gpu_data, darr.gpu_data)
+        for unit in DATETIME_UNITS:
+            with self.subTest(unit=unit):
+                arr = self._datetime_array(unit)
+                arr = arr - (arr - 1)
+                self.assertEqual(
+                    arr.dtype, np.dtype('timedelta64[%s]' % unit))
+                darr = cuda.to_device(arr)
+                viewed = darr.view(np.int64)
+                self.assertPreciseEqual(
+                    arr.view(np.int64), viewed.copy_to_host())
+                self.assertEqual(viewed.gpu_data, darr.gpu_data)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Fixes #5530, which reported two issues:

1. `numba.cuda.tests.cudapy.test_datetime` only tested `datetime64[D]` / `timedelta64[D]`.
2. There was no mention in the docs that datetime/timedelta types are supported on CUDA.

This PR addresses both:

- Parametrizes the existing CUDA datetime tests over a representative set of units - `Y`, `M`, `D`, `h`, `m`, `s`, `ms`, `us`, `ns` - covering both calendar-based units (`Y`, `M`) and units with a fixed conversion factor (`D` and finer), rather than adding new test methods, to keep the diff minimal.
- Adds an explicit note to `docs/source/cuda/cudapysupported.rst` that `datetime64`/`timedelta64` (of any unit) are supported in CUDA kernels and device functions, and in `vectorize`/`guvectorize` with `target='cuda'`.

## Test plan

- [x] Ran the updated `test_basic_datetime_kernel` and `test_scalar_datetime_kernel` under `NUMBA_ENABLE_CUDASIM=1` - both pass across all 9 units.
- [x] `test_ufunc`, `test_gufunc`, `test_datetime_view_as_int64`, and `test_timedelta_view_as_int64` are skipped under the simulator (as before) since they need real GPU hardware/`.copy_to_host()`. I don't have access to CUDA hardware to run these directly, so I'd appreciate CI/a maintainer confirming these pass on a real GPU across the added units.
- [x] `flake8 --max-line-length=79` passes on the modified test file.
- [x] Sanity-checked the RST additions parse without structural errors (docutils, ignoring expected "unknown Sphinx role" noise for `:func:`/`:class:`/`:ref:`, which is consistent with the rest of the file).

I'll follow up with a `docs/upcoming_changes/<PR#>.doc.rst` changelog fragment once this PR has a number.

---

**Tool use disclosure**: This PR was prepared with the assistance of Claude (Anthropic), per numba's [AI Tool Use Policy](https://numba.readthedocs.io/en/stable/reference/ai_tools_policy.html). #5530 is not labelled `good first issue`. All claims in this description (test results, lint output, etc.) were generated and checked by running the stated commands, not asserted.
