### PR TITLE
Add inline type annotations to `unliteral`.

### DIFF
--- a/numba/core/types/common.py
+++ b/numba/core/types/common.py
@@ -2,8 +2,10 @@
 Helper classes / mixins for defining types.
 """
 
-from .abstract import ArrayCompatible, Dummy, IterableType, IteratorType
 from numba.core.errors import NumbaTypeError, NumbaValueError
+from numba.core.types.abstract import ArrayCompatible, IteratorType
+from numba.core.types.abstract import Dummy as Dummy
+from numba.core.types.abstract import IterableType as IterableType
 
 
 class Opaque(Dummy):

--- a/numba/core/types/common.pyi
+++ b/numba/core/types/common.pyi
@@ -1,8 +1,10 @@
-from typing import ClassVar, Literal, TypeAlias
+from typing import ClassVar, Generic, Literal, TypeAlias, TypeVar
 
-from typing_extensions import Generic, Self, TypeVar, override
+from typing_extensions import Self, override
 
-from .abstract import ArrayCompatible, Dummy, IterableType, IteratorType, Type
+from .abstract import ArrayCompatible, IteratorType, Type
+from .abstract import Dummy as Dummy
+from .abstract import IterableType as IterableType
 from .iterators import ArrayIterator
 
 _TypeT_co = TypeVar("_TypeT_co", bound=Type, default=Type, covariant=True)
@@ -11,19 +13,32 @@ _Layout: TypeAlias = Literal["C", "F", "CS", "FS", "A"]
 
 ###
 
-class Opaque(Dummy): ...
+
+class Opaque(Dummy):
+    ...
+
 
 class SimpleIterableType(IterableType[_TypeT_co], Generic[_TypeT_co]):
-    def __init__(self, name: str, iterator_type: IteratorType[_TypeT_co]) -> None: ...
+    def __init__(
+        self, name: str, iterator_type: IteratorType[_TypeT_co]
+    ) -> None:
+        ...
+
     @property
     @override
-    def iterator_type(self) -> IteratorType[_TypeT_co]: ...
+    def iterator_type(self) -> IteratorType[_TypeT_co]:
+        ...
+
 
 class SimpleIteratorType(IteratorType[_TypeT_co], Generic[_TypeT_co]):
-    def __init__(self, name: str, yield_type: _TypeT_co) -> None: ...
+    def __init__(self, name: str, yield_type: _TypeT_co) -> None:
+        ...
+
     @property
     @override
-    def yield_type(self) -> _TypeT_co: ...
+    def yield_type(self) -> _TypeT_co:
+        ...
+
 
 class Buffer(IterableType, ArrayCompatible):
     LAYOUTS: ClassVar[frozenset[_Layout]] = ...
@@ -40,24 +55,36 @@ class Buffer(IterableType, ArrayCompatible):
         layout: _Layout,
         readonly: bool = False,
         name: str | None = None,
-    ) -> None: ...
+    ) -> None:
+        ...
+
     @property  # TODO: Use generic `ArrayIterator` once we have `iterators.pyi`
     @override
-    def iterator_type(self) -> ArrayIterator: ...
+    def iterator_type(self) -> ArrayIterator:
+        ...
+
     @property
     @override
-    def as_array(self) -> Self: ...
+    def as_array(self) -> Self:
+        ...
+
     @property
     @override
-    def key(self) -> tuple[Type, int, _Layout, bool]: ...
+    def key(self) -> tuple[Type, int, _Layout, bool]:
+        ...
 
     #
     @property
-    def is_c_contig(self) -> bool: ...
+    def is_c_contig(self) -> bool:
+        ...
+
     @property
-    def is_f_contig(self) -> bool: ...
+    def is_f_contig(self) -> bool:
+        ...
+
     @property
-    def is_contig(self) -> bool: ...
+    def is_contig(self) -> bool:
+        ...
 
     #
     def copy(
@@ -65,4 +92,5 @@ class Buffer(IterableType, ArrayCompatible):
         dtype: Type | None = None,
         ndim: int | None = None,
         layout: _Layout | None = None,
-    ) -> Self: ...
+    ) -> Self:
+        ...

--- a/numba/core/types/misc.py
+++ b/numba/core/types/misc.py
@@ -5,6 +5,10 @@ from numba.core.typeconv import Conversion
 from numba.core.errors import TypingError, LiteralTypingError
 from numba.core.ir import UndefinedType
 from numba.core.utils import get_hashable_key
+from typing import TypeVar
+
+
+_TypeT = TypeVar("_TypeT", bound=Type, default=Type)
 
 
 class PyObject(Dummy):
@@ -60,13 +64,15 @@ class StringLiteral(Literal, Dummy):
 Literal.ctor_map[str] = StringLiteral
 
 
-def unliteral(lit_type):
-    """
-    Get base type from Literal type.
-    """
+def unliteral(lit_type: _TypeT) -> Type | _TypeT:
+    """Get base type from Literal type."""
     if hasattr(lit_type, '__unliteral__'):
-        return lit_type.__unliteral__()
-    return getattr(lit_type, 'literal_type', lit_type)
+        returnMe = lit_type.__unliteral__()
+    elif hasattr(lit_type, 'literal_type'):
+        returnMe = lit_type.literal_type
+    else:
+        returnMe = lit_type
+    return returnMe
 
 
 def literal(value):

--- a/numba/core/types/misc.py
+++ b/numba/core/types/misc.py
@@ -1,12 +1,10 @@
-from numba.core.types.abstract import Callable, Literal, Type, Hashable
-from numba.core.types.common import (Dummy, IterableType, Opaque,
-                                     SimpleIteratorType)
-from numba.core.typeconv import Conversion
-from numba.core.errors import TypingError, LiteralTypingError
-from numba.core.ir import UndefinedType
-from numba.core.utils import get_hashable_key
 from typing import TypeVar
 
+from numba.core.errors import LiteralTypingError, TypingError
+from numba.core.typeconv import Conversion
+from numba.core.types.abstract import Callable, Hashable, Literal, Type
+from numba.core.types.common import Dummy, IterableType, Opaque, SimpleIteratorType
+from numba.core.utils import get_hashable_key
 
 _TypeT = TypeVar("_TypeT", bound=Type, default=Type)
 

--- a/numba/core/types/misc.py
+++ b/numba/core/types/misc.py
@@ -29,7 +29,7 @@ class Phantom(Dummy):
 
 class Undefined(Dummy):
     """
-    A type that is left imprecise.  This is used as a temporaray placeholder
+    A type that is left imprecise.  This is used as a temporary placeholder
     during type inference in the hope that the type can be later refined.
     """
 


### PR DESCRIPTION
- Add TypeVar in the style of abstract.pyi.
- Format docstring.
- Refactor
    - May help some type checkers infer the type.
    - Can help humans understand why a type checker inferred or didn't infer a type.
    - Single return.
- Update import statements.
- Fix flake8 diagnostics.
- Fix typo.