### PR TITLE
CI: upgrade `manylinux` image to `manylinux_2_28` for numba builds

### DIFF
--- a/.github/workflows/numba_linux-64_wheel_builder.yml
+++ b/.github/workflows/numba_linux-64_wheel_builder.yml
@@ -32,6 +32,7 @@ env:
   ARTIFACT_RETENTION_DAYS: 7
   WHEELS_INDEX_URL: https://pypi.anaconda.org/numba/label/dev/simple
   CONDA_CHANNEL_NUMBA: numba/label/dev
+  MANYLINUX_IMAGE: "manylinux_2_28_x86_64:2026.08.08-1"
   # Set USE_TBB to true by default, only override if explicitly set to false
   USE_TBB: ${{ github.event_name == 'workflow_dispatch' && inputs.use_tbb != false || true }}
 
@@ -97,7 +98,7 @@ jobs:
           # Run the build script inside Docker container
           docker run --rm \
             -v ${{ github.workspace }}:/io \
-            quay.io/pypa/manylinux2014_x86_64 \
+            quay.io/pypa/${{ env.MANYLINUX_IMAGE }} \
             bash /io/buildscripts/github/build_wheel_linux.sh \
             "${PYTHON_EXECUTABLE}" \
             "${USE_TBB}" \
@@ -120,7 +121,7 @@ jobs:
           # Run the repair script in Docker
           docker run --rm \
             -v ${{ github.workspace }}:/io \
-            quay.io/pypa/manylinux2014_x86_64 \
+            quay.io/pypa/${{ env.MANYLINUX_IMAGE }} \
             bash /io/buildscripts/github/repair_wheel_linux.sh \
             "$PYTHON_EXECUTABLE" \
             "$USE_TBB" \

--- a/.github/workflows/numba_linux-aarch64_wheel_builder.yml
+++ b/.github/workflows/numba_linux-aarch64_wheel_builder.yml
@@ -27,7 +27,7 @@ env:
   ARTIFACT_RETENTION_DAYS: 7
   WHEELS_INDEX_URL: https://pypi.anaconda.org/numba/label/dev/simple
   CONDA_CHANNEL_NUMBA: numba/label/dev
-  MANYLINUX_IMAGE: "manylinux_2_28_aarch64"
+  MANYLINUX_IMAGE: "manylinux_2_28_aarch64:2026.08.08-1"
 
 jobs:
   load-matrix:

--- a/docs/upcoming_changes/10804.change.rst
+++ b/docs/upcoming_changes/10804.change.rst
@@ -1,0 +1,7 @@
+Linux ``x86_64`` wheels now require ``glibc`` 2.28 or newer
+-----------------------------------------------------------
+
+``linux-64`` wheels are built as ``manylinux_2_28`` instead of
+``manylinux2014``. Installing from PyPI requires ``glibc`` 2.28 or
+newer. Systems with older ``glibc`` can remain on Numba 0.67.
+``linux-aarch64`` was already on ``manylinux_2_28``.


### PR DESCRIPTION
This follows numba/llvmlite#1478 (and numba/llvmlite#1471), to upgrade `manylinux` image for #10774

It moves the docker image used for `linux-64` wheel builds from `manylinux2014` to `manylinux_2_28`, and pins the `linux-aarch64` image to the same tag already used by `llvmdev` and `llvmlite` (`2026.08.08-1`).
