### PR TITLE
CI: use `--pre` for llvmlite installs on wheel builder workflows

### DIFF
--- a/.github/workflows/numba_osx-arm64_wheel_builder.yml
+++ b/.github/workflows/numba_osx-arm64_wheel_builder.yml
@@ -99,7 +99,7 @@ jobs:
           if [ "${{ inputs.llvmlite_wheel_runid }}" != "" ]; then
               arch -arm64 python -m pip install llvmlite_wheels/*.whl
           else
-              arch -arm64 python -m pip install -i ${{ env.WHEELS_INDEX_URL }} llvmlite
+              arch -arm64 python -m pip install --pre -i ${{ env.WHEELS_INDEX_URL }} llvmlite
           fi
           python -m pip install build numpy==${{ matrix.numpy_build }} "setuptools>=69.0.0" wheel
 

--- a/.github/workflows/numba_win-64_wheel_builder.yml
+++ b/.github/workflows/numba_win-64_wheel_builder.yml
@@ -83,7 +83,7 @@ jobs:
           if [ "${{ inputs.llvmlite_wheel_runid }}" != "" ]; then
               python -m pip install llvmlite_wheels/*.whl
           else
-              python -m pip install -i ${{ env.WHEELS_INDEX_URL }} llvmlite
+              python -m pip install --pre -i ${{ env.WHEELS_INDEX_URL }} llvmlite
           fi
           python -m pip install build numpy==${{ matrix.numpy_build }} "setuptools>=69.0.0" wheel tbb==2021.6 tbb-devel==2021.6
 

--- a/.github/workflows/numba_win-arm64_wheel_builder.yml
+++ b/.github/workflows/numba_win-arm64_wheel_builder.yml
@@ -77,7 +77,7 @@ jobs:
           if [ "${{ inputs.llvmlite_wheel_runid }}" != "" ]; then
               python -m pip install llvmlite_wheels/*.whl
           else
-              python -m pip install -i ${{ env.WHEELS_INDEX_URL }} llvmlite
+              python -m pip install --pre -i ${{ env.WHEELS_INDEX_URL }} llvmlite
           fi
           python -m pip install --pre numpy==${NUMPY_VERSION}
           python -m pip install build "setuptools>=69.0.0" wheel

--- a/buildscripts/github/build_wheel_linux.sh
+++ b/buildscripts/github/build_wheel_linux.sh
@@ -25,7 +25,7 @@ fi
 if [ -n "$LLVMLITE_WHEEL_PATH" ] && [ -d "$LLVMLITE_WHEEL_PATH" ]; then
     $PYTHON_EXECUTABLE -m pip install --no-cache-dir $LLVMLITE_WHEEL_PATH/*.whl
 else
-    $PYTHON_EXECUTABLE -m pip install --no-cache-dir -i $WHEELS_INDEX_URL llvmlite
+    $PYTHON_EXECUTABLE -m pip install --no-cache-dir --pre -i $WHEELS_INDEX_URL llvmlite
 fi
 
 # Change to the mounted workspace directory


### PR DESCRIPTION
The Numba wheel builder workflows did not use `--pre` to install llvmlite on build environment. This resulted in dev builds using stable release llvmlite build, when they should have been using `dev` tagged llvmlite wheel builds. 

This PR updates -
- Build-time `pip install llvmlite` from the numba dev index now uses `--pre`, matching the test jobs.
- Without `--pre`, pip prefers the latest stable llvmlite (`manylinux2014`) over newer pre-release `manylinux_2_28` builds. 

## Test plan
- [ ] Confirm `linux-64` / `linux-aarch64` wheel builds install a `manylinux_2_28` llvmlite from the `dev` index
- [ ] Confirm `osx-arm64` / `win-64` / `win-arm64` build jobs still resolve llvmlite from the `dev` index

Assisted by: Kilo AI