### PR TITLE
Inline closure calls with a locally built *args tuple

### DIFF
--- a/docs/upcoming_changes/10806.new_feature.rst
+++ b/docs/upcoming_changes/10806.new_feature.rst
@@ -1,0 +1,8 @@
+Support calling closures with ``*args``
+---------------------------------------
+
+Calling a closure with an unpacked tuple, e.g. ``closure(*args)``, previously
+raised ``UnsupportedError``. When the tuple is built in the enclosing
+function, the closure inliner now unpacks it into direct arguments and
+inlines the call as usual. Varargs that are not locally built tuples (e.g. a
+tuple passed in as a parameter) remain unsupported.

--- a/numba/core/inline_closurecall.py
+++ b/numba/core/inline_closurecall.py
@@ -751,8 +751,18 @@ def _get_callee_args(call_expr, callee, loc, func_ir):
     if call_expr.op == 'call':
         args = list(call_expr.args)
         if call_expr.vararg:
-            msg = "Calling a closure with *args is unsupported."
-            raise errors.UnsupportedError(msg, call_expr.loc)
+            # unpack a locally built tuple into direct arguments; a single
+            # definition for the tuple and each item guarantees the values
+            # cannot have changed between the build_tuple and the call
+            dfn = guard(get_definition, func_ir, call_expr.vararg)
+            defs = func_ir._definitions
+            if (isinstance(dfn, ir.Expr) and dfn.op == 'build_tuple'
+                    and all(len(defs.get(v.name, ())) == 1
+                            for v in [call_expr.vararg] + list(dfn.items))):
+                args.extend(dfn.items)
+            else:
+                msg = "Calling a closure with *args is unsupported."
+                raise errors.UnsupportedError(msg, call_expr.loc)
     elif call_expr.op == 'getattr':
         args = [call_expr.value]
     elif ir_utils.is_operator_or_getitem(call_expr):

--- a/numba/tests/test_closure.py
+++ b/numba/tests/test_closure.py
@@ -380,17 +380,17 @@ class TestInlinedClosure(TestCase):
                 return x + np.cos(z)
             return inner(x)
 
-        def outer22():
-            """Test to ensure that unsupported *args raises correctly"""
+        def outer22(x):
+            """ closure called with a locally built *args tuple"""
             def bar(a, b):
-                pass
-            x = 1, 2
-            bar(*x)
+                return a + b
+            t = x, x + 1
+            return bar(*t)
 
         # functions to test that are expected to pass
         f = [outer1, outer2, outer5, outer6, outer7, outer8,
              outer9, outer10, outer12, outer13, outer14,
-             outer15, outer19, outer20, outer21]
+             outer15, outer19, outer20, outer21, outer22]
         for ref in f:
             cfunc = njit(ref)
             var = 10
@@ -433,11 +433,59 @@ class TestInlinedClosure(TestCase):
         msg = "The use of yield in a closure is unsupported."
         self.assertIn(msg, str(raises.exception))
 
-        with self.assertRaises(UnsupportedError) as raises:
-            cfunc = jit(nopython=True)(outer22)
-            cfunc()
+    def test_closure_vararg(self):
+        # a closure called with a locally built *args tuple is inlined by
+        # unpacking the tuple into direct arguments
+
+        def outer_single(x):
+            def bar(a):
+                return a * 2
+            t = (x,)
+            return bar(*t)
+
+        def outer_default(x):
+            def bar(a, b, c=10):
+                return a + b + c
+            t = x, x + 1
+            return bar(*t)
+
+        # more than 30 arguments: CPython emits the append window that the
+        # list_to_tuple peephole coalesces into one build_tuple (#10782)
+        n = 31
+        src = ("def outer_wide(x):\n"
+               "    def bar(%s):\n"
+               "        return %s\n"
+               "    return bar(%s)\n"
+               % (", ".join("a%d" % i for i in range(n)),
+                  " + ".join("a%d" % i for i in range(n)),
+                  ", ".join(["x"] * n)))
+        glbls = {}
+        exec(src, glbls)
+
+        for ref in (outer_single, outer_default, glbls["outer_wide"]):
+            cfunc = njit(ref)
+            self.assertEqual(cfunc(10), ref(10))
+
+    def test_closure_vararg_unsupported(self):
+        # only a locally built tuple can be unpacked; any other vararg
+        # still raises
+
+        def outer_param(t):
+            def bar(a, b):
+                return a + b
+            return bar(*t)
+
+        def outer_mixed(x):
+            def bar(a, b, c):
+                return a + b + c
+            t = x, x + 1
+            return bar(x, *t)  # append + extend window: a concatenation
+
         msg = "Calling a closure with *args is unsupported."
-        self.assertIn(msg, str(raises.exception))
+        for ref, arg in ((outer_param, (1, 2)), (outer_mixed, 1)):
+            with self.assertRaises(UnsupportedError) as raises:
+                njit(ref)(arg)
+            self.assertIn(msg, str(raises.exception))
 
     def test_closure_renaming_scheme(self):
         # See #7380, this checks that inlined (from closure) variables have a


### PR DESCRIPTION
Follow-up to #10782, requested in https://github.com/numba/numba/pull/10782#issuecomment-5452143449: the feature half of the commit that was dropped there — `closure(*args)` — as its own PR, and much smaller than the dropped version.

## Why not the original patch

The dropped commit ([`1ff3a9e8`](https://github.com/velochy/numba/commit/1ff3a9e8383863b5274f335ed6544cb2a3ec7fb7)) rewrote `f(*tuple)` into direct arguments inside the `CALL_FUNCTION_EX` peephole for *every* call — 57 lines with a whole-IR use-count walk and definition surgery. But ordinary functions already compile `f(*t)` fine through vararg typing; the only thing that refuses a vararg is the closure *inliner*. So the general rewrite bought nothing except its side effect on closures, which can be had at the source instead:

## Fix

`_get_callee_args` in `inline_closurecall.py`: when the vararg's definition is a `build_tuple` in the enclosing function, its items *are* the call's arguments — unpack them and inline as usual (composing with the existing default/kwarg folding right below). ~10 lines, no IR mutation; the tuple assignment dies as dead code.

Correctness of the unpacked values: bytecode-built tuples load their operands onto the stack first, so each item is a fresh single-definition temporary holding the value at tuple-build time — reassigning the source variable afterwards cannot change what is unpacked. The guard requires a single definition for the tuple and every item (belt and braces, since `inline_closure_call` is public API that can be handed hand-built IR), and anything that isn't a locally built `build_tuple` — a tuple parameter, or the concatenation left by mixing `f(x, *t)` — keeps raising `UnsupportedError` exactly as before.

Thanks to #10782 this also covers closures called with more than 30 arguments, since the coalesced append window is a plain `build_tuple`; there is a test for that shape.

`outer22` in `test_closure.py`, previously the asserts-it-raises case, moves to the expected-to-pass list; new tests cover single-item/defaults/31-argument tuples and the still-unsupported forms.
