### PR TITLE
Release frame-owned references when an exception propagates out of a jitted function

### DIFF
--- a/docs/upcoming_changes/10783.bug_fix.rst
+++ b/docs/upcoming_changes/10783.bug_fix.rst
@@ -1,0 +1,9 @@
+Fix memory leak when an exception propagates out of a jitted function
+---------------------------------------------------------------------
+
+When an exception raised in a callee propagated out of a jitted function,
+references owned by that function's frame (arguments and locals live across
+the raising call) were leaked. This could pin caller-provided arrays and
+cause unbounded memory growth. Error propagation is now routed through a
+per-function cleanup block that releases all NRT-managed references owned
+by the frame before returning.

--- a/numba/core/callconv.py
+++ b/numba/core/callconv.py
@@ -774,7 +774,18 @@ class CPUCallConv(BaseCallConv):
         excptr = self._get_excinfo_argument(builder.function)
         builder.store(status.excinfoptr, excptr)
         with builder.if_then(builder.not_(trystatus.in_try)):
-            self._return_errcode_raw(builder, status.code)
+
+            # If the lowering registered an exception cleanup block for
+            # this frame, route the error return through it so that owned
+            # references are released (see issue #10783).
+            frame_cleanup = getattr(builder, '_frame_exception_cleanup', None)
+
+            if frame_cleanup is not None:
+                bb, retcode_slot = frame_cleanup()
+                builder.store(status.code, retcode_slot)
+                builder.branch(bb)
+            else:
+                self._return_errcode_raw(builder, status.code)
 
     def _return_errcode_raw(self, builder, code):
         builder.ret(code)

--- a/numba/core/lowering.py
+++ b/numba/core/lowering.py
@@ -348,8 +348,22 @@ class Lower(BaseLower):
 
     def init(self):
         super().init()
+
         # find all singly assigned variables
         self._find_singly_assigned_variable()
+
+        # Lazily created (block, retcode slot) pair releasing this frame's
+        # owned references before returning a propagated error status.
+        # See _get_exception_cleanup_block().
+
+        self._exception_cleanup = None
+
+        # Frontend type of each stack slot, recorded when the slot is
+        # created.  Kept separately from fndesc.typemap as the latter may
+        # be temporarily swapped out (e.g. by parfor lowering) while the
+        # slots live on.
+
+        self._varmap_fetypes = {}
 
     @property
     def _disable_sroa_like_opt(self):
@@ -395,6 +409,22 @@ class Lower(BaseLower):
                     num_assigns_for_blk[stmt.target.name] += 1
                 num_assigns_by_defblk_and_var[defblk] = num_assigns_for_blk
 
+            # NRT-managed variables must live in a stack slot so that the
+            # exception cleanup block can release the references they own
+            # when an error status is propagated out of this function (see
+            # _get_exception_cleanup_block).
+
+            dmm = self.context.data_model_manager
+            typemap = self.fndesc.typemap
+
+            def must_spill(var):
+                if not self.context.enable_nrt:
+                    return False
+                fetype = typemap.get(var)
+                if fetype is None:
+                    return False
+                return dmm[fetype].contains_nrt_meminfo()
+
             # Keep only variables that are defined locally and used locally
             for var in var_assign_map:
                 if var not in alloca_vars and len(var_assign_map[var]) == 1:
@@ -403,11 +433,75 @@ class Lower(BaseLower):
                         [defblk] = var_assign_map[var]
                         # Ensure that the variable is not defined multiple
                         # times in the block
-                        if num_assigns_by_defblk_and_var[defblk][var] == 1:
+                        if (num_assigns_by_defblk_and_var[defblk][var] == 1
+                                and not must_spill(var)):
                             sav.add(var)
 
         self._singly_assigned_vars = sav
         self._blk_local_varmap = {}
+
+    def pre_lower(self):
+        super().pre_lower()
+
+        # Let the call convention route error propagation through this
+        # frame's exception cleanup block so that owned references are
+        # released; see issue #10783.  Generators manage their state
+        # differently and are not supported.
+
+        if self.context.enable_nrt and not self.func_ir.func_id.is_generator:
+            self.builder._frame_exception_cleanup = \
+                self._get_exception_cleanup_block
+
+    def post_lower(self):
+        self._emit_exception_cleanup_block()
+        super().post_lower()
+
+    def _get_exception_cleanup_block(self):
+        """
+        Get (creating it if necessary) the basic block releasing this
+        frame's owned references before returning a propagated error
+        status, along with the stack slot holding the error code to
+        return.  The block contents are emitted by
+        _emit_exception_cleanup_block() once the whole function body has
+        been lowered.
+        """
+        if self._exception_cleanup is None:
+            bb = self.function.append_basic_block('exc.cleanup')
+            retcode_slot = cgutils.alloca_once(
+                self.builder, llvmlite.ir.IntType(32), name='exc.retcode',
+            )
+            self._exception_cleanup = (bb, retcode_slot)
+
+        return self._exception_cleanup
+
+    def _emit_exception_cleanup_block(self):
+        """
+        Populate the exception cleanup block, if it was requested by a
+        call site.  Decref every NRT-managed variable slot; slots are
+        NULL-initialized and zero-filled on deletion, so at any point a
+        non-NULL slot holds exactly one reference owned by this frame and
+        decref of a NULL value is a no-op.
+        """
+        if self._exception_cleanup is None:
+            return
+
+        bb, retcode_slot = self._exception_cleanup
+        dmm = self.context.data_model_manager
+
+        with debuginfo.suspend_emission(self.builder):
+            self.builder.position_at_end(bb)
+            for name, ptr in self.varmap.items():
+                # Slots inserted into varmap by external code (e.g. parfor
+                # lowering) have no recorded frontend type; skip them.
+                fetype = self._varmap_fetypes.get(name)
+                if fetype is None:
+                    continue
+                if dmm[fetype].contains_nrt_meminfo():
+                    self.context.nrt.decref(self.builder, fetype,
+                                            self.builder.load(ptr))
+
+            retcode = self.builder.load(retcode_slot)
+            self.call_conv._return_errcode_raw(self.builder, retcode)
 
     def pre_block(self, block):
         from numba.core.unsafe import eh
@@ -1496,8 +1590,9 @@ class Lower(BaseLower):
                 self._disable_sroa_like_opt):
             # If not already defined, allocate it
             ptr = self.alloca(name, fetype)
-            # Remember the pointer
+            # Remember the pointer and the frontend type
             self.varmap[name] = ptr
+            self._varmap_fetypes[name] = fetype
 
     def getvar(self, name):
         """

--- a/numba/tests/test_exceptions.py
+++ b/numba/tests/test_exceptions.py
@@ -4,7 +4,8 @@ import traceback
 
 from numba import jit, njit
 from numba.core import types, errors, utils
-from numba.tests.support import (TestCase, expected_failure_py311,
+from numba.tests.support import (TestCase, MemoryLeakMixin,
+                                 expected_failure_py311,
                                  expected_failure_py312,
                                  expected_failure_py313,
                                  expected_failure_py314,
@@ -520,6 +521,146 @@ class TestRaising(TestCase):
                 with self.assertRaises(ValueError) as e:
                     fn(arg)
                 self.assertEqual((arg,), e.exception.args)
+
+
+class TestPropagationRefCleanup(MemoryLeakMixin, TestCase):
+    """
+    Issue #10783: references owned by a function frame (arguments and
+    locals that are live across a raising call) must be released when an
+    exception raised in a callee propagates out of the frame.
+    """
+
+    def _check_raises(self, cfunc, *args):
+        with self.assertRaises(ValueError) as cm:
+            cfunc(*args)
+        self.assertIn("bad", str(cm.exception))
+
+    def test_arg_live_across_raising_call(self):
+        # The reference to `data` held by the caller's frame used to leak,
+        # pinning the array.
+        @njit
+        def callee(x):
+            if x >= 1.0:
+                raise ValueError("bad")
+            return 2.0 * x
+
+        @njit
+        def caller(data, x):
+            v = callee(x)
+            for i in range(data.size):
+                data[i] = v
+
+        data = np.zeros(4)
+        caller(data, 0.5)
+        self.assertPreciseEqual(data, np.ones(4))
+        for _ in range(10):
+            self._check_raises(caller, data, 1.5)
+
+    def test_local_alloc_live_across_raising_call(self):
+        # An array allocated in the caller, live across the raising call,
+        # in a single basic block (exercises the SSA-like fastpath).
+        @njit
+        def callee(x):
+            if x >= 1.0:
+                raise ValueError("bad")
+            return 2.0 * x
+
+        @njit
+        def caller(x):
+            a = np.ones(3)
+            v = callee(x)
+            return a[0] + v
+
+        self.assertPreciseEqual(caller(0.5), 2.0)
+        for _ in range(10):
+            self._check_raises(caller, 1.5)
+
+    def test_local_alloc_multiblock(self):
+        # Same as above but with control flow so the local lives in a
+        # stack slot.
+        @njit
+        def callee(x):
+            if x >= 1.0:
+                raise ValueError("bad")
+            return 2.0 * x
+
+        @njit
+        def caller(n, x):
+            a = np.zeros(3)
+            if n > 0:
+                a[0] = 1.0
+            v = callee(x)
+            return a[0] + v
+
+        self.assertPreciseEqual(caller(1, 0.5), 2.0)
+        for _ in range(10):
+            self._check_raises(caller, 1, 1.5)
+
+    def test_dynamic_exception_from_callee(self):
+        @njit
+        def callee(x):
+            if x >= 1.0:
+                raise ValueError("bad", x)
+            return 2.0 * x
+
+        @njit
+        def caller(data, x):
+            v = callee(x)
+            for i in range(data.size):
+                data[i] = v
+
+        data = np.zeros(4)
+        caller(data, 0.5)
+        for _ in range(10):
+            self._check_raises(caller, data, 1.5)
+
+    def test_propagation_through_two_frames(self):
+        # Each frame in the call stack must release its own references.
+        @njit
+        def callee(x):
+            if x >= 1.0:
+                raise ValueError("bad")
+            return 2.0 * x
+
+        @njit
+        def mid(data, x):
+            tmp = np.ones(2)
+            v = callee(x)
+            return tmp[0] + v + data[0]
+
+        @njit
+        def caller(data, x):
+            v = mid(data, x)
+            for i in range(data.size):
+                data[i] = v
+
+        data = np.zeros(4)
+        caller(data, 0.5)
+        for _ in range(10):
+            self._check_raises(caller, data, 1.5)
+
+    def test_caught_exception_unaffected(self):
+        # A locally caught exception must not double-release references.
+        @njit
+        def callee(x):
+            if x >= 1.0:
+                raise ValueError("bad")
+            return 2.0 * x
+
+        @njit
+        def caller(data, x):
+            try:
+                v = callee(x)
+            except Exception:
+                v = -1.0
+            for i in range(data.size):
+                data[i] = v
+            return data[0]
+
+        data = np.zeros(4)
+        self.assertPreciseEqual(caller(data, 0.5), 1.0)
+        for _ in range(10):
+            self.assertPreciseEqual(caller(data, 1.5), -1.0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION

# Summary

Release frame-owned references when an exception propagates out of a jitted
function

Fixes #10783. Addresses the main remaining instance of #1549.

## The bug

When a callee raises, the caller's call site checks the returned status and
calls `return_status_propagate`, which returns the error code from the caller
immediately. This skips every `ir.Del` that would normally release the
references owned by the caller's frame. The incref'd arguments, and any locals
or temporaries live across the raising call.

Direct raises and `try`/`except` do not leak, because their cleanup edges are
visible to the IR-level liveness analysis (dels are inserted before the raise
terminator / on the handler edge). The error branch at a call site, by
contrast, is generated only at lowering time and is invisible to liveness.
That is why the presence of a write after the call mattered in the issue's
reproducer. It kept the array argument live across the call.

The leaked reference is one NRT meminfo per raising call. For an unboxed array
argument the meminfo holds a reference to the ndarray, so caller-provided
arrays are pinned and RSS grows without bound. With the issue's reproducer,
`NUMBA_NRT_STATS` shows exactly `mi_alloc - mi_free == 1` per raising call
before this patch, `0` after. RSS goes from 163 MB → 3488 MB before, flat at
150 MB after.

## The fix

Route error propagation through a per-function cleanup block that releases
every reference the frame owns, then returns the error code.

1. **`Lower` builds a lazily-created `exc.cleanup` block**
   (`numba/core/lowering.py`). Its body is emitted in `post_lower`, once the
   variable map is complete.  It decrefs every NRT-managed variable slot and
   returns the propagated error code (stored into an `exc.retcode` stack
   slot by the propagate site).

   This is safe to run from any propagate point because of an existing
   invariant.  Slots are zero-initialized at entry (`cgutils.alloca_once`),
   zero-filled again on `del` (`delvar`), and NRT decref is a null-checked
   no-op. So at every point in the function, a non-null slot holds exactly
   one frame-owned reference, and a null slot is skipped.

2. **`CPUCallConv.return_status_propagate`** (`numba/core/callconv.py`)
   branches to that block instead of returning directly, when the lowering has
   registered it on the builder (same builder-attribute pattern as the existing
   `_in_try_block` hack). The in-`try` path is unchanged, and builders without
   the registration (cpython/cfunc wrappers, generator lowering, other call
   conventions) keep the old behavior.

3. **Refcounted variables are excluded from the SSA-like fast path**
   (`_find_singly_assigned_variable`), so they always live in stack slots
   the cleanup block can see. Without this, a local like `a = np.ones(3)`
   defined and used in a single block is held as a bare SSA value and would
   still leak. LLVM's own mem2reg/SROA still promotes these allocas later,
   so the cost is numba-side IR size, not generated-code quality.

   Slot types are recorded at alloca time in a side map rather than read
   from `fndesc.typemap` at cleanup-emission time, because parfor lowering
   temporarily swaps the typemap while its temporary variables' slots live
   on (this was caught by a parfor test during development). Slots inserted
   into `varmap` directly by external code (e.g. parfor's loop index) have
   no recorded type and are skipped.

Because every frame cleans up its own references, propagation through
multiple jitted frames releases everything.  Each frame's
`return_status_propagate` runs in turn. The same routing automatically
covers the other propagate sites (`call_internal`, recursive calls via
`call_unresolved`, first-class function calls, `imputils.user_function`).

## What this does not cover

- **Generator frames**: generators manage state differently and are
  explicitly excluded (`is_generator` guard); their propagate behavior is
  unchanged.
- **Implementation-internal temporaries**: values created inside library
  implementations (not numba-IR variables) that are live when a nested
  `call_internal` errors can still leak. This is a smaller, pre-existing
  class that a frame-variable-based cleanup cannot reach.
- Targets using other calling conventions (`MinimalCallConv`, CUDA) are
  unaffected: they never register the cleanup hook.

## Points for reviewers / uncertainties

- The cleanup block calls `self.call_conv._return_errcode_raw` from
  `Lower`; happy to add a small public method on the call convention if
  that layering is preferred.
- Excluding refcounted vars from the SSA-like opt shrinks its scope; I did
  not measure a compile-time impact, but flagging it as the one place this
  touches a fast path.
- The builder-attribute registration follows the existing `_in_try_block`
  precedent; an explicit API would be cleaner but wider.

## Testing

- New `TestPropagationRefCleanup` class in `numba/tests/test_exceptions.py`
  (uses `MemoryLeakMixin`): argument live across a raising call, local
  allocations (both the single-block SSA shape and the multi-block slot
  shape), dynamic exceptions, propagation through two frames, and a
  `try`/`except` case guarding against double-release. Five of the six
  fail without the fix.
- Targeted suites pass locally (Linux x86_64, Python 3.14, llvmlite
  0.50.0dev1): test_exceptions, test_try_except, test_nrt, test_nrt_refct,
  test_refop_pruning, test_generators, test_function_type, test_debuginfo,
  test_recursion, test_withlifting, test_dyn_array, test_unicode,
  test_typedlist, test_dictobject, test_ssa, test_dispatcher,
  test_flow_control, test_looplifting, test_closure, test_array_exprs,
  test_objects, test_optional, and the parfor leak/basic/prange subsets.
- Full test suite passes locally (`python -m numba.runtests -m 16`):
  10836 tests, 0 failures (702 skipped, 27 expected failures).

Per the [AI tool use policy](https://numba.readthedocs.io/en/stable/reference/ai_tools_policy.html):
this change was developed with substantial assistance from an AI tool
(Claude Code); I have reviewed and understand all of it, and commits carry
an `Assisted-by:` trailer.