### PR TITLE
FIX:  Use signext on numba_ldexp's exponent

### DIFF
--- a/docs/upcoming_changes/10789.bug_fix.rst
+++ b/docs/upcoming_changes/10789.bug_fix.rst
@@ -1,0 +1,10 @@
+Fix ``math.ldexp`` and ``np.ldexp`` with negative exponents on PowerPC64LE
+--------------------------------------------------------------------------
+
+The exponent argument of the ``numba_ldexp`` and ``numba_ldexpf`` helpers is a
+C ``int``, and ABIs such as PowerPC64LE ELFv2 require the caller to sign-extend
+it into the full argument register. The declaration Numba emitted used a bare
+``i32`` parameter, which carries no signedness, so LLVM did not sign-extend it
+and a negative exponent reached the callee as a large positive one. Both
+lowerings, for ``math.ldexp`` and for the ``np.ldexp`` ufunc, now mark the
+exponent parameter ``signext``.

--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -94,24 +94,8 @@ numba_urem(uint64_t a, uint64_t b) {
 /* provide frexp and ldexp; these wrappers deal with special cases
  * (zero, nan, infinity) directly, to sidestep platform differences.
  */
-/* NOTE(ppc64le workaround, numba#8489, llvm/llvm-project#214260): the
- * parameter order below is (int/pointer, float) rather than the more
- * natural (float, int/pointer). This works around an LLVM PowerPC64LE
- * ELFv2 ABI-lowering bug: when a JIT-compiled caller passes a
- * float/double parameter before an integer/pointer parameter, LLVM
- * incorrectly shadows an extra GPR slot for the float argument,
- * shifting the following integer argument's register by one position.
- * AOT/GCC-compiled callees (these functions) use the true ABI register
- * instead, so the JIT caller and this callee disagree on which
- * register carries the integer argument, producing a garbage value
- * (observed as `math.ldexp` returning `inf` on ppc64le). Putting the
- * integer/pointer parameter first avoids the erroneous shadow
- * entirely, since no float parameter precedes it. The corresponding
- * LLVM IR call-site changes are in numba/cpython/mathimpl.py's
- * frexp_impl/ldexp_impl.
- */
 NUMBA_EXPORT_FUNC(double)
-numba_frexp(int *exp, double x)
+numba_frexp(double x, int *exp)
 {
     if (!Py_IS_FINITE(x) || !x)
         *exp = 0;
@@ -121,7 +105,7 @@ numba_frexp(int *exp, double x)
 }
 
 NUMBA_EXPORT_FUNC(float)
-numba_frexpf(int *exp, float x)
+numba_frexpf(float x, int *exp)
 {
     if (Py_IS_NAN(x) || Py_IS_INFINITY(x) || !x)
         *exp = 0;

--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -94,8 +94,24 @@ numba_urem(uint64_t a, uint64_t b) {
 /* provide frexp and ldexp; these wrappers deal with special cases
  * (zero, nan, infinity) directly, to sidestep platform differences.
  */
+/* NOTE(ppc64le workaround, numba#8489, llvm/llvm-project#214260): the
+ * parameter order below is (int/pointer, float) rather than the more
+ * natural (float, int/pointer). This works around an LLVM PowerPC64LE
+ * ELFv2 ABI-lowering bug: when a JIT-compiled caller passes a
+ * float/double parameter before an integer/pointer parameter, LLVM
+ * incorrectly shadows an extra GPR slot for the float argument,
+ * shifting the following integer argument's register by one position.
+ * AOT/GCC-compiled callees (these functions) use the true ABI register
+ * instead, so the JIT caller and this callee disagree on which
+ * register carries the integer argument, producing a garbage value
+ * (observed as `math.ldexp` returning `inf` on ppc64le). Putting the
+ * integer/pointer parameter first avoids the erroneous shadow
+ * entirely, since no float parameter precedes it. The corresponding
+ * LLVM IR call-site changes are in numba/cpython/mathimpl.py's
+ * frexp_impl/ldexp_impl.
+ */
 NUMBA_EXPORT_FUNC(double)
-numba_frexp(double x, int *exp)
+numba_frexp(int *exp, double x)
 {
     if (!Py_IS_FINITE(x) || !x)
         *exp = 0;
@@ -105,7 +121,7 @@ numba_frexp(double x, int *exp)
 }
 
 NUMBA_EXPORT_FUNC(float)
-numba_frexpf(float x, int *exp)
+numba_frexpf(int *exp, float x)
 {
     if (Py_IS_NAN(x) || Py_IS_INFINITY(x) || !x)
         *exp = 0;

--- a/numba/cpython/mathimpl.py
+++ b/numba/cpython/mathimpl.py
@@ -286,13 +286,11 @@ def ldexp_impl(context, builder, sig, args):
         "double": "numba_ldexp",
         }[str(fltty)]
     fn = cgutils.insert_pure_function(builder.module, fnty, name=fname)
-    # numba#8489: the exponent is a C `int`.  A bare i32 parameter
-    # carries no signedness, so LLVM zero-extends it into the 64-bit
-    # GPR, while the GCC-compiled helper produces and relies on
-    # sign-extension per the PowerPC64LE ELFv2 ABI (at -O2 it forwards
-    # the register untouched).  A negative exponent then arrives as a
-    # huge positive one and ldexp saturates to inf.  `signext` makes
-    # LLVM emit the sign-extending form and match the callee.
+    # The exponent is a C `int`, and ABIs such as PowerPC64LE ELFv2
+    # require the caller to sign-extend it into the full argument
+    # register.  A bare i32 parameter carries no signedness, so LLVM
+    # does not, and a negative exponent reaches the callee as a large
+    # positive one.  See issue #8489.
     fn.args[1].add_attribute('signext')
     res = builder.call(fn, (val, exp))
     return impl_ret_untracked(context, builder, sig.return_type, res)

--- a/numba/cpython/mathimpl.py
+++ b/numba/cpython/mathimpl.py
@@ -265,29 +265,55 @@ def frexp_impl(context, builder, sig, args):
     fltty = context.get_data_type(sig.args[0])
     intty = context.get_data_type(sig.return_type[1])
     expptr = cgutils.alloca_once(builder, intty, name='exp')
-    fnty = llvmlite.ir.FunctionType(fltty, (fltty, llvmlite.ir.PointerType(intty)))
+    # Pointer parameter first: see numba_frexp's comment in _helperlib.c
+    # (ppc64le ABI-lowering workaround, numba#8489).
+    fnty = llvmlite.ir.FunctionType(fltty, (llvmlite.ir.PointerType(intty), fltty))
     fname = {
         "float": "numba_frexpf",
         "double": "numba_frexp",
         }[str(fltty)]
     fn = cgutils.get_or_insert_function(builder.module, fnty, fname)
-    res = builder.call(fn, (val, expptr))
+    res = builder.call(fn, (expptr, val))
     res = cgutils.make_anonymous_struct(builder, (res, builder.load(expptr)))
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 
+def _ldexp_impl(x, n):
+    # Avoids a native (double, int) extern call whose argument shape
+    # triggers a PPC64LE LLVM ABI-lowering bug (numba#8489) at numba's
+    # OWN JIT function-call boundary (see numba/core/callconv.py --
+    # every jitted function's own argument list is passed in its
+    # natural declared order, so no call-site reordering can fix a
+    # bug baked into math.ldexp's own (x, exp) signature). Instead,
+    # avoid crossing any such call boundary at all: clamp n into a
+    # safe range wide enough to span the full subnormal-to-overflow
+    # exponent range of a double (~2097 steps in either direction),
+    # then apply repeated doubling/halving -- IEEE 754 float
+    # multiplication naturally produces correct overflow-to-inf,
+    # gradual-underflow-through-subnormals, and flush-to-zero
+    # behaviour at each individual step.
+    if not math.isfinite(x) or x == 0.0 or n == 0:
+        return x
+    if n > 2100:
+        n = 2100
+    elif n < -2100:
+        n = -2100
+    if n > 0:
+        for _ in range(n):
+            x = x * 2.0
+            if not math.isfinite(x):
+                break
+    else:
+        for _ in range(-n):
+            x = x * 0.5
+            if x == 0.0:
+                break
+    return x
+
+
 @lower(math.ldexp, types.Float, types.intc)
 def ldexp_impl(context, builder, sig, args):
-    val, exp = args
-    fltty, intty = map(context.get_data_type, sig.args)
-    fnty = llvmlite.ir.FunctionType(fltty, (fltty, intty))
-    fname = {
-        "float": "numba_ldexpf",
-        "double": "numba_ldexp",
-        }[str(fltty)]
-    fn = cgutils.insert_pure_function(builder.module, fnty, name=fname)
-    res = builder.call(fn, (val, exp))
-    return impl_ret_untracked(context, builder, sig.return_type, res)
+    return context.compile_internal(builder, _ldexp_impl, sig, args)
 
 
 # -----------------------------------------------------------------------------

--- a/numba/cpython/mathimpl.py
+++ b/numba/cpython/mathimpl.py
@@ -265,55 +265,37 @@ def frexp_impl(context, builder, sig, args):
     fltty = context.get_data_type(sig.args[0])
     intty = context.get_data_type(sig.return_type[1])
     expptr = cgutils.alloca_once(builder, intty, name='exp')
-    # Pointer parameter first: see numba_frexp's comment in _helperlib.c
-    # (ppc64le ABI-lowering workaround, numba#8489).
-    fnty = llvmlite.ir.FunctionType(fltty, (llvmlite.ir.PointerType(intty), fltty))
+    fnty = llvmlite.ir.FunctionType(fltty, (fltty, llvmlite.ir.PointerType(intty)))
     fname = {
         "float": "numba_frexpf",
         "double": "numba_frexp",
         }[str(fltty)]
     fn = cgutils.get_or_insert_function(builder.module, fnty, fname)
-    res = builder.call(fn, (expptr, val))
+    res = builder.call(fn, (val, expptr))
     res = cgutils.make_anonymous_struct(builder, (res, builder.load(expptr)))
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 
-def _ldexp_impl(x, n):
-    # Avoids a native (double, int) extern call whose argument shape
-    # triggers a PPC64LE LLVM ABI-lowering bug (numba#8489) at numba's
-    # OWN JIT function-call boundary (see numba/core/callconv.py --
-    # every jitted function's own argument list is passed in its
-    # natural declared order, so no call-site reordering can fix a
-    # bug baked into math.ldexp's own (x, exp) signature). Instead,
-    # avoid crossing any such call boundary at all: clamp n into a
-    # safe range wide enough to span the full subnormal-to-overflow
-    # exponent range of a double (~2097 steps in either direction),
-    # then apply repeated doubling/halving -- IEEE 754 float
-    # multiplication naturally produces correct overflow-to-inf,
-    # gradual-underflow-through-subnormals, and flush-to-zero
-    # behaviour at each individual step.
-    if not math.isfinite(x) or x == 0.0 or n == 0:
-        return x
-    if n > 2100:
-        n = 2100
-    elif n < -2100:
-        n = -2100
-    if n > 0:
-        for _ in range(n):
-            x = x * 2.0
-            if not math.isfinite(x):
-                break
-    else:
-        for _ in range(-n):
-            x = x * 0.5
-            if x == 0.0:
-                break
-    return x
-
-
 @lower(math.ldexp, types.Float, types.intc)
 def ldexp_impl(context, builder, sig, args):
-    return context.compile_internal(builder, _ldexp_impl, sig, args)
+    val, exp = args
+    fltty, intty = map(context.get_data_type, sig.args)
+    fnty = llvmlite.ir.FunctionType(fltty, (fltty, intty))
+    fname = {
+        "float": "numba_ldexpf",
+        "double": "numba_ldexp",
+        }[str(fltty)]
+    fn = cgutils.insert_pure_function(builder.module, fnty, name=fname)
+    # numba#8489: the exponent is a C `int`.  A bare i32 parameter
+    # carries no signedness, so LLVM zero-extends it into the 64-bit
+    # GPR, while the GCC-compiled helper produces and relies on
+    # sign-extension per the PowerPC64LE ELFv2 ABI (at -O2 it forwards
+    # the register untouched).  A negative exponent then arrives as a
+    # huge positive one and ldexp saturates to inf.  `signext` makes
+    # LLVM emit the sign-extending form and match the callee.
+    fn.args[1].add_attribute('signext')
+    res = builder.call(fn, (val, exp))
+    return impl_ret_untracked(context, builder, sig.return_type, res)
 
 
 # -----------------------------------------------------------------------------

--- a/numba/np/math/mathimpl.py
+++ b/numba/np/math/mathimpl.py
@@ -276,6 +276,10 @@ def frexp_impl(context, builder, sig, args):
 
 # @lower(math.ldexp, types.Float, types.intc)
 def ldexp_impl(context, builder, sig, args):
+    # Reached from numba.np.npyfuncs.np_real_ldexp_impl, i.e. the
+    # np.ldexp ufunc path.  It makes the same extern call as
+    # numba.cpython.mathimpl.ldexp_impl and needs the same `signext` on
+    # the exponent - see the comment there (numba#8489).
     val, exp = args
     fltty, intty = map(context.get_data_type, sig.args)
     fnty = llvmlite.ir.FunctionType(fltty, (fltty, intty))
@@ -284,6 +288,7 @@ def ldexp_impl(context, builder, sig, args):
         "double": "numba_ldexp",
         }[str(fltty)]
     fn = cgutils.insert_pure_function(builder.module, fnty, name=fname)
+    fn.args[1].add_attribute('signext')
     res = builder.call(fn, (val, exp))
     return impl_ret_untracked(context, builder, sig.return_type, res)
 

--- a/numba/np/math/mathimpl.py
+++ b/numba/np/math/mathimpl.py
@@ -276,10 +276,6 @@ def frexp_impl(context, builder, sig, args):
 
 # @lower(math.ldexp, types.Float, types.intc)
 def ldexp_impl(context, builder, sig, args):
-    # Reached from numba.np.npyfuncs.np_real_ldexp_impl, i.e. the
-    # np.ldexp ufunc path.  It makes the same extern call as
-    # numba.cpython.mathimpl.ldexp_impl and needs the same `signext` on
-    # the exponent - see the comment there (numba#8489).
     val, exp = args
     fltty, intty = map(context.get_data_type, sig.args)
     fnty = llvmlite.ir.FunctionType(fltty, (fltty, intty))
@@ -288,6 +284,8 @@ def ldexp_impl(context, builder, sig, args):
         "double": "numba_ldexp",
         }[str(fltty)]
     fn = cgutils.insert_pure_function(builder.module, fnty, name=fname)
+    # Same extern call as numba.cpython.mathimpl.ldexp_impl; see the
+    # comment there.
     fn.args[1].add_attribute('signext')
     res = builder.call(fn, (val, exp))
     return impl_ret_untracked(context, builder, sig.return_type, res)

--- a/numba/tests/test_mathlib.py
+++ b/numba/tests/test_mathlib.py
@@ -1,5 +1,6 @@
 import itertools
 import math
+import re
 import sys
 import unittest
 import warnings
@@ -170,6 +171,21 @@ def frexp(x):
 
 def ldexp(x, e):
     return math.ldexp(x, e)
+
+
+def frexp_ldexp_roundtrip(x):
+    m, e = math.frexp(x)
+    return math.ldexp(m, e)
+
+
+def np_ldexp(x, e):
+    return np.ldexp(x, e)
+
+
+# IEEE-754 double corners, named for readability in TestFrexpLdexp.
+DBL_TRUE_MIN = 5e-324                 # smallest positive subnormal
+DBL_MIN = 2.2250738585072014e-308     # smallest positive normal
+DBL_MAX = 1.7976931348623157e308
 
 
 def get_constants():
@@ -565,6 +581,196 @@ class TestMathLib(TestCase):
                          (float('nan'), 0)]:
                 msg = 'for input %r' % (args,)
                 self.assertPreciseEqual(cfunc(*args), pyfunc(*args))
+
+
+class TestFrexpLdexp(TestCase):
+    """
+    Corner-case coverage for math.frexp and math.ldexp.
+
+    These also guard the ppc64le fix for numba #8489.  A bare ``i32``
+    parameter on an extern declaration carries no signedness, so LLVM
+    zero-extends the exponent into the 64-bit GPR while the
+    GCC-compiled ``numba_ldexp`` relies on sign-extension per the
+    PowerPC64LE ELFv2 ABI.  A negative exponent therefore arrives as a
+    huge positive one and the result saturates to inf.  The many
+    negative exponents exercised below are what catch that at runtime;
+    ``test_ldexp_declaration_has_signext_exponent`` pins the mechanism
+    itself and needs no ppc64le host.
+    """
+
+    def test_frexp_wide_range(self):
+        pyfunc = frexp
+        cfunc = njit(pyfunc)
+        x_values = [1.0, -1.0, 0.5, -0.5, 2.5, -2.5, math.pi,
+                    123456789.0, 1e300, -1e300, 1e-300,
+                    DBL_MIN, -DBL_MIN, DBL_TRUE_MIN, -DBL_TRUE_MIN,
+                    DBL_MAX, -DBL_MAX,
+                    0.0, -0.0, float('inf'), float('-inf'), float('nan')]
+        for x in x_values:
+            self.assertPreciseEqual(cfunc(x), pyfunc(x),
+                                    msg='for input %r' % (x,))
+
+    def test_frexp_exponent_over_full_double_range(self):
+        # A wrong integer register shows up as a bogus exponent, so walk
+        # every exponent a double can produce, subnormals included.
+        cfunc = njit(frexp)
+        for e in range(-1073, 1025):
+            x = math.ldexp(0.75, e)
+            if x == 0.0 or math.isinf(x):
+                continue
+            self.assertEqual(cfunc(x)[1], math.frexp(x)[1],
+                             msg='for exponent %d' % (e,))
+
+    def test_frexp_float32(self):
+        # Exercises numba_frexpf, whose parameter order changed too.
+        cfunc = njit(frexp)
+        for v in [1.0, -1.0, 2.5, -2.5, 0.5, 1e30, -1e30, 1e-30,
+                  0.0, -0.0, float('inf'), float('-inf'), float('nan')]:
+            x = np.float32(v)
+            got_m, got_e = cfunc(x)
+            expected_m, expected_e = math.frexp(float(x))
+            self.assertPreciseEqual(got_m, np.float32(expected_m),
+                                    msg='mantissa for input %r' % (v,))
+            self.assertEqual(got_e, expected_e,
+                             msg='exponent for input %r' % (v,))
+
+    def test_ldexp_normal_range(self):
+        pyfunc = ldexp
+        cfunc = njit(pyfunc)
+        x_values = [1.0, -1.0, 0.5, -0.5, 2.5, -2.5, math.pi, -math.pi,
+                    0.7071067811865476, 1.9999999999999998, 1e100, 1e-100]
+        exponents = [-200, -64, -53, -10, -3, -1, 0, 1, 3, 10, 53, 64, 200]
+        for x in x_values:
+            for n in exponents:
+                self.assertPreciseEqual(cfunc(x, n), pyfunc(x, n),
+                                        msg='for input (%r, %r)' % (x, n))
+
+    def test_ldexp_special_values(self):
+        pyfunc = ldexp
+        cfunc = njit(pyfunc)
+        for x in [0.0, -0.0, float('inf'), float('-inf'), float('nan')]:
+            for n in [-1000, -1, 0, 1, 1000]:
+                self.assertPreciseEqual(cfunc(x, n), pyfunc(x, n),
+                                        msg='for input (%r, %r)' % (x, n))
+
+    def test_ldexp_overflows_to_inf(self):
+        # Numba saturates like C's ldexp; CPython raises OverflowError.
+        # Pin that intentional divergence so a change to the lowering
+        # cannot alter it unnoticed.
+        cfunc = njit(ldexp)
+        for x in [1.0, -1.0, DBL_MAX, -DBL_MAX]:
+            for n in [1200, 2000, 2100, 2101, 100000, 2 ** 31 - 1]:
+                self.assertPreciseEqual(cfunc(x, n),
+                                        math.copysign(float('inf'), x),
+                                        msg='for input (%r, %r)' % (x, n))
+                with self.assertRaises(OverflowError):
+                    math.ldexp(x, n)
+
+    def test_ldexp_underflows_to_signed_zero(self):
+        cfunc = njit(ldexp)
+        for x in [1.0, -1.0, DBL_MIN, -DBL_MIN, DBL_TRUE_MIN, -DBL_TRUE_MIN]:
+            for n in [-1200, -2000, -2100, -2101, -100000, -(2 ** 31)]:
+                self.assertPreciseEqual(cfunc(x, n), math.copysign(0.0, x),
+                                        msg='for input (%r, %r)' % (x, n))
+
+    def test_ldexp_huge_exponent_saturates(self):
+        # An exponent large enough to cross the entire double range must
+        # saturate rather than return a finite, wrong value.
+        cfunc = njit(ldexp)
+        self.assertPreciseEqual(cfunc(DBL_TRUE_MIN, 2100), float('inf'))
+        self.assertPreciseEqual(cfunc(-DBL_TRUE_MIN, 2100), float('-inf'))
+        self.assertPreciseEqual(cfunc(DBL_MAX, -2100), 0.0)
+        self.assertPreciseEqual(cfunc(-DBL_MAX, -2100), -0.0)
+
+    def test_ldexp_frexp_roundtrip(self):
+        # End-to-end check of both halves of the workaround: an exponent
+        # corrupted on either side of the ABI boundary breaks identity.
+        pyfunc = frexp_ldexp_roundtrip
+        cfunc = njit(pyfunc)
+        x_values = [1.0, -1.0, 2.5, -2.5, math.pi, 1e300, -1e300, 1e-300,
+                    DBL_MIN, DBL_MAX, DBL_TRUE_MIN, 3 * DBL_TRUE_MIN,
+                    11 * DBL_TRUE_MIN, 0.0, -0.0,
+                    float('inf'), float('-inf'), float('nan')]
+        for x in x_values:
+            self.assertPreciseEqual(cfunc(x), x, msg='for input %r' % (x,))
+
+    def test_ldexp_subnormal_results_are_correctly_rounded(self):
+        # Results landing in the subnormal range must be rounded once,
+        # the way math.ldexp rounds them.  Scaling by repeated halving
+        # rounds again at every step once the value is subnormal, so
+        # these inputs detect the accumulated double-rounding error.
+        cfunc = njit(ldexp)
+        cases = [(4.359607055276148e-151, -574),
+                 (-6.853580717782567e-197, -423),
+                 (7.162365283163292e-228, -319),
+                 (1.5259499737847772e-83, -796),
+                 (6.458979912260433e-06, -1048)]
+        for x, n in cases:
+            self.assertPreciseEqual(cfunc(x, n), math.ldexp(x, n),
+                                    msg='for input (%r, %r)' % (x, n))
+
+    def test_ldexp_float32(self):
+        cfunc = njit(ldexp)
+        for v in [1.0, -1.0, 2.5, -2.5, 0.5, 1e20, 1e-20]:
+            for n in [-40, -10, -1, 0, 1, 10, 40]:
+                x = np.float32(v)
+                self.assertPreciseEqual(
+                    cfunc(x, n), np.float32(math.ldexp(float(x), n)),
+                    msg='for input (%r, %r)' % (v, n))
+
+    def test_ldexp_declaration_has_signext_exponent(self):
+        # numba #8489.  Without `signext` LLVM zero-extends the exponent
+        # into the 64-bit GPR, while the GCC-compiled numba_ldexp relies
+        # on sign-extension, so ldexp(x, -2) becomes ldexp(x, 2**32 - 2)
+        # and returns inf on ppc64le.  The declaration is
+        # target-independent, so this pins the fix on any host.
+        #
+        # Four cases: both lowerings (math.ldexp via
+        # numba/cpython/mathimpl.py, np.ldexp via
+        # numba/np/math/mathimpl.py) times both helper symbols
+        # (numba_ldexp for float64, numba_ldexpf for float32).  The
+        # trailing \( in the pattern keeps numba_ldexp from matching
+        # numba_ldexpf.
+        cases = [(ldexp, 2.5, 'numba_ldexp'),
+                 (ldexp, np.float32(2.5), 'numba_ldexpf'),
+                 (np_ldexp, 2.5, 'numba_ldexp'),
+                 (np_ldexp, np.float32(2.5), 'numba_ldexpf')]
+        for pyfunc, x, symbol in cases:
+            cfunc = njit(pyfunc)
+            cfunc(x, 3)
+            llvm_ir = '\n'.join(cfunc.inspect_llvm().values())
+            match = re.search(
+                r'declare[^@\n]*@%s\(([^)]*)\)' % (symbol,), llvm_ir)
+            self.assertIsNotNone(
+                match,
+                msg='no %s declaration for %r' % (symbol, pyfunc))
+            params = [p.strip() for p in match.group(1).split(',')]
+            self.assertEqual(len(params), 2, msg=match.group(0))
+            self.assertIn('signext', params[1], msg=match.group(0))
+
+    def test_np_ldexp_matches_numpy(self):
+        # np.ldexp reaches its own lowering: numba/np/npyfuncs.py's
+        # np_real_ldexp_impl calls numba.np.math.mathimpl.ldexp_impl,
+        # a separate copy of the extern call that needs its own
+        # `signext`.  Cover it directly so the two cannot drift apart.
+        cfunc = njit(np_ldexp)
+
+        for v in [1.0, -1.0, 2.5, -2.5, math.pi, 1e100, 1e-100]:
+            for n in [-200, -53, -10, -1, 0, 1, 10, 53, 200]:
+                self.assertPreciseEqual(cfunc(v, n),
+                                        float(np.ldexp(v, n)),
+                                        msg='for input (%r, %r)' % (v, n))
+
+        # Subnormal results must be correctly rounded here too; NumPy's
+        # ldexp is the oracle.
+        for v, n in [(4.359607055276148e-151, -574),
+                     (-6.853580717782567e-197, -423),
+                     (7.162365283163292e-228, -319),
+                     (1.5259499737847772e-83, -796),
+                     (6.458979912260433e-06, -1048)]:
+            self.assertPreciseEqual(cfunc(v, n),
+                                    float(np.ldexp(v, n)),
+                                    msg='for input (%r, %r)' % (v, n))
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_mathlib.py
+++ b/numba/tests/test_mathlib.py
@@ -735,9 +735,18 @@ class TestFrexpLdexp(TestCase):
                  (ldexp, np.float32(2.5), 'numba_ldexpf'),
                  (np_ldexp, 2.5, 'numba_ldexp'),
                  (np_ldexp, np.float32(2.5), 'numba_ldexpf')]
+        # The exponent is np.int32 rather than a plain Python int: the
+        # np.ldexp ufunc only ever has int32 exponent loops on Windows
+        # with NumPy < 2.0 (C long is 32-bit there, so NumPy registers
+        # no wider loop), and ufunc typing requires a *safe* input cast,
+        # so an int64 exponent resolves to no loop at all.  See the
+        # IS_WIN32 remap of 'fl->f'/'dl->d' in numba/np/ufunc_db.py.
+        # int32 hits 'fi->f'/'di->d', which exist on every platform and
+        # NumPy version, and reaches the same np_real_ldexp_impl
+        # lowering, so the signext assertion below is unaffected.
         for pyfunc, x, symbol in cases:
             cfunc = njit(pyfunc)
-            cfunc(x, 3)
+            cfunc(x, np.int32(3))
             llvm_ir = '\n'.join(cfunc.inspect_llvm().values())
             match = re.search(
                 r'declare[^@\n]*@%s\(([^)]*)\)' % (symbol,), llvm_ir)
@@ -755,9 +764,11 @@ class TestFrexpLdexp(TestCase):
         # `signext`.  Cover it directly so the two cannot drift apart.
         cfunc = njit(np_ldexp)
 
+        # np.int32 exponents: see test_ldexp_declaration_has_signext_exponent
+        # for why a plain Python int is not portable here.
         for v in [1.0, -1.0, 2.5, -2.5, math.pi, 1e100, 1e-100]:
             for n in [-200, -53, -10, -1, 0, 1, 10, 53, 200]:
-                self.assertPreciseEqual(cfunc(v, n),
+                self.assertPreciseEqual(cfunc(v, np.int32(n)),
                                         float(np.ldexp(v, n)),
                                         msg='for input (%r, %r)' % (v, n))
 
@@ -768,7 +779,7 @@ class TestFrexpLdexp(TestCase):
                      (7.162365283163292e-228, -319),
                      (1.5259499737847772e-83, -796),
                      (6.458979912260433e-06, -1048)]:
-            self.assertPreciseEqual(cfunc(v, n),
+            self.assertPreciseEqual(cfunc(v, np.int32(n)),
                                     float(np.ldexp(v, n)),
                                     msg='for input (%r, %r)' % (v, n))
 

--- a/numba/tests/test_mathlib.py
+++ b/numba/tests/test_mathlib.py
@@ -584,20 +584,6 @@ class TestMathLib(TestCase):
 
 
 class TestFrexpLdexp(TestCase):
-    """
-    Corner-case coverage for math.frexp and math.ldexp.
-
-    These also guard the ppc64le fix for numba #8489.  A bare ``i32``
-    parameter on an extern declaration carries no signedness, so LLVM
-    zero-extends the exponent into the 64-bit GPR while the
-    GCC-compiled ``numba_ldexp`` relies on sign-extension per the
-    PowerPC64LE ELFv2 ABI.  A negative exponent therefore arrives as a
-    huge positive one and the result saturates to inf.  The many
-    negative exponents exercised below are what catch that at runtime;
-    ``test_ldexp_declaration_has_signext_exponent`` pins the mechanism
-    itself and needs no ppc64le host.
-    """
-
     def test_frexp_wide_range(self):
         pyfunc = frexp
         cfunc = njit(pyfunc)
@@ -611,8 +597,7 @@ class TestFrexpLdexp(TestCase):
                                     msg='for input %r' % (x,))
 
     def test_frexp_exponent_over_full_double_range(self):
-        # A wrong integer register shows up as a bogus exponent, so walk
-        # every exponent a double can produce, subnormals included.
+        # Walk every exponent a double can produce, subnormals included.
         cfunc = njit(frexp)
         for e in range(-1073, 1025):
             x = math.ldexp(0.75, e)
@@ -622,7 +607,7 @@ class TestFrexpLdexp(TestCase):
                              msg='for exponent %d' % (e,))
 
     def test_frexp_float32(self):
-        # Exercises numba_frexpf, whose parameter order changed too.
+        # Exercises the float32 helper, numba_frexpf.
         cfunc = njit(frexp)
         for v in [1.0, -1.0, 2.5, -2.5, 0.5, 1e30, -1e30, 1e-30,
                   0.0, -0.0, float('inf'), float('-inf'), float('nan')]:
@@ -655,8 +640,7 @@ class TestFrexpLdexp(TestCase):
 
     def test_ldexp_overflows_to_inf(self):
         # Numba saturates like C's ldexp; CPython raises OverflowError.
-        # Pin that intentional divergence so a change to the lowering
-        # cannot alter it unnoticed.
+        # Pin that intentional divergence.
         cfunc = njit(ldexp)
         for x in [1.0, -1.0, DBL_MAX, -DBL_MAX]:
             for n in [1200, 2000, 2100, 2101, 100000, 2 ** 31 - 1]:
@@ -683,8 +667,7 @@ class TestFrexpLdexp(TestCase):
         self.assertPreciseEqual(cfunc(-DBL_MAX, -2100), -0.0)
 
     def test_ldexp_frexp_roundtrip(self):
-        # End-to-end check of both halves of the workaround: an exponent
-        # corrupted on either side of the ABI boundary breaks identity.
+        # A corrupted exponent on either side breaks the identity.
         pyfunc = frexp_ldexp_roundtrip
         cfunc = njit(pyfunc)
         x_values = [1.0, -1.0, 2.5, -2.5, math.pi, 1e300, -1e300, 1e-300,
@@ -719,31 +702,19 @@ class TestFrexpLdexp(TestCase):
                     msg='for input (%r, %r)' % (v, n))
 
     def test_ldexp_declaration_has_signext_exponent(self):
-        # numba #8489.  Without `signext` LLVM zero-extends the exponent
-        # into the 64-bit GPR, while the GCC-compiled numba_ldexp relies
-        # on sign-extension, so ldexp(x, -2) becomes ldexp(x, 2**32 - 2)
-        # and returns inf on ppc64le.  The declaration is
-        # target-independent, so this pins the fix on any host.
-        #
-        # Four cases: both lowerings (math.ldexp via
-        # numba/cpython/mathimpl.py, np.ldexp via
-        # numba/np/math/mathimpl.py) times both helper symbols
-        # (numba_ldexp for float64, numba_ldexpf for float32).  The
-        # trailing \( in the pattern keeps numba_ldexp from matching
-        # numba_ldexpf.
+        # See issue #8489.  The declaration is target-independent, so
+        # this checks the signext on any host.  Both lowerings
+        # (math.ldexp, np.ldexp) times both helper symbols; the
+        # trailing \( in the pattern below keeps numba_ldexp from
+        # matching numba_ldexpf.
         cases = [(ldexp, 2.5, 'numba_ldexp'),
                  (ldexp, np.float32(2.5), 'numba_ldexpf'),
                  (np_ldexp, 2.5, 'numba_ldexp'),
                  (np_ldexp, np.float32(2.5), 'numba_ldexpf')]
-        # The exponent is np.int32 rather than a plain Python int: the
-        # np.ldexp ufunc only ever has int32 exponent loops on Windows
-        # with NumPy < 2.0 (C long is 32-bit there, so NumPy registers
-        # no wider loop), and ufunc typing requires a *safe* input cast,
-        # so an int64 exponent resolves to no loop at all.  See the
-        # IS_WIN32 remap of 'fl->f'/'dl->d' in numba/np/ufunc_db.py.
-        # int32 hits 'fi->f'/'di->d', which exist on every platform and
-        # NumPy version, and reaches the same np_real_ldexp_impl
-        # lowering, so the signext assertion below is unaffected.
+        # np.int32, not a plain int: on Windows with NumPy < 2.0 the
+        # np.ldexp ufunc has no int64 exponent loop, and ufunc typing
+        # requires a safe cast, so int64 resolves to no loop at all.
+        # See the IS_WIN32 remap in numba/np/ufunc_db.py.
         for pyfunc, x, symbol in cases:
             cfunc = njit(pyfunc)
             cfunc(x, np.int32(3))
@@ -758,22 +729,19 @@ class TestFrexpLdexp(TestCase):
             self.assertIn('signext', params[1], msg=match.group(0))
 
     def test_np_ldexp_matches_numpy(self):
-        # np.ldexp reaches its own lowering: numba/np/npyfuncs.py's
-        # np_real_ldexp_impl calls numba.np.math.mathimpl.ldexp_impl,
-        # a separate copy of the extern call that needs its own
-        # `signext`.  Cover it directly so the two cannot drift apart.
+        # np.ldexp goes through a separate copy of the extern call, in
+        # numba/np/math/mathimpl.py.  Cover it so the two cannot drift.
         cfunc = njit(np_ldexp)
 
-        # np.int32 exponents: see test_ldexp_declaration_has_signext_exponent
-        # for why a plain Python int is not portable here.
+        # np.int32 exponents: see
+        # test_ldexp_declaration_has_signext_exponent.
         for v in [1.0, -1.0, 2.5, -2.5, math.pi, 1e100, 1e-100]:
             for n in [-200, -53, -10, -1, 0, 1, 10, 53, 200]:
                 self.assertPreciseEqual(cfunc(v, np.int32(n)),
                                         float(np.ldexp(v, n)),
                                         msg='for input (%r, %r)' % (v, n))
 
-        # Subnormal results must be correctly rounded here too; NumPy's
-        # ldexp is the oracle.
+        # Subnormal results must be correctly rounded here too.
         for v, n in [(4.359607055276148e-151, -574),
                      (-6.853580717782567e-197, -423),
                      (7.162365283163292e-228, -319),


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
post to the Numba forum https://numba.discourse.group/.

Second, please ensure that you have read and understood Numba's AI tool use
policy: https://numba.readthedocs.io/en/stable/reference/ai_tools_policy.html

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
The real defect is argument extension. numba declares numba_ldexp{,f}
with a bare i32 exponent and no parameter attribute, so LLVM zero-extends
it (clrldi). The GCC-compiled helper takes a signed int and both produces
and relies on sign-extension (lwa; at -O2 it forwards the register
untouched). A negative exponent therefore arrives corrupted: -2 becomes
4294967294, and math.ldexp(2.5, -2) returns inf.

Marking the argument signext makes LLVM emit extsw, matching the ABI.
This restores the real libm ldexp call and leaves frexp at its pristine
signature -- its int* argument is a 64-bit pointer with no extension

llvm/llvm-project#214260 has been closed; there is no LLVM bug here.


Closes: https://github.com/numba/numba/issues/8489