### PR TITLE
Add axis argument support to np.mean, np.std and np.var

### DIFF
--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -1151,27 +1151,40 @@ def array_var(a, axis=None):
 
 @overload(np.std)
 @overload_method(types.Array, "std")
-def array_std(a):
+def array_std(a, axis=None):
+    if not (isinstance(axis, types.Integer) or
+            is_nonelike(axis) or (
+                isinstance(axis, types.UniTuple) and
+                isinstance(axis.dtype, types.Integer))
+            or (
+                isinstance(axis, types.Tuple) and
+                axis.count == 0)):
+        raise TypingError(
+            "NumPy std only supports integer axis value or tuple of integers"
+        )
+
     if isinstance(a, types.Array):
-        def array_std_impl(a):
-            return a.var() ** 0.5
+        # np.sqrt is a ufunc so it preserves the precision of the variance
+        # (unlike ``** 0.5`` which would promote float32 to float64).
+        def array_std_impl(a, axis=None):
+            return np.sqrt(a.var(axis=axis))
 
         return array_std_impl
 
     # Integers and booleans default to float64(0.0) in numpy.std
     elif isinstance(a, (types.Integer, types.Boolean)):
 
-        def std_scalar_integer_impl(a):
+        def std_scalar_integer_impl(a, axis=None):
             return np.float64(0.0)
         return std_scalar_integer_impl
 
     # Floats and numbers preserve types in numpy.std
     elif isinstance(a, (types.Float, types.Complex)):
-        out_dtype = as_dtype(getattr(a,'underlying_float',a))
+        out_dtype = as_dtype(getattr(a, 'underlying_float', a))
         zero = out_dtype.type(0)
         nan_val = out_dtype.type(np.nan)
 
-        def std_scalar_float_impl(a):
+        def std_scalar_float_impl(a, axis=None):
             if not np.isfinite(a):
                 return nan_val
             return zero

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -851,27 +851,159 @@ def array_cumsum(a, axis=None, dtype=None):
         return scalar_cumsum_impl
 
 
+@intrinsic
+def _numpy_cumprod(typingctx, aryty, axisty, dtype):
+    ret_dtype = get_ret_dtype_if_any(aryty, dtype)
+
+    ret = types.Array(ret_dtype, aryty.ndim, layout='C')
+    sig = ret(aryty, axisty, dtype)
+
+    def codegen(context, builder, sig, args):
+        ary, _, _ = args
+
+        ary = make_array(aryty)(context, builder, ary)
+        if isinstance(ret_dtype, types.NPTimedelta):
+            one = context.get_constant(ret_dtype, ret_dtype(1))
+        else:
+            one = context.get_constant(ret_dtype, 1)
+        acc = cgutils.alloca_once_value(builder, one)
+
+        res = _empty_nd_impl(
+            context, builder, sig.return_type,
+            cgutils.unpack_tuple(builder, ary.shape)
+        )
+        cgutils.memset(
+            builder, res.data,
+            builder.mul(res.itemsize, res.nitems), 0
+        )
+
+        fnty = context.typing_context.resolve_value_type(operator.imul)
+        fn_sig = fnty.get_call_type(
+            context.typing_context,
+            (sig.return_type.dtype, sig.return_type.dtype),
+            {}
+        )
+        if isinstance(ret_dtype, types.Boolean):
+            mul_funcfn = lambda builder, args: builder.and_(*args)
+        else:
+            mul_funcfn = context.get_function(fnty, fn_sig)
+
+        mask = get_mask(context, builder, aryty.ndim, None)
+        # Loop on source and copy to destination
+        with ArrayIterator(context, builder, aryty, ary,
+                           (mask,), (res,)) as (iter_val_ptr, res_ptr_tup):
+            res_ptr = res_ptr_tup[0]
+            val = load_item(context, builder, aryty, iter_val_ptr)
+            res_val = mul_funcfn(builder, (
+                builder.load(acc),
+                context.cast(builder, val, aryty.dtype, sig.return_type.dtype)))
+            builder.store(res_val, acc)
+            store_item(context, builder, sig.return_type,
+                       builder.load(acc), res_ptr)
+
+        return impl_ret_new_ref(
+            context, builder, sig.return_type, res._getvalue()
+        )
+
+    return sig, codegen
+
+
+@intrinsic
+def _numpy_cumprod_axis(typingctx, aryty, axisty, dtype):
+    ret_dtype = get_ret_dtype_if_any(aryty, dtype)
+    ret = types.Array(ret_dtype, aryty.ndim, layout='C')
+    sig = ret(aryty, axisty, dtype)
+
+    def codegen(context, builder, sig, args):
+        ary, axis, _ = args
+
+        ary = make_array(aryty)(context, builder, ary)
+
+        res = _empty_nd_impl(
+            context, builder, sig.return_type,
+            cgutils.unpack_tuple(builder, ary.shape)
+        )
+        cgutils.memset(
+            builder, res.data,
+            builder.mul(res.itemsize, res.nitems), 0
+        )
+
+        acc_shape = get_spliced_tuple(
+            context, builder, ary.shape.type, ary.shape, axis
+        )
+        acc_type = types.Array(ret_dtype, aryty.ndim - 1, layout='C')
+        acc = _empty_nd_impl(
+            context, builder, acc_type,
+            cgutils.unpack_tuple(builder, acc_shape)
+        )
+        if isinstance(ret_dtype, types.NPTimedelta):
+            one = context.get_constant(ret_dtype, ret_dtype(1))
+        else:
+            one = context.get_constant(ret_dtype, 1)
+        _fill_array_with_constant(context, builder, acc_type, acc, one)
+
+        fnty = context.typing_context.resolve_value_type(operator.imul)
+        fn_sig = fnty.get_call_type(
+            context.typing_context,
+            (sig.return_type.dtype, sig.return_type.dtype),
+            {}
+        )
+        if isinstance(ret_dtype, types.Boolean):
+            mul_funcfn = lambda builder, args: builder.and_(*args)
+        else:
+            mul_funcfn = context.get_function(fnty, fn_sig)
+
+        mask = get_mask(context, builder, aryty.ndim, None)
+        inverted_mask = get_mask(context, builder, aryty.ndim, axis)
+
+        # Loop on source and copy to destination
+        with ArrayIterator(
+            context, builder, aryty, ary, (mask, inverted_mask),
+            (res, acc)
+        ) as (ary_iter_ptr, res_ptr_tup):
+            res_ptr, acc_ptr = res_ptr_tup
+            val = load_item(context, builder, aryty, ary_iter_ptr)
+            res_val = mul_funcfn(builder, (
+                load_item(context, builder, acc_type, acc_ptr),
+                context.cast(builder, val, aryty.dtype, sig.return_type.dtype)))
+            store_item(context, builder, acc_type, res_val, acc_ptr)
+            store_item(context, builder, sig.return_type,
+                       load_item(context, builder, acc_type, acc_ptr), res_ptr)
+
+        context.nrt.decref(builder, acc_type, acc._getvalue())
+
+        return impl_ret_new_ref(
+            context, builder, sig.return_type, res._getvalue()
+        )
+
+    return sig, codegen
+
+
 @overload(np.cumprod)
 @overload_method(types.Array, "cumprod")
-def array_cumprod(a):
+def array_cumprod(a, axis=None, dtype=None):
+    if not (isinstance(axis, types.Integer) or is_nonelike(axis)):
+        raise TypingError(
+            "NumPy cumprod only supports integer axis value"
+        )
     if isinstance(a, types.Array):
-        is_integer = a.dtype in types.signed_domain
-        is_bool = a.dtype == types.bool_
-        if (is_integer and a.dtype.bitwidth < types.intp.bitwidth)\
-                or is_bool:
-            dtype = as_dtype(types.intp)
+        axis_length = 1
+        if is_nonelike(axis) or a.ndim == axis_length:
+            def array_cumprod_impl(a, axis=None, dtype=None):
+                if axis is not None and (axis < -a.ndim or axis >= a.ndim):
+                    raise ValueError(
+                        f"axis {axis} is out of bounds for "
+                        f"array of dimension {a.ndim}"
+                    )
+                return _numpy_cumprod(a, axis, dtype).reshape(a.size)
         else:
-            dtype = as_dtype(a.dtype)
-
-        acc_init = get_accumulator(dtype, 1)
-
-        def array_cumprod_impl(a):
-            out = np.empty(a.size, dtype)
-            c = acc_init
-            for idx, v in enumerate(a.flat):
-                c *= v
-                out[idx] = c
-            return out
+            def array_cumprod_impl(a, axis=None, dtype=None):
+                if axis is not None and (axis < -a.ndim or axis >= a.ndim):
+                    raise ValueError(
+                        f"axis {axis} is out of bounds for "
+                        f"array of dimension {a.ndim}"
+                    )
+                return _numpy_cumprod_axis(a, axis, dtype)
 
         return array_cumprod_impl
 

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -434,104 +434,113 @@ def get_ret_dtype_if_any(aryty, dtype):
     return ret_dtype
 
 
-@intrinsic
-def _numpy_sum(typingctx, aryty, axisty, dtype):
-    ret_dtype = get_ret_dtype_if_any(aryty, dtype)
-    sig = ret_dtype(aryty, axisty, dtype)
+def _np_func_builder(axis):
+    """
+    Build an intrinsic implementing a sum reduction.  When ``axis`` is False
+    the reduction is over the whole array (like ``_numpy_sum``); when True
+    it is along one or more axes (like ``_numpy_sum_axis``).  The two
+    variants share almost all of their code generation, differing only in
+    the accumulator (a scalar vs. an output array) and the return type.
+    """
+    @intrinsic
+    def _numpy_sum(typingctx, aryty, axisty, dtype):
+        ret_dtype = get_ret_dtype_if_any(aryty, dtype)
 
-    def codegen(context, builder, sig, args):
-        ary, _, _ = args
-
-        ary = make_array(aryty)(context, builder, ary)
-        if isinstance(ret_dtype, types.NPTimedelta):
-            zero = context.get_constant(ret_dtype, ret_dtype(0))
+        if axis:
+            axis_length = axisty.count if isinstance(axisty, types.UniTuple) else 1
+            ret = types.Array(ret_dtype, aryty.ndim - axis_length, layout='C')
         else:
-            zero = context.get_constant(ret_dtype, 0)
-        result = cgutils.alloca_once_value(builder, zero)
+            ret = ret_dtype
 
-        fnty = context.typing_context.resolve_value_type(operator.iadd)
-        fn_sig = fnty.get_call_type(
-            context.typing_context,
-            (sig.return_type, sig.return_type),
-            {}
-        )
-        if isinstance(ret_dtype, types.Boolean):
-            add_funcfn = lambda builder, args: builder.or_(*args)
-        else:
-            add_funcfn = context.get_function(fnty, fn_sig)
+        sig = ret(aryty, axisty, dtype)
 
-        # Loop on source and copy to destination
-        with ArrayIterator(context, builder, aryty, ary) as iter_val_ptr:
-            val = load_item(context, builder, aryty, iter_val_ptr)
-            res_val = add_funcfn(builder, (
-                builder.load(result),
-                context.cast(builder, val, aryty.dtype, sig.return_type)))
-            builder.store(res_val, result)
+        def codegen(context, builder, sig, args):
+            ary, axis_arg, _ = args
 
-        return impl_ret_borrowed(
-            context, builder, sig.return_type, builder.load(result)
-        )
+            ary = make_array(aryty)(context, builder, ary)
 
-    return sig, codegen
+            if axis:
+                if isinstance(axisty, types.UniTuple):
+                    axis_arg = cgutils.unpack_tuple(builder, axis_arg)
+
+                # Res shape will be a tuple one axis less than
+                # ndim and need appropriate shape calculations.
+                res_shape = get_spliced_tuple(
+                    context, builder, ary.shape.type, ary.shape, axis_arg
+                )
+                res = _empty_nd_impl(
+                    context, builder, sig.return_type,
+                    cgutils.unpack_tuple(builder, res_shape)
+                )
+                cgutils.memset(
+                    builder, res.data,
+                    builder.mul(res.itemsize, res.nitems), 0
+                )
+                mask = get_mask(context, builder, aryty.ndim, axis_arg)
+
+                def load_accumulator(ptr):
+                    return load_item(context, builder, sig.return_type, ptr)
+
+                def store_accumulator(val, ptr):
+                    store_item(context, builder, sig.return_type, val, ptr)
+
+                iter_args = (context, builder, aryty, ary, (mask,), (res,))
+            else:
+                if isinstance(ret_dtype, types.NPTimedelta):
+                    zero = context.get_constant(ret_dtype, ret_dtype(0))
+                else:
+                    zero = context.get_constant(ret_dtype, 0)
+                result = cgutils.alloca_once_value(builder, zero)
+
+                def load_accumulator(ptr):
+                    return builder.load(ptr)
+
+                def store_accumulator(val, ptr):
+                    builder.store(val, ptr)
+
+                iter_args = (context, builder, aryty, ary)
+
+            fnty = context.typing_context.resolve_value_type(operator.iadd)
+            fn_sig = fnty.get_call_type(
+                context.typing_context,
+                (ret_dtype, ret_dtype),
+                {}
+            )
+            if isinstance(ret_dtype, types.Boolean):
+                add_funcfn = lambda builder, args: builder.or_(*args)
+            else:
+                add_funcfn = context.get_function(fnty, fn_sig)
+
+            # Loop on source and copy to destination
+            with ArrayIterator(*iter_args) as iter_vals:
+                if axis:
+                    ary_iter_ptr, res_ptr_tup = iter_vals
+                    acc_ptr = res_ptr_tup[0]
+                else:
+                    ary_iter_ptr = iter_vals
+                    acc_ptr = result
+                val = load_item(context, builder, aryty, ary_iter_ptr)
+                res_val = add_funcfn(builder, (
+                    load_accumulator(acc_ptr),
+                    context.cast(builder, val, aryty.dtype, ret_dtype)))
+                store_accumulator(res_val, acc_ptr)
+
+            if axis:
+                return impl_ret_new_ref(
+                    context, builder, sig.return_type, res._getvalue()
+                )
+            else:
+                return impl_ret_borrowed(
+                    context, builder, sig.return_type, builder.load(result)
+                )
+
+        return sig, codegen
+
+    return _numpy_sum
 
 
-@intrinsic
-def _numpy_sum_axis(typingctx, aryty, axisty, dtype):
-    ret_dtype = get_ret_dtype_if_any(aryty, dtype)
-
-    axis_length = axisty.count if isinstance(axisty, types.UniTuple) else 1
-    ret = types.Array(ret_dtype, aryty.ndim - axis_length, layout='C')
-    sig = ret(aryty, axisty, dtype)
-
-    def codegen(context, builder, sig, args):
-        ary, axis, _ = args
-
-        ary = make_array(aryty)(context, builder, ary)
-        if isinstance(axisty, types.UniTuple):
-            axis = cgutils.unpack_tuple(builder, axis)
-
-        # Res shape will be a tuple one axis less than
-        # ndim and need appropriate shape calculations.
-        res_shape = get_spliced_tuple(
-            context, builder, ary.shape.type, ary.shape, axis
-        )
-        res = _empty_nd_impl(
-            context, builder, sig.return_type,
-            cgutils.unpack_tuple(builder, res_shape)
-        )
-        cgutils.memset(
-            builder, res.data,
-            builder.mul(res.itemsize, res.nitems), 0
-        )
-
-        fnty = context.typing_context.resolve_value_type(operator.iadd)
-        fn_sig = fnty.get_call_type(
-            context.typing_context,
-            (sig.return_type.dtype, sig.return_type.dtype),
-            {}
-        )
-        if isinstance(ret_dtype, types.Boolean):
-            add_funcfn = lambda builder, args: builder.or_(*args)
-        else:
-            add_funcfn = context.get_function(fnty, fn_sig)
-
-        mask = get_mask(context, builder, aryty.ndim, axis)
-        # Loop on source and copy to destination
-        with ArrayIterator(
-            context, builder, aryty, ary, (mask,), (res,)
-        ) as (ary_iter_ptr, res_ptr_tup):
-            res_ptr = res_ptr_tup[0]
-            val = load_item(context, builder, aryty, ary_iter_ptr)
-            res_val = add_funcfn(builder, (
-                load_item(context, builder, sig.return_type, res_ptr),
-                context.cast(builder, val, aryty.dtype, sig.return_type.dtype)))
-            store_item(context, builder, sig.return_type, res_val, res_ptr)
-
-        return impl_ret_new_ref(
-            context, builder, sig.return_type, res._getvalue()
-        )
-
-    return sig, codegen
+_numpy_sum = _np_func_builder(axis=False)
+_numpy_sum_axis = _np_func_builder(axis=True)
 
 
 axis_bound_err = ValueError if numpy_version < (1, 25)\

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -891,20 +891,30 @@ def array_cumprod(a, axis=None, dtype=None):
 
 @overload(np.mean)
 @overload_method(types.Array, "mean")
-def array_mean(a):
+def array_mean(a, axis=None):
+    if not (isinstance(axis, types.Integer) or
+            is_nonelike(axis) or (
+                isinstance(axis, types.UniTuple) and
+                isinstance(axis.dtype, types.Integer))
+            or (
+                isinstance(axis, types.Tuple) and
+                axis.count == 0)):
+        raise TypingError(
+            "NumPy mean only supports integer axis value or tuple of integers"
+        )
     if isinstance(a, (types.Integer, types.Boolean)):
         # Integers and Booleans default to float64 in numpy.mean
-        def _scalar_mean(a):
+        def _scalar_mean(a, axis=None):
             return np.float64(a) + 0.0
         return _scalar_mean
     elif isinstance(a, NPTimedelta):
-        def _temporal_scalar_mean(a):
+        def _temporal_scalar_mean(a, axis=None):
             return a
         return _temporal_scalar_mean
     elif isinstance(a, (types.Float, types.Complex)):
         typed_zero = as_dtype(a).type(0)
 
-        def _scalar_mean(a):
+        def _scalar_mean(a, axis=None):
             return a + typed_zero
         return _scalar_mean
     elif isinstance(a, types.Array):
@@ -922,36 +932,84 @@ def array_mean(a):
         # Is complex array
         is_complex = isinstance(a.dtype, types.Complex)
 
-        if not is_datetime_like:
-            if is_complex:
-                # For complex, both real and imag should be nan
-                nan_value = dtype.type(complex("nan+nanj"))
+        if isinstance(axis, types.Tuple) and axis.count == 0:
+            # axis=() returns a copy of the array cast to float for
+            # integer inputs to match NumPy behaviour.
+            if is_number:
+                def array_mean_impl(a, axis=None):
+                    return a.astype(np.float64)
             else:
-                nan_value = dtype.type(np.nan)
+                def array_mean_impl(a, axis=None):
+                    return np.copy(a)
+            return array_mean_impl
 
-            # For numeric types, handle empty arrays by returning nan
-            def array_mean_impl(a):
-                # Handle empty arrays as a special case to match NumPy
-                # behavior
-                if a.size == 0:
-                    return nan_value
-                # Can't use the naive `arr.sum() / arr.size`, as it would return
-                # a wrong result on integer sum overflow.
-                c = acc_init
-                for v in np.nditer(a):
-                    c += v.item()
-                return dtype.type(c / a.size)
+        if is_nonelike(axis):
+            if not is_datetime_like:
+                if is_complex:
+                    # For complex, both real and imag should be nan
+                    nan_value = dtype.type(complex("nan+nanj"))
+                else:
+                    nan_value = dtype.type(np.nan)
+
+                # For numeric types, handle empty arrays by returning nan
+                def array_mean_impl(a, axis=None):
+                    # Handle empty arrays as a special case to match NumPy
+                    # behavior
+                    if a.size == 0:
+                        return nan_value
+                    # Can't use the naive `arr.sum() / arr.size`, as it
+                    # would return a wrong result on integer sum overflow.
+                    c = acc_init
+                    for v in np.nditer(a):
+                        c += v.item()
+                    return dtype.type(c / a.size)
+            else:
+                # For datetime/timedelta, don't add special empty array handling
+                # Let it behave as before (NumPy itself raises error for empty
+                # datetime arrays)
+                def array_mean_impl(a, axis=None):
+                    c = acc_init
+                    for v in np.nditer(a):
+                        c += v.item()
+                    return c / a.size
+
+            return array_mean_impl
         else:
-            # For datetime/timedelta, don't add special empty array handling
-            # Let it behave as before (NumPy itself raises error for empty
-            # datetime arrays)
-            def array_mean_impl(a):
-                c = acc_init
-                for v in np.nditer(a):
-                    c += v.item()
-                return c / a.size
+            # axis-based reduction: compute the sum along the given axis
+            # (using float64 accumulation for integer inputs to avoid
+            # overflow) and divide by the number of elements reduced over.
+            if is_number:
+                def array_mean_axis_impl(a, axis=None):
+                    check_axis_bounds(a, axis)
+                    check_duplicates(axis, a.ndim)
+                    if isinstance(axis, tuple):
+                        count = 1
+                        for ax in axis:
+                            if ax < 0:
+                                ax = a.ndim + ax
+                            count *= a.shape[ax]
+                    else:
+                        if axis < 0:
+                            axis = a.ndim + axis
+                        count = a.shape[axis]
+                    return np.sum(a, axis=axis, dtype=np.float64) / count
+            else:
+                def array_mean_axis_impl(a, axis=None):
+                    check_axis_bounds(a, axis)
+                    check_duplicates(axis, a.ndim)
+                    if isinstance(axis, tuple):
+                        count = 1
+                        for ax in axis:
+                            if ax < 0:
+                                ax = a.ndim + ax
+                            count *= a.shape[ax]
+                    else:
+                        if axis < 0:
+                            axis = a.ndim + axis
+                        count = a.shape[axis]
+                    return np.sum(a, axis=axis) / count
 
-        return array_mean_impl
+            return array_mean_axis_impl
     return None
 
 

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -1013,22 +1013,140 @@ def array_mean(a, axis=None):
     return None
 
 
+@register_jitable
+def _var_1d(a, mean, count, zero):
+    # Two-pass variance of the values in ``a`` given the precomputed
+    # ``mean``. ``zero`` is the typed zero used to initialise the
+    # accumulator and ``count`` is the number of elements typed in the
+    # result precision, so the result keeps the input's precision.
+    ssd = zero
+    for v in np.nditer(a):
+        val = v.item() - mean
+        ssd += np.real(val * np.conj(val))
+    return ssd / count
+
+
 @overload(np.var)
 @overload_method(types.Array, "var")
-def array_var(a):
-    if isinstance(a, types.Array):
-        def array_var_impl(a):
-            # Compute the mean
-            m = a.mean()
+def array_var(a, axis=None):
+    if not (isinstance(axis, types.Integer) or
+            is_nonelike(axis) or (
+                isinstance(axis, types.UniTuple) and
+                isinstance(axis.dtype, types.Integer))
+            or (
+                isinstance(axis, types.Tuple) and
+                axis.count == 0)):
+        raise TypingError(
+            "NumPy var only supports integer axis value or tuple of integers"
+        )
 
-            # Compute the sum of square diffs
-            ssd = 0
-            for v in np.nditer(a):
-                val = (v.item() - m)
-                ssd += np.real(val * np.conj(val))
-            return ssd / a.size
+    if isinstance(a, (types.Integer, types.Boolean)):
+        # Integers and Booleans default to float64 in numpy.var
+        def _scalar_var(a, axis=None):
+            return np.float64(0.0)
+        return _scalar_var
+    elif isinstance(a, (types.Float, types.Complex)):
+        out_dtype = as_dtype(getattr(a, 'underlying_float', a))
+        zero = out_dtype.type(0)
 
-        return array_var_impl
+        def _scalar_var(a, axis=None):
+            return zero
+        return _scalar_var
+    elif isinstance(a, types.Array):
+        # NumPy computes the variance in the same precision as the input for
+        # floating point arrays, in float64 for integer/boolean arrays and in
+        # the precision of the underlying float for complex arrays.
+        if a.dtype in types.integer_domain | frozenset([types.bool_]):
+            var_dtype = types.float64
+        elif isinstance(a.dtype, types.Complex):
+            var_dtype = a.dtype.underlying_float
+        else:
+            var_dtype = a.dtype
+
+        nan_value = as_dtype(var_dtype).type(np.nan)
+        zero_value = as_dtype(var_dtype).type(0)
+        count_cast = as_dtype(var_dtype).type
+
+        if isinstance(axis, types.Tuple) and axis.count == 0:
+            # axis=() returns an array of zeros (the variance of a single
+            # element) cast to the appropriate dtype.
+            def array_var_impl(a, axis=None):
+                return np.zeros(a.shape, var_dtype)
+            return array_var_impl
+
+        if is_nonelike(axis):
+            def array_var_impl(a, axis=None):
+                if a.size == 0:
+                    return nan_value
+                return _var_1d(a, a.mean(), count_cast(a.size), zero_value)
+            return array_var_impl
+
+        # axis-based reduction: move the reduced axis/axes to the end of the
+        # array so the mean broadcasts correctly, then sum the squared
+        # deviations from the mean and divide by the number of elements
+        # reduced over.
+        if isinstance(axis, types.UniTuple):
+            k = axis.count
+            dest = tuple(range(a.ndim - k, a.ndim))
+            seed = (0,) * a.ndim
+
+            def array_var_axis_impl(a, axis=None):
+                check_axis_bounds(a, axis)
+                check_duplicates(axis, a.ndim)
+                if len(axis) == a.ndim:
+                    # Reducing over every axis gives a scalar result
+                    # equivalent to the whole-array variance.
+                    if a.size == 0:
+                        return nan_value
+                    return _var_1d(a, a.mean(), count_cast(a.size),
+                                   zero_value)
+                count = 1
+                for ax in axis:
+                    if ax < 0:
+                        ax = a.ndim + ax
+                    count *= a.shape[ax]
+                t = np.moveaxis(a, axis, dest)
+                m = t.mean(axis=dest)
+                # Give the mean unit dimensions in the reduced axes so it
+                # broadcasts against the moved array.
+                newshape = seed
+                for i in range(a.ndim - k):
+                    newshape = tuple_setitem(newshape, i, m.shape[i])
+                for i in range(a.ndim - k, a.ndim):
+                    newshape = tuple_setitem(newshape, i, 1)
+                m2 = np.reshape(m, newshape)
+                dev = t - m2
+                ssd = np.sum(np.real(dev * np.conj(dev)), axis=dest)
+                return ssd / count
+            return array_var_axis_impl
+        else:
+            seed = (0,) * a.ndim
+
+            def array_var_axis_impl(a, axis=None):
+                check_axis_bounds(a, axis)
+                check_duplicates(axis, a.ndim)
+                if a.ndim == 1:
+                    # Reducing over the only axis gives a scalar result
+                    # equivalent to the whole-array variance.
+                    if a.size == 0:
+                        return nan_value
+                    return _var_1d(a, a.mean(), count_cast(a.size),
+                                   zero_value)
+                if axis < 0:
+                    axis = a.ndim + axis
+                count = a.shape[axis]
+                t = np.moveaxis(a, axis, -1)
+                m = t.mean(axis=-1)
+                newshape = seed
+                for i in range(a.ndim - 1):
+                    newshape = tuple_setitem(newshape, i, m.shape[i])
+                newshape = tuple_setitem(newshape, a.ndim - 1, 1)
+                m2 = np.reshape(m, newshape)
+                dev = t - m2
+                ssd = np.sum(np.real(dev * np.conj(dev)), axis=-1)
+                return ssd / count
+            return array_var_axis_impl
+    return None
 
 
 @overload(np.std)

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -434,20 +434,29 @@ def get_ret_dtype_if_any(aryty, dtype):
     return ret_dtype
 
 
-def _np_func_builder(axis):
+def _fill_array_with_constant(context, builder, aryty, ary, value):
+    # Fill an array with a constant value using an ArrayIterator
+    with ArrayIterator(context, builder, aryty, ary) as ptr:
+        store_item(context, builder, aryty, value, ptr)
+
+
+def _np_func_builder(axis, funcfn):
     """
-    Build an intrinsic implementing a sum reduction.  When ``axis`` is False
+    Build an intrinsic implementing a reduction.  When ``axis`` is False
     the reduction is over the whole array (like ``_numpy_sum``); when True
-    it is along one or more axes (like ``_numpy_sum_axis``).  The two
-    variants share almost all of their code generation, differing only in
-    the accumulator (a scalar vs. an output array) and the return type.
+    it is along one or more axes (like ``_numpy_sum_axis``).  ``funcfn`` is
+    the binary operation to accumulate with (``operator.iadd`` for sum,
+    ``operator.imul`` for prod).  The two variants share almost all of their
+    code generation, differing only in the accumulator (a scalar vs. an
+    output array) and the return type.
     """
     @intrinsic
-    def _numpy_sum(typingctx, aryty, axisty, dtype):
+    def _numpy_reduce(typingctx, aryty, axisty, dtype):
         ret_dtype = get_ret_dtype_if_any(aryty, dtype)
 
         if axis:
-            axis_length = axisty.count if isinstance(axisty, types.UniTuple) else 1
+            axis_length = axisty.count if isinstance(
+                axisty, types.UniTuple) else 1
             ret = types.Array(ret_dtype, aryty.ndim - axis_length, layout='C')
         else:
             ret = ret_dtype
@@ -472,10 +481,16 @@ def _np_func_builder(axis):
                     context, builder, sig.return_type,
                     cgutils.unpack_tuple(builder, res_shape)
                 )
-                cgutils.memset(
-                    builder, res.data,
-                    builder.mul(res.itemsize, res.nitems), 0
-                )
+                if funcfn is operator.imul:
+                    identity = context.get_constant(ret_dtype, 1)
+                    _fill_array_with_constant(
+                        context, builder, sig.return_type, res, identity
+                    )
+                else:
+                    cgutils.memset(
+                        builder, res.data,
+                        builder.mul(res.itemsize, res.nitems), 0
+                    )
                 mask = get_mask(context, builder, aryty.ndim, axis_arg)
 
                 def load_accumulator(ptr):
@@ -487,10 +502,12 @@ def _np_func_builder(axis):
                 iter_args = (context, builder, aryty, ary, (mask,), (res,))
             else:
                 if isinstance(ret_dtype, types.NPTimedelta):
-                    zero = context.get_constant(ret_dtype, ret_dtype(0))
+                    identity = context.get_constant(ret_dtype, ret_dtype(0))
                 else:
-                    zero = context.get_constant(ret_dtype, 0)
-                result = cgutils.alloca_once_value(builder, zero)
+                    identity = context.get_constant(
+                        ret_dtype, 1 if funcfn is operator.imul else 0
+                    )
+                result = cgutils.alloca_once_value(builder, identity)
 
                 def load_accumulator(ptr):
                     return builder.load(ptr)
@@ -500,16 +517,19 @@ def _np_func_builder(axis):
 
                 iter_args = (context, builder, aryty, ary)
 
-            fnty = context.typing_context.resolve_value_type(operator.iadd)
+            fnty = context.typing_context.resolve_value_type(funcfn)
             fn_sig = fnty.get_call_type(
                 context.typing_context,
                 (ret_dtype, ret_dtype),
                 {}
             )
             if isinstance(ret_dtype, types.Boolean):
-                add_funcfn = lambda builder, args: builder.or_(*args)
+                if funcfn is operator.iadd:
+                    reduce_funcfn = lambda builder, args: builder.or_(*args)
+                else:
+                    reduce_funcfn = lambda builder, args: builder.and_(*args)
             else:
-                add_funcfn = context.get_function(fnty, fn_sig)
+                reduce_funcfn = context.get_function(fnty, fn_sig)
 
             # Loop on source and copy to destination
             with ArrayIterator(*iter_args) as iter_vals:
@@ -520,7 +540,7 @@ def _np_func_builder(axis):
                     ary_iter_ptr = iter_vals
                     acc_ptr = result
                 val = load_item(context, builder, aryty, ary_iter_ptr)
-                res_val = add_funcfn(builder, (
+                res_val = reduce_funcfn(builder, (
                     load_accumulator(acc_ptr),
                     context.cast(builder, val, aryty.dtype, ret_dtype)))
                 store_accumulator(res_val, acc_ptr)
@@ -536,11 +556,13 @@ def _np_func_builder(axis):
 
         return sig, codegen
 
-    return _numpy_sum
+    return _numpy_reduce
 
 
-_numpy_sum = _np_func_builder(axis=False)
-_numpy_sum_axis = _np_func_builder(axis=True)
+_numpy_sum = _np_func_builder(axis=False, funcfn=operator.iadd)
+_numpy_sum_axis = _np_func_builder(axis=True, funcfn=operator.iadd)
+_numpy_prod = _np_func_builder(axis=False, funcfn=operator.imul)
+_numpy_prod_axis = _np_func_builder(axis=True, funcfn=operator.imul)
 
 
 axis_bound_err = ValueError if numpy_version < (1, 25)\
@@ -619,23 +641,45 @@ def array_sum(a, axis=None, dtype=None):
 
 @overload(np.prod)
 @overload_method(types.Array, "prod")
-def array_prod(a):
+def array_prod(a, axis=None, dtype=None):
+    if not (isinstance(axis, types.Integer) or
+            is_nonelike(axis) or (
+                isinstance(axis, types.UniTuple) and
+                isinstance(axis.dtype, types.Integer))
+            or (
+                isinstance(axis, types.Tuple) and
+                axis.count == 0)):
+        raise TypingError(
+            "NumPy prod only supports integer axis value or tuple of integers"
+        )
     if isinstance(a, types.Array):
-        dtype = as_dtype(a.dtype)
-
-        acc_init = get_accumulator(dtype, 1)
-
-        def array_prod_impl(a):
-            c = acc_init
-            for v in np.nditer(a):
-                c *= v.item()
-            return c
+        if isinstance(axis, types.Tuple) and axis.count == 0:
+            if is_nonelike(dtype):
+                def array_prod_impl(a, axis=None, dtype=None):
+                    return np.copy(a)
+            else:
+                def array_prod_impl(a, axis=None, dtype=None):
+                    return a.astype(dtype)
+        elif is_nonelike(axis) or a.ndim <= (
+            axis.count if isinstance(
+                axis, (types.Tuple, types.UniTuple)) else 1):
+            def array_prod_impl(a, axis=None, dtype=None):
+                check_axis_bounds(a, axis)
+                check_duplicates(axis, a.ndim)
+                return _numpy_prod(a, axis, dtype)
+        else:
+            def array_prod_impl(a, axis=None, dtype=None):
+                check_axis_bounds(a, axis)
+                return _numpy_prod_axis(a, axis, dtype)
 
         return array_prod_impl
     elif isinstance(a, (types.Number, types.Boolean)):
-        acc_init = as_dtype(a).type(1)
+        if is_nonelike(dtype):
+            acc_init = as_dtype(a).type(1)
+        else:
+            acc_init = as_dtype(dtype).type(1)
 
-        def scalar_prod_impl(a):
+        def scalar_prod_impl(a, axis=None, dtype=None):
             return acc_init * a
 
         return scalar_prod_impl

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -685,131 +685,140 @@ def array_prod(a, axis=None, dtype=None):
         return scalar_prod_impl
 
 
-@intrinsic
-def _numpy_cumsum(typingctx, aryty, axisty, dtype):
-    ret_dtype = get_ret_dtype_if_any(aryty, dtype)
+def _np_cum_func_builder(axis, funcfn):
+    """
+    Build an intrinsic implementing a cumulative reduction.  When ``axis`` is
+    False the reduction is over the whole array (like ``_numpy_cumsum``); when
+    True it is along one axis (like ``_numpy_cumsum_axis``).  ``funcfn`` is
+    the binary operation to accumulate with (``operator.iadd`` for cumsum,
+    ``operator.imul`` for cumprod).  The two variants share almost all of
+    their code generation, differing only in the accumulator (a scalar vs. an
+    accumulator array) and how the accumulator is initialised.
+    """
+    @intrinsic
+    def _numpy_cumulative(typingctx, aryty, axisty, dtype):
+        ret_dtype = get_ret_dtype_if_any(aryty, dtype)
 
-    ret = types.Array(ret_dtype, aryty.ndim, layout='C')
-    sig = ret(aryty, axisty, dtype)
+        ret = types.Array(ret_dtype, aryty.ndim, layout='C')
+        sig = ret(aryty, axisty, dtype)
 
-    def codegen(context, builder, sig, args):
-        ary, _, _ = args
+        def codegen(context, builder, sig, args):
+            ary, axis_arg, _ = args
 
-        ary = make_array(aryty)(context, builder, ary)
-        if isinstance(ret_dtype, types.NPTimedelta):
-            zero = context.get_constant(ret_dtype, ret_dtype(0))
-        else:
-            zero = context.get_constant(ret_dtype, 0)
-        acc = cgutils.alloca_once_value(builder, zero)
+            ary = make_array(aryty)(context, builder, ary)
 
-        res = _empty_nd_impl(
-            context, builder, sig.return_type,
-            cgutils.unpack_tuple(builder, ary.shape)
-        )
-        cgutils.memset(
-            builder, res.data,
-            builder.mul(res.itemsize, res.nitems), 0
-        )
+            res = _empty_nd_impl(
+                context, builder, sig.return_type,
+                cgutils.unpack_tuple(builder, ary.shape)
+            )
+            cgutils.memset(
+                builder, res.data,
+                builder.mul(res.itemsize, res.nitems), 0
+            )
 
-        fnty = context.typing_context.resolve_value_type(operator.iadd)
-        fn_sig = fnty.get_call_type(
-            context.typing_context,
-            (sig.return_type.dtype, sig.return_type.dtype),
-            {}
-        )
-        if isinstance(ret_dtype, types.Boolean):
-            add_funcfn = lambda builder, args: builder.or_(*args)
-        else:
-            add_funcfn = context.get_function(fnty, fn_sig)
+            fnty = context.typing_context.resolve_value_type(funcfn)
+            fn_sig = fnty.get_call_type(
+                context.typing_context,
+                (sig.return_type.dtype, sig.return_type.dtype),
+                {}
+            )
+            if isinstance(ret_dtype, types.Boolean):
+                if funcfn is operator.iadd:
+                    accumulate_funcfn = (
+                        lambda builder, args: builder.or_(*args)
+                    )
+                else:
+                    accumulate_funcfn = (
+                        lambda builder, args: builder.and_(*args)
+                    )
+            else:
+                accumulate_funcfn = context.get_function(fnty, fn_sig)
 
-        mask = get_mask(context, builder, aryty.ndim, None)
-        # Loop on source and copy to destination
-        with ArrayIterator(context, builder, aryty, ary,
-                           (mask,), (res,)) as (iter_val_ptr, res_ptr_tup):
-            res_ptr = res_ptr_tup[0]
-            val = load_item(context, builder, aryty, iter_val_ptr)
-            res_val = add_funcfn(builder, (
-                builder.load(acc),
-                context.cast(builder, val, aryty.dtype, sig.return_type.dtype)))
-            builder.store(res_val, acc)
-            store_item(context, builder, sig.return_type,
-                       builder.load(acc), res_ptr)
+            if axis:
+                acc_shape = get_spliced_tuple(
+                    context, builder, ary.shape.type, ary.shape, axis_arg
+                )
+                acc_type = types.Array(ret_dtype, aryty.ndim - 1, layout='C')
+                acc = _empty_nd_impl(
+                    context, builder, acc_type,
+                    cgutils.unpack_tuple(builder, acc_shape)
+                )
+                if funcfn is operator.imul:
+                    if isinstance(ret_dtype, types.NPTimedelta):
+                        one = context.get_constant(ret_dtype, ret_dtype(1))
+                    else:
+                        one = context.get_constant(ret_dtype, 1)
+                    _fill_array_with_constant(
+                        context, builder, acc_type, acc, one
+                    )
+                else:
+                    cgutils.memset(
+                        builder, acc.data,
+                        builder.mul(acc.itemsize, acc.nitems), 0
+                    )
 
-        return impl_ret_new_ref(
-            context, builder, sig.return_type, res._getvalue()
-        )
+                mask = get_mask(context, builder, aryty.ndim, None)
+                inverted_mask = get_mask(
+                    context, builder, aryty.ndim, axis_arg
+                )
 
-    return sig, codegen
+                # Loop on source and copy to destination
+                with ArrayIterator(
+                    context, builder, aryty, ary, (mask, inverted_mask),
+                    (res, acc)
+                ) as (ary_iter_ptr, res_ptr_tup):
+                    res_ptr, acc_ptr = res_ptr_tup
+                    val = load_item(context, builder, aryty, ary_iter_ptr)
+                    res_val = accumulate_funcfn(builder, (
+                        load_item(context, builder, acc_type, acc_ptr),
+                        context.cast(builder, val, aryty.dtype,
+                                     sig.return_type.dtype)))
+                    store_item(context, builder, acc_type, res_val, acc_ptr)
+                    store_item(context, builder, sig.return_type,
+                               load_item(context, builder, acc_type, acc_ptr),
+                               res_ptr)
+
+                context.nrt.decref(builder, acc_type, acc._getvalue())
+            else:
+                if isinstance(ret_dtype, types.NPTimedelta):
+                    identity = context.get_constant(
+                        ret_dtype,
+                        ret_dtype(1 if funcfn is operator.imul else 0)
+                    )
+                else:
+                    identity = context.get_constant(
+                        ret_dtype, 1 if funcfn is operator.imul else 0
+                    )
+                acc = cgutils.alloca_once_value(builder, identity)
+
+                mask = get_mask(context, builder, aryty.ndim, None)
+                # Loop on source and copy to destination
+                with ArrayIterator(
+                    context, builder, aryty, ary, (mask,), (res,)
+                ) as (iter_val_ptr, res_ptr_tup):
+                    res_ptr = res_ptr_tup[0]
+                    val = load_item(context, builder, aryty, iter_val_ptr)
+                    res_val = accumulate_funcfn(builder, (
+                        builder.load(acc),
+                        context.cast(builder, val, aryty.dtype,
+                                     sig.return_type.dtype)))
+                    builder.store(res_val, acc)
+                    store_item(context, builder, sig.return_type,
+                               builder.load(acc), res_ptr)
+
+            return impl_ret_new_ref(
+                context, builder, sig.return_type, res._getvalue()
+            )
+
+        return sig, codegen
+
+    return _numpy_cumulative
 
 
-@intrinsic
-def _numpy_cumsum_axis(typingctx, aryty, axisty, dtype):
-    ret_dtype = get_ret_dtype_if_any(aryty, dtype)
-    ret = types.Array(ret_dtype, aryty.ndim, layout='C')
-    sig = ret(aryty, axisty, dtype)
-
-    def codegen(context, builder, sig, args):
-        ary, axis, _ = args
-
-        ary = make_array(aryty)(context, builder, ary)
-
-        res = _empty_nd_impl(
-            context, builder, sig.return_type,
-            cgutils.unpack_tuple(builder, ary.shape)
-        )
-        cgutils.memset(
-            builder, res.data,
-            builder.mul(res.itemsize, res.nitems), 0
-        )
-
-        acc_shape = get_spliced_tuple(
-            context, builder, ary.shape.type, ary.shape, axis
-        )
-        acc_type = types.Array(ret_dtype, aryty.ndim - 1, layout='C')
-        acc = _empty_nd_impl(
-            context, builder, acc_type,
-            cgutils.unpack_tuple(builder, acc_shape)
-        )
-        cgutils.memset(
-            builder, acc.data,
-            builder.mul(acc.itemsize, acc.nitems), 0
-        )
-
-        fnty = context.typing_context.resolve_value_type(operator.iadd)
-        fn_sig = fnty.get_call_type(
-            context.typing_context,
-            (sig.return_type.dtype, sig.return_type.dtype),
-            {}
-        )
-        if isinstance(ret_dtype, types.Boolean):
-            add_funcfn = lambda builder, args: builder.or_(*args)
-        else:
-            add_funcfn = context.get_function(fnty, fn_sig)
-
-        mask = get_mask(context, builder, aryty.ndim, None)
-        inverted_mask = get_mask(context, builder, aryty.ndim, axis)
-
-        # Loop on source and copy to destination
-        with ArrayIterator(
-            context, builder, aryty, ary, (mask, inverted_mask),
-            (res, acc)
-        ) as (ary_iter_ptr, res_ptr_tup):
-            res_ptr, acc_ptr = res_ptr_tup
-            val = load_item(context, builder, aryty, ary_iter_ptr)
-            res_val = add_funcfn(builder, (
-                load_item(context, builder, acc_type, acc_ptr),
-                context.cast(builder, val, aryty.dtype, sig.return_type.dtype)))
-            store_item(context, builder, acc_type, res_val, acc_ptr)
-            store_item(context, builder, sig.return_type,
-                       load_item(context, builder, acc_type, acc_ptr), res_ptr)
-
-        context.nrt.decref(builder, acc_type, acc._getvalue())
-
-        return impl_ret_new_ref(
-            context, builder, sig.return_type, res._getvalue()
-        )
-
-    return sig, codegen
+_numpy_cumsum = _np_cum_func_builder(axis=False, funcfn=operator.iadd)
+_numpy_cumsum_axis = _np_cum_func_builder(axis=True, funcfn=operator.iadd)
+_numpy_cumprod = _np_cum_func_builder(axis=False, funcfn=operator.imul)
+_numpy_cumprod_axis = _np_cum_func_builder(axis=True, funcfn=operator.imul)
 
 
 @overload(np.cumsum)
@@ -849,134 +858,6 @@ def array_cumsum(a, axis=None, dtype=None):
             return acc_init + a
 
         return scalar_cumsum_impl
-
-
-@intrinsic
-def _numpy_cumprod(typingctx, aryty, axisty, dtype):
-    ret_dtype = get_ret_dtype_if_any(aryty, dtype)
-
-    ret = types.Array(ret_dtype, aryty.ndim, layout='C')
-    sig = ret(aryty, axisty, dtype)
-
-    def codegen(context, builder, sig, args):
-        ary, _, _ = args
-
-        ary = make_array(aryty)(context, builder, ary)
-        if isinstance(ret_dtype, types.NPTimedelta):
-            one = context.get_constant(ret_dtype, ret_dtype(1))
-        else:
-            one = context.get_constant(ret_dtype, 1)
-        acc = cgutils.alloca_once_value(builder, one)
-
-        res = _empty_nd_impl(
-            context, builder, sig.return_type,
-            cgutils.unpack_tuple(builder, ary.shape)
-        )
-        cgutils.memset(
-            builder, res.data,
-            builder.mul(res.itemsize, res.nitems), 0
-        )
-
-        fnty = context.typing_context.resolve_value_type(operator.imul)
-        fn_sig = fnty.get_call_type(
-            context.typing_context,
-            (sig.return_type.dtype, sig.return_type.dtype),
-            {}
-        )
-        if isinstance(ret_dtype, types.Boolean):
-            mul_funcfn = lambda builder, args: builder.and_(*args)
-        else:
-            mul_funcfn = context.get_function(fnty, fn_sig)
-
-        mask = get_mask(context, builder, aryty.ndim, None)
-        # Loop on source and copy to destination
-        with ArrayIterator(context, builder, aryty, ary,
-                           (mask,), (res,)) as (iter_val_ptr, res_ptr_tup):
-            res_ptr = res_ptr_tup[0]
-            val = load_item(context, builder, aryty, iter_val_ptr)
-            res_val = mul_funcfn(builder, (
-                builder.load(acc),
-                context.cast(builder, val, aryty.dtype, sig.return_type.dtype)))
-            builder.store(res_val, acc)
-            store_item(context, builder, sig.return_type,
-                       builder.load(acc), res_ptr)
-
-        return impl_ret_new_ref(
-            context, builder, sig.return_type, res._getvalue()
-        )
-
-    return sig, codegen
-
-
-@intrinsic
-def _numpy_cumprod_axis(typingctx, aryty, axisty, dtype):
-    ret_dtype = get_ret_dtype_if_any(aryty, dtype)
-    ret = types.Array(ret_dtype, aryty.ndim, layout='C')
-    sig = ret(aryty, axisty, dtype)
-
-    def codegen(context, builder, sig, args):
-        ary, axis, _ = args
-
-        ary = make_array(aryty)(context, builder, ary)
-
-        res = _empty_nd_impl(
-            context, builder, sig.return_type,
-            cgutils.unpack_tuple(builder, ary.shape)
-        )
-        cgutils.memset(
-            builder, res.data,
-            builder.mul(res.itemsize, res.nitems), 0
-        )
-
-        acc_shape = get_spliced_tuple(
-            context, builder, ary.shape.type, ary.shape, axis
-        )
-        acc_type = types.Array(ret_dtype, aryty.ndim - 1, layout='C')
-        acc = _empty_nd_impl(
-            context, builder, acc_type,
-            cgutils.unpack_tuple(builder, acc_shape)
-        )
-        if isinstance(ret_dtype, types.NPTimedelta):
-            one = context.get_constant(ret_dtype, ret_dtype(1))
-        else:
-            one = context.get_constant(ret_dtype, 1)
-        _fill_array_with_constant(context, builder, acc_type, acc, one)
-
-        fnty = context.typing_context.resolve_value_type(operator.imul)
-        fn_sig = fnty.get_call_type(
-            context.typing_context,
-            (sig.return_type.dtype, sig.return_type.dtype),
-            {}
-        )
-        if isinstance(ret_dtype, types.Boolean):
-            mul_funcfn = lambda builder, args: builder.and_(*args)
-        else:
-            mul_funcfn = context.get_function(fnty, fn_sig)
-
-        mask = get_mask(context, builder, aryty.ndim, None)
-        inverted_mask = get_mask(context, builder, aryty.ndim, axis)
-
-        # Loop on source and copy to destination
-        with ArrayIterator(
-            context, builder, aryty, ary, (mask, inverted_mask),
-            (res, acc)
-        ) as (ary_iter_ptr, res_ptr_tup):
-            res_ptr, acc_ptr = res_ptr_tup
-            val = load_item(context, builder, aryty, ary_iter_ptr)
-            res_val = mul_funcfn(builder, (
-                load_item(context, builder, acc_type, acc_ptr),
-                context.cast(builder, val, aryty.dtype, sig.return_type.dtype)))
-            store_item(context, builder, acc_type, res_val, acc_ptr)
-            store_item(context, builder, sig.return_type,
-                       load_item(context, builder, acc_type, acc_ptr), res_ptr)
-
-        context.nrt.decref(builder, acc_type, acc._getvalue())
-
-        return impl_ret_new_ref(
-            context, builder, sig.return_type, res._getvalue()
-        )
-
-    return sig, codegen
 
 
 @overload(np.cumprod)

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -225,6 +225,12 @@ def array_var_axis_kws(a, axis):
 def array_var_axis_tuple_kws(a, axis):
     return np.var(a, axis=axis)
 
+def array_std_axis_kws(a, axis):
+    return a.std(axis=axis)
+
+def array_std_axis_tuple_kws(a, axis):
+    return np.std(a, axis=axis)
+
 def array_prod(a, *args):
     return a.prod(*args)
 
@@ -1984,6 +1990,42 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
                 continue
             for axis in ((0, 1), (1, 2), (0, 2), (0, 1, 2)):
                 with self.subTest("Testing np.var(tuple axis) with {} "
+                                  "input ".format(arr.dtype)):
+                    self.assertPreciseEqual(pyfunc(arr, axis=axis),
+                                            cfunc(arr, axis=axis))
+
+    def test_std_axis(self):
+        """ test std with axis parameter over a whole range of dtypes
+        """
+        pyfunc = array_std_axis_kws
+        cfunc = jit(nopython=True)(pyfunc)
+        signed_dtypes = [np.float64, np.float32, np.int64, np.int32,
+                         np.complex64, np.complex128]
+        unsigned_dtypes = [np.uint32, np.uint64, np.bool_]
+
+        for arr in self.gen_sum_array_cases(signed_dtypes, unsigned_dtypes):
+            for axis in (0, 1, 2):
+                if axis > len(arr.shape) - 1:
+                    continue
+                with self.subTest("Testing np.std(axis) with {} "
+                                  "input ".format(arr.dtype)):
+                    self.assertPreciseEqual(pyfunc(arr, axis=axis),
+                                            cfunc(arr, axis=axis))
+
+    def test_std_axis_tuple(self):
+        """ test std with tuple axis over a whole range of dtypes
+        """
+        pyfunc = array_std_axis_tuple_kws
+        cfunc = jit(nopython=True)(pyfunc)
+        signed_dtypes = [np.float64, np.float32, np.int64, np.int32,
+                         np.complex64, np.complex128]
+        unsigned_dtypes = [np.uint32, np.uint64, np.bool_]
+
+        for arr in self.gen_sum_array_cases(signed_dtypes, unsigned_dtypes):
+            if arr.ndim != 3:
+                continue
+            for axis in ((0, 1), (1, 2), (0, 2), (0, 1, 2)):
+                with self.subTest("Testing np.std(tuple axis) with {} "
                                   "input ".format(arr.dtype)):
                     self.assertPreciseEqual(pyfunc(arr, axis=axis),
                                             cfunc(arr, axis=axis))

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -213,6 +213,12 @@ def array_cumprod_axis_dtype_kws(a, dtype, axis):
 def array_sum_axis_dtype_pos(a, a1, a2):
     return a.sum(a1, a2)
 
+def array_mean_axis_kws(a, axis):
+    return a.mean(axis=axis)
+
+def array_mean_axis_tuple_kws(a, axis):
+    return np.mean(a, axis=axis)
+
 def array_prod(a, *args):
     return a.prod(*args)
 
@@ -1903,6 +1909,42 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
                         py_res = pyfunc(arr, axis=axis, dtype=out_dtype)
                         nb_res = cfunc(arr, axis=axis, dtype=out_dtype)
                         self.assertPreciseEqual(py_res, nb_res)
+
+    def test_mean_axis(self):
+        """ test mean with axis parameter over a whole range of dtypes
+        """
+        pyfunc = array_mean_axis_kws
+        cfunc = jit(nopython=True)(pyfunc)
+        signed_dtypes = [np.float64, np.float32, np.int64, np.int32,
+                         np.complex64, np.complex128]
+        unsigned_dtypes = [np.uint32, np.uint64, np.bool_]
+
+        for arr in self.gen_sum_array_cases(signed_dtypes, unsigned_dtypes):
+            for axis in (0, 1, 2):
+                if axis > len(arr.shape) - 1:
+                    continue
+                with self.subTest("Testing np.mean(axis) with {} "
+                                  "input ".format(arr.dtype)):
+                    self.assertPreciseEqual(pyfunc(arr, axis=axis),
+                                            cfunc(arr, axis=axis))
+
+    def test_mean_axis_tuple(self):
+        """ test mean with tuple axis over a whole range of dtypes
+        """
+        pyfunc = array_mean_axis_tuple_kws
+        cfunc = jit(nopython=True)(pyfunc)
+        signed_dtypes = [np.float64, np.float32, np.int64, np.int32,
+                         np.complex64, np.complex128]
+        unsigned_dtypes = [np.uint32, np.uint64, np.bool_]
+
+        for arr in self.gen_sum_array_cases(signed_dtypes, unsigned_dtypes):
+            if arr.ndim != 3:
+                continue
+            for axis in ((0, 1), (1, 2), (0, 2), (0, 1, 2)):
+                with self.subTest("Testing np.mean(tuple axis) with {} "
+                                  "input ".format(arr.dtype)):
+                    self.assertPreciseEqual(pyfunc(arr, axis=axis),
+                                            cfunc(arr, axis=axis))
 
     def test_take(self):
         pyfunc = array_take

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -219,6 +219,12 @@ def array_mean_axis_kws(a, axis):
 def array_mean_axis_tuple_kws(a, axis):
     return np.mean(a, axis=axis)
 
+def array_var_axis_kws(a, axis):
+    return a.var(axis=axis)
+
+def array_var_axis_tuple_kws(a, axis):
+    return np.var(a, axis=axis)
+
 def array_prod(a, *args):
     return a.prod(*args)
 
@@ -1942,6 +1948,42 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
                 continue
             for axis in ((0, 1), (1, 2), (0, 2), (0, 1, 2)):
                 with self.subTest("Testing np.mean(tuple axis) with {} "
+                                  "input ".format(arr.dtype)):
+                    self.assertPreciseEqual(pyfunc(arr, axis=axis),
+                                            cfunc(arr, axis=axis))
+
+    def test_var_axis(self):
+        """ test var with axis parameter over a whole range of dtypes
+        """
+        pyfunc = array_var_axis_kws
+        cfunc = jit(nopython=True)(pyfunc)
+        signed_dtypes = [np.float64, np.float32, np.int64, np.int32,
+                         np.complex64, np.complex128]
+        unsigned_dtypes = [np.uint32, np.uint64, np.bool_]
+
+        for arr in self.gen_sum_array_cases(signed_dtypes, unsigned_dtypes):
+            for axis in (0, 1, 2):
+                if axis > len(arr.shape) - 1:
+                    continue
+                with self.subTest("Testing np.var(axis) with {} "
+                                  "input ".format(arr.dtype)):
+                    self.assertPreciseEqual(pyfunc(arr, axis=axis),
+                                            cfunc(arr, axis=axis))
+
+    def test_var_axis_tuple(self):
+        """ test var with tuple axis over a whole range of dtypes
+        """
+        pyfunc = array_var_axis_tuple_kws
+        cfunc = jit(nopython=True)(pyfunc)
+        signed_dtypes = [np.float64, np.float32, np.int64, np.int32,
+                         np.complex64, np.complex128]
+        unsigned_dtypes = [np.uint32, np.uint64, np.bool_]
+
+        for arr in self.gen_sum_array_cases(signed_dtypes, unsigned_dtypes):
+            if arr.ndim != 3:
+                continue
+            for axis in ((0, 1), (1, 2), (0, 2), (0, 1, 2)):
+                with self.subTest("Testing np.var(tuple axis) with {} "
                                   "input ".format(arr.dtype)):
                     self.assertPreciseEqual(pyfunc(arr, axis=axis),
                                             cfunc(arr, axis=axis))

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -210,6 +210,21 @@ def array_cumsum_axis_dtype_kws(a, dtype, axis):
 def array_sum_axis_dtype_pos(a, a1, a2):
     return a.sum(a1, a2)
 
+def array_prod(a, *args):
+    return a.prod(*args)
+
+def array_prod_axis_kws(a, axis):
+    return a.prod(axis=axis)
+
+def array_prod_dtype_kws(a, dtype):
+    return a.prod(dtype=dtype)
+
+def array_prod_axis_dtype_kws(a, dtype, axis):
+    return a.prod(axis=axis, dtype=dtype)
+
+def array_prod_axis_dtype_pos(a, a1, a2):
+    return a.prod(a1, a2)
+
 def array_sum_const_multi(arr, axis):
     # use np.sum with different constant args multiple times to check
     # for internal compile cache to see if constant-specialization is
@@ -1592,6 +1607,163 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
 
         self.assertPreciseEqual(pyfunc(a, 2, dtype),
                                 cfunc(a, 2, dtype))
+
+    def test_prod_axis_kws1(self):
+        """ test prod with axis parameter over a whole range of dtypes  """
+        pyfunc = array_prod_axis_kws
+        cfunc = jit(nopython=True)(pyfunc)
+        signed_dtypes_no_int32 = [
+            np.float64, np.float32, np.int64, np.complex64,
+            np.complex128,
+        ]
+
+        unsigned_dtypes_no_uint32 = [np.uint64, np.bool_]
+
+        for arr in self.gen_sum_array_cases(signed_dtypes_no_int32,
+                                            unsigned_dtypes_no_uint32):
+            for axis in (0, 1, 2):
+                if axis > len(arr.shape)-1:
+                    continue
+                with self.subTest("Testing np.prod(axis) with {} "
+                                  "input ".format(arr.dtype)):
+                    self.assertPreciseEqual(pyfunc(arr, axis=axis),
+                                            cfunc(arr, axis=axis))
+
+    def test_prod_axis_kws2(self):
+        """  testing uint32 and int32 separately
+
+        uint32 and int32 must be tested separately because Numpy's current
+        behaviour is different in 64bits Windows (accumulates as int32)
+        and 64bits Linux (accumulates as int64), while Numba has decided to
+        always accumulate as int64, when the OS is 64bits. No testing has
+        been done for behaviours in 32 bits platforms.
+        """
+        pyfunc = array_prod_axis_kws
+        cfunc = jit(nopython=True)(pyfunc)
+        signed_dtypes_only_int32 = [np.int32]
+        # expected return dtypes in Numba
+        out_dtypes = {np.dtype('int32'): np.int64,
+                      np.dtype('uint32'): np.uint64,
+                      np.dtype('int64'): np.int64}
+
+        unsigned_dtypes_only_uint32 = [np.uint32]
+
+        for arr in self.gen_sum_array_cases(signed_dtypes_only_int32,
+                                            unsigned_dtypes_only_uint32):
+            for axis in (0, 1, 2):
+                if axis > len(arr.shape)-1:
+                    continue
+                with self.subTest("Testing np.prod(axis) with {} "
+                                  "input ".format(arr.dtype)):
+                    npy_res = pyfunc(arr, axis=axis)
+                    numba_res = cfunc(arr, axis=axis)
+                    if isinstance(numba_res, np.ndarray):
+                        self.assertPreciseEqual(
+                            npy_res.astype(out_dtypes[arr.dtype]),
+                            numba_res.astype(out_dtypes[arr.dtype]))
+                    else:
+                        # the results are scalars
+                        self.assertEqual(npy_res, numba_res)
+
+    def test_prod_axis_dtype_kws(self):
+        """ test prod with axis and dtype parameters over a whole range
+        of dtypes """
+        pyfunc = array_prod_axis_dtype_kws
+        cfunc = jit(nopython=True)(pyfunc)
+        signed_dtypes = [np.float64, np.float32, np.int64, np.int32,
+                         np.complex64, np.complex128]
+
+        unsigned_dtypes = [np.uint32, np.uint64, np.bool_]
+
+        out_dtypes = {np.dtype('float64'): [np.float64],
+                      np.dtype('float32'): [np.float64, np.float32],
+                      np.dtype('int64'): [np.float64, np.int64, np.float32],
+                      np.dtype('int32'): [np.float64, np.int64, np.float32,
+                                          np.int32],
+                      np.dtype('uint32'): [np.float64, np.int64, np.float32],
+                      np.dtype('uint64'): [np.float64, np.uint64],
+                      np.dtype('bool'): [np.float64, np.int64, np.float32,
+                                         np.int32, np.bool_],
+                      np.dtype('complex64'): [np.complex64, np.complex128],
+                      np.dtype('complex128'): [np.complex128]}
+
+        for arr in self.gen_sum_array_cases(signed_dtypes, unsigned_dtypes):
+            for out_dtype in out_dtypes[arr.dtype]:
+                for axis in (0, 1, 2):
+                    if axis > len(arr.shape) - 1:
+                        continue
+                    subtest_str = ("Testing np.prod with {} input and {} "
+                                   "output ".format(arr.dtype, out_dtype))
+                    with self.subTest(subtest_str):
+                        py_res = pyfunc(arr, axis=axis, dtype=out_dtype)
+                        nb_res = cfunc(arr, axis=axis, dtype=out_dtype)
+                        self.assertPreciseEqual(py_res, nb_res)
+
+    def test_prod_axis_tuple(self):
+        """ test prod with axis as a tuple """
+        pyfunc = array_prod_axis_kws
+        cfunc = jit(nopython=True)(pyfunc)
+        a = np.arange(2 * 3 * 4).reshape(2, 3, 4)
+
+        data = [-2, -1, 0, 1, 2]
+        all_perms = list(chain.from_iterable(
+            permutations(data, r) for r in range(len(data) + 1)
+        ))
+        for axes in all_perms:
+            with self.subTest(axes=axes):
+                # Check for duplicate axis
+                np_axes = (np.array(axes) % 3)
+                if len(np_axes) == len(np.unique(np_axes)):
+                    self.assertPreciseEqual(pyfunc(a, axes), cfunc(a, axes))
+
+    def test_prod_axis_tuple_duplicates(self):
+        """ test prod with axis as a tuple """
+        self.disable_leak_check()
+        pyfunc = array_prod_axis_kws
+        err = ValueError if numpy_version < (1, 25) else np.exceptions.AxisError
+        cfunc = jit(nopython=True)(pyfunc)
+        a = np.arange(2 * 3 * 4).reshape(2, 3, 4)
+
+        data = [-3, -2, -1, 0, 1, 2, 3]
+        all_perms = list(chain.from_iterable(
+            permutations(data, r) for r in range(len(data) + 1)
+        ))
+        for axes in all_perms:
+            with self.subTest(axes=axes):
+                # Check for duplicate axis
+                if 3 in axes:
+                    # 3 is out of bounds for an array of dimension 3
+                    # but -3 is not.
+                    with self.assertRaises(err) as c_raises:
+                        cfunc(a, axes)
+                    # This will raise a different exception than the duplicate
+                    # axis case, so we need to check for the correct error
+                    # message.
+                    self.assertIn(
+                        "out of bounds for array of dimension 3",
+                        str(c_raises.exception)
+                    )
+                    with self.assertRaises(err) as py_raises:
+                        pyfunc(a, axes)
+                    self.assertEqual(
+                        str(c_raises.exception),
+                        str(py_raises.exception)
+                    )
+                    continue
+                np_axes = (np.array(axes) % 3)
+                if len(np_axes) != len(np.unique(np_axes)):
+                    with self.assertRaises(ValueError) as c_raises:
+                        cfunc(a, axes)
+                    self.assertIn(
+                        "duplicate value in 'axis'",
+                        str(c_raises.exception)
+                    )
+                    with self.assertRaises(ValueError) as py_raises:
+                        pyfunc(a, axes)
+                    self.assertEqual(
+                        str(c_raises.exception),
+                        str(py_raises.exception)
+                    )
 
     def test_sum_1d_kws(self):
         # check 1d reduces to scalar

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -207,6 +207,9 @@ def array_sum_axis_dtype_kws(a, dtype, axis):
 def array_cumsum_axis_dtype_kws(a, dtype, axis):
     return a.cumsum(axis=axis, dtype=dtype)
 
+def array_cumprod_axis_dtype_kws(a, dtype, axis):
+    return a.cumprod(axis=axis, dtype=dtype)
+
 def array_sum_axis_dtype_pos(a, a1, a2):
     return a.sum(a1, a2)
 
@@ -1864,6 +1867,37 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
                     if axis > len(arr.shape) - 1:
                         continue
                     subtest_str = ("Testing np.cumsum with {} input and {} output "
+                                    .format(arr.dtype, out_dtype))
+                    with self.subTest(subtest_str):
+                        py_res = pyfunc(arr, axis=axis, dtype=out_dtype)
+                        nb_res = cfunc(arr, axis=axis, dtype=out_dtype)
+                        self.assertPreciseEqual(py_res, nb_res)
+
+    def test_cumprod(self):
+        """ test cumprod with axis and dtype parameters over a whole range of dtypes """
+        pyfunc = array_cumprod_axis_dtype_kws
+        cfunc = jit(nopython=True)(pyfunc)
+        signed_dtypes = [np.float64, np.float32, np.int64, np.int32,
+                      np.complex64, np.complex128]
+
+        unsigned_dtypes = [np.uint32, np.uint64, np.bool_]
+
+        out_dtypes = {np.dtype('float64'): [np.float64],
+                      np.dtype('float32'): [np.float64, np.float32],
+                      np.dtype('int64'): [np.float64, np.int64, np.float32],
+                      np.dtype('int32'): [np.float64, np.int64, np.float32, np.int32],
+                      np.dtype('uint32'): [np.float64, np.int64, np.float32],
+                      np.dtype('uint64'): [np.float64, np.uint64],
+                      np.dtype('bool'): [np.float64, np.int64, np.float32, np.int32, np.bool_],
+                      np.dtype('complex64'): [np.complex64, np.complex128],
+                      np.dtype('complex128'): [np.complex128]}
+
+        for arr in self.gen_sum_array_cases(signed_dtypes, unsigned_dtypes):
+            for out_dtype in out_dtypes[arr.dtype]:
+                for axis in (0, 1, 2):
+                    if axis > len(arr.shape) - 1:
+                        continue
+                    subtest_str = ("Testing np.cumprod with {} input and {} output "
                                     .format(arr.dtype, out_dtype))
                     with self.subTest(subtest_str):
                         py_res = pyfunc(arr, axis=axis, dtype=out_dtype)

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -26,6 +26,12 @@ def array_cumprod(arr):
 def array_cumprod_global(arr):
     return np.cumprod(arr)
 
+def array_cumprod_axis(arr, axis):
+    return arr.cumprod(axis=axis)
+
+def array_cumprod_global_axis(arr, axis):
+    return np.cumprod(arr, axis=axis)
+
 def array_nancumprod(arr):
     return np.nancumprod(arr)
 
@@ -979,6 +985,30 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
 
     def test_array_cumprod_global(self):
         self.check_cumulative(array_cumprod_global)
+
+    def check_cumulative_axis(self, pyfunc):
+        cfunc = jit(nopython=True)(pyfunc)
+
+        def check(arr, axis):
+            expected = pyfunc(arr, axis)
+            got = cfunc(arr, axis)
+            self.assertPreciseEqual(got, expected)
+
+        arr = np.arange(1, 13, dtype=np.int16).reshape(3, 4)
+        for axis in (0, 1, -1):
+            check(arr, axis)
+        arr = np.arange(1, 25, dtype=np.int32).reshape(2, 3, 4)
+        for axis in (0, 1, 2, -1):
+            check(arr, axis)
+        arr = np.linspace(2, 8, 12).reshape(3, 4)
+        for axis in (0, 1):
+            check(arr, axis)
+
+    def test_array_cumprod_axis(self):
+        self.check_cumulative_axis(array_cumprod_axis)
+
+    def test_array_cumprod_global_axis(self):
+        self.check_cumulative_axis(array_cumprod_global_axis)
 
     def check_aggregation_magnitude(self, pyfunc, is_prod=False):
         """

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -62,6 +62,12 @@ def array_mean(arr):
 def array_mean_global(arr):
     return np.mean(arr)
 
+def array_mean_axis(arr, axis):
+    return arr.mean(axis=axis)
+
+def array_mean_global_axis(arr, axis):
+    return np.mean(arr, axis=axis)
+
 def array_var(arr):
     return arr.var()
 
@@ -458,6 +464,57 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
 
     def test_mean_basic(self):
         self.check_reduction_basic(array_mean)
+
+    def check_mean_axis(self, pyfunc):
+        cfunc = jit(nopython=True)(pyfunc)
+
+        def check(arr, axis):
+            expected = pyfunc(arr, axis)
+            got = cfunc(arr, axis)
+            self.assertPreciseEqual(got, expected)
+
+        # integer arrays
+        arr = np.arange(1, 13, dtype=np.int16).reshape(3, 4)
+        for axis in (0, 1, -1, -2):
+            check(arr, axis)
+        arr = np.arange(1, 25, dtype=np.int32).reshape(2, 3, 4)
+        for axis in (0, 1, 2, -1, -2, -3):
+            check(arr, axis)
+        # tuple axes
+        for axis in ((0, 1), (1, 2), (0, 2), (0, 1, 2), (-1, -2)):
+            check(arr, axis)
+        # floating point arrays
+        arr = np.linspace(2, 8, 12).reshape(3, 4)
+        for axis in (0, 1, -1):
+            check(arr, axis)
+        arr = np.linspace(1, 5, 24).reshape(2, 3, 4)
+        for axis in ((0, 1), (1, 2)):
+            check(arr, axis)
+        # complex arrays (exact values, as Numba's sequential sum may
+        # differ from NumPy's pairwise sum in the last bit otherwise)
+        arr = (np.arange(1, 13) + 1j *
+               np.arange(13, 25)).reshape(3, 4)
+        for axis in (0, 1, -1):
+            check(arr, axis)
+        arr = (np.arange(1, 25) + 1j *
+               np.arange(25, 49)).reshape(2, 3, 4)
+        for axis in ((0, 1), (1, 2)):
+            check(arr, axis)
+        # boolean arrays
+        arr = (np.arange(12).reshape(3, 4) % 2).astype(np.bool_)
+        for axis in (0, 1):
+            check(arr, axis)
+        # timedelta arrays
+        arr = np.arange(1, 13, dtype=np.int64).reshape(3, 4).astype(
+            'timedelta64[D]')
+        for axis in (0, 1, -1):
+            check(arr, axis)
+
+    def test_array_mean_axis(self):
+        self.check_mean_axis(array_mean_axis)
+
+    def test_array_mean_global_axis(self):
+        self.check_mean_axis(array_mean_global_axis)
 
     def test_np_mean_scalar(self):
         cfunc = jit(nopython=True)(array_mean_global)

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -86,6 +86,12 @@ def array_std(arr):
 def array_std_global(arr):
     return np.std(arr)
 
+def array_std_axis(arr, axis):
+    return arr.std(axis=axis)
+
+def array_std_global_axis(arr, axis):
+    return np.std(arr, axis=axis)
+
 def array_min(arr):
     return arr.min()
 
@@ -569,6 +575,54 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
 
     def test_array_var_global_axis(self):
         self.check_var_axis(array_var_global_axis)
+
+    def check_std_axis(self, pyfunc):
+        cfunc = jit(nopython=True)(pyfunc)
+
+        def check(arr, axis):
+            expected = pyfunc(arr, axis)
+            got = cfunc(arr, axis)
+            # Numba's sequential sum may differ from NumPy's pairwise sum
+            # in the last bit, so allow a small tolerance.
+            self.assertPreciseEqual(got, expected, prec='double')
+
+        # integer arrays
+        arr = np.arange(1, 13, dtype=np.int16).reshape(3, 4)
+        for axis in (0, 1, -1, -2):
+            check(arr, axis)
+        arr = np.arange(1, 25, dtype=np.int32).reshape(2, 3, 4)
+        for axis in (0, 1, 2, -1, -2, -3):
+            check(arr, axis)
+        # tuple axes
+        for axis in ((0, 1), (1, 2), (0, 2), (0, 1, 2), (-1, -2)):
+            check(arr, axis)
+        # floating point arrays
+        arr = np.linspace(2, 8, 12).reshape(3, 4)
+        for axis in (0, 1, -1):
+            check(arr, axis)
+        arr = np.linspace(1, 5, 24).reshape(2, 3, 4)
+        for axis in ((0, 1), (1, 2)):
+            check(arr, axis)
+        # complex arrays (exact values, as Numba's sequential sum may
+        # differ from NumPy's pairwise sum in the last bit otherwise)
+        arr = (np.arange(1, 13) + 1j *
+               np.arange(13, 25)).reshape(3, 4)
+        for axis in (0, 1, -1):
+            check(arr, axis)
+        arr = (np.arange(1, 25) + 1j *
+               np.arange(25, 49)).reshape(2, 3, 4)
+        for axis in ((0, 1), (1, 2)):
+            check(arr, axis)
+        # boolean arrays
+        arr = (np.arange(12).reshape(3, 4) % 2).astype(np.bool_)
+        for axis in (0, 1):
+            check(arr, axis)
+
+    def test_array_std_axis(self):
+        self.check_std_axis(array_std_axis)
+
+    def test_array_std_global_axis(self):
+        self.check_std_axis(array_std_global_axis)
 
     def test_np_mean_scalar(self):
         cfunc = jit(nopython=True)(array_mean_global)

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -74,6 +74,12 @@ def array_var(arr):
 def array_var_global(arr):
     return np.var(arr)
 
+def array_var_axis(arr, axis):
+    return arr.var(axis=axis)
+
+def array_var_global_axis(arr, axis):
+    return np.var(arr, axis=axis)
+
 def array_std(arr):
     return arr.std()
 
@@ -515,6 +521,54 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
 
     def test_array_mean_global_axis(self):
         self.check_mean_axis(array_mean_global_axis)
+
+    def check_var_axis(self, pyfunc):
+        cfunc = jit(nopython=True)(pyfunc)
+
+        def check(arr, axis):
+            expected = pyfunc(arr, axis)
+            got = cfunc(arr, axis)
+            # Numba's sequential sum may differ from NumPy's pairwise sum
+            # in the last bit, so allow a small tolerance.
+            self.assertPreciseEqual(got, expected, prec='double')
+
+        # integer arrays
+        arr = np.arange(1, 13, dtype=np.int16).reshape(3, 4)
+        for axis in (0, 1, -1, -2):
+            check(arr, axis)
+        arr = np.arange(1, 25, dtype=np.int32).reshape(2, 3, 4)
+        for axis in (0, 1, 2, -1, -2, -3):
+            check(arr, axis)
+        # tuple axes
+        for axis in ((0, 1), (1, 2), (0, 2), (0, 1, 2), (-1, -2)):
+            check(arr, axis)
+        # floating point arrays
+        arr = np.linspace(2, 8, 12).reshape(3, 4)
+        for axis in (0, 1, -1):
+            check(arr, axis)
+        arr = np.linspace(1, 5, 24).reshape(2, 3, 4)
+        for axis in ((0, 1), (1, 2)):
+            check(arr, axis)
+        # complex arrays (exact values, as Numba's sequential sum may
+        # differ from NumPy's pairwise sum in the last bit otherwise)
+        arr = (np.arange(1, 13) + 1j *
+               np.arange(13, 25)).reshape(3, 4)
+        for axis in (0, 1, -1):
+            check(arr, axis)
+        arr = (np.arange(1, 25) + 1j *
+               np.arange(25, 49)).reshape(2, 3, 4)
+        for axis in ((0, 1), (1, 2)):
+            check(arr, axis)
+        # boolean arrays
+        arr = (np.arange(12).reshape(3, 4) % 2).astype(np.bool_)
+        for axis in (0, 1):
+            check(arr, axis)
+
+    def test_array_var_axis(self):
+        self.check_var_axis(array_var_axis)
+
+    def test_array_var_global_axis(self):
+        self.check_var_axis(array_var_global_axis)
 
     def test_np_mean_scalar(self):
         cfunc = jit(nopython=True)(array_mean_global)


### PR DESCRIPTION
Builds on top of #10795 

This PR adds `axis` argument support for `np.mean`, `np.var` and `np.std` reduction functions.