### PR TITLE
Document object identity behavior in nopython mode

### DIFF
--- a/docs/source/reference/pysemantics.rst
+++ b/docs/source/reference/pysemantics.rst
@@ -86,3 +86,76 @@ implementation, all variables are zero-initialized. Example::
         print(i) # will print 0 and not raise UnboundLocalError
 
     foo()
+
+
+Object identity
+---------------
+
+In :term:`nopython mode`, values are converted ("boxed") from their native
+representation back into Python objects whenever they cross the boundary
+from compiled code to the interpreter, such as when a jitted function
+returns. Numba does not generally preserve Python object identity across
+this boundary - if the same value is returned more than once, each
+occurrence may be boxed into a *different* Python object::
+
+    from numba import njit
+
+    @njit
+    def f():
+        a = [1, 2, 3]
+        return a, a
+
+    x, y = f()
+    x is y  # False
+
+This applies to values created inside a jitted function, regardless of
+their type - arrays, :ref:`@jitclass <jitclass>` instances, lists, sets,
+and scalars are all affected.
+
+.. warning::
+   For arrays and jitclass instances, two boxed objects that are not
+   identical (``x is y`` is ``False``) can nonetheless refer to the *same*
+   underlying memory, because the underlying buffer is not copied when
+   boxing occurs more than once for the same value::
+
+       import numpy as np
+
+       @njit
+       def f_returning_array_twice():
+           arr = np.array([1, 2, 3])
+           return arr, arr
+
+       x, y = f_returning_array_twice()
+       x is y      # False
+       x[0] = 99
+       y[0]        # 99 - the underlying buffer is shared
+
+   This means ``is`` cannot be used to reliably check whether two arrays
+   or jitclass instances returned from a jitted function alias the same
+   memory; use :func:`numpy.shares_memory` for arrays instead.
+
+   Lists and sets do not share this behavior - independently boxed copies
+   of a list or set created inside a jitted function do not share
+   underlying storage, so mutating one does not affect the other.
+
+A value that is *passed into* a jitted function as an argument is not
+re-boxed on return - if it is returned unchanged, the exact same Python
+object that was passed in is returned::
+
+    @njit
+    def identity(x):
+        return x
+
+    original = [1, 2, 3]
+    identity(original) is original  # True
+
+Numba's implementation of the ``is`` operator also differs from CPython's
+for immutable types (such as integers, floats, and tuples of immutable
+values): it compares by value rather than by identity, which can produce
+results that CPython does not guarantee for non-cached objects::
+
+    @njit
+    def same(u, v):
+        return u is v
+
+    same(666, 666)  # True in Numba; not guaranteed by CPython

--- a/docs/upcoming_changes/10788.doc.rst
+++ b/docs/upcoming_changes/10788.doc.rst
@@ -1,0 +1,8 @@
+Document object identity behavior in nopython mode
+--------------------------------------------------
+
+The "Deviations from Python Semantics" reference page now documents that
+Numba does not generally preserve Python object identity across the
+boundary of a jitted function - including a caveat that arrays and
+``jitclass`` instances can still share underlying memory despite not
+being ``is``-identical.


### PR DESCRIPTION
## Summary

Fixes #3639, which reported that returning the same object more than once from a jitted function (e.g. in a tuple) produces separate Python objects on the other side, rather than preserving identity as plain Python would. The reporter suggested this was "probably more of a documentation issue," and a follow-up comment from @asodeur collected several related deviations and volunteered to write this section but it looks like that never landed.

Adds a new "Object identity" section to `docs/source/reference/pysemantics.rst` (Deviations from Python Semantics) covering:

- Values created inside a jitted function are independently re-boxed each time they're returned, so `x, y = f()` where `f` returns the same variable twice gives `x is y == False`.
- A caveat I found while verifying this that seemed worth documenting alongside it: for arrays and jitclass instances specifically, the two boxed objects, despite not being identical, can still share the same underlying memory - mutating one is visible through the other. This means `is` can't be used to check whether two returned arrays alias memory; `numpy.shares_memory` should be used instead. Lists/sets don't share this behavior (independent copies).
- Values passed in as arguments and returned unchanged keep their original identity.
- Numba's `is` operator compares immutable types (ints, floats, etc.) by value rather than identity, which can diverge from CPython's behavior for non-cached objects.

## Test plan

- [x] Every code example in the new section was extracted into a standalone script and run against a real `numba==0.67.0` install to confirm the exact behavior described (including the array/jitclass memory-sharing caveat, which I verified explicitly rather than assuming).
- [x] Parsed the modified file with `docutils` to check for RST structural errors (ignoring expected "unknown Sphinx role" noise for `:ref:`/`:func:`/`:term:`, consistent with the rest of the file).
- [x] Confirmed the `:ref:`@jitclass <jitclass>`` target exists (`docs/source/user/jitclass.rst`).