### PR TITLE
Fix TypeRef string formatting for instance type

### DIFF
--- a/numba/core/types/abstract.py
+++ b/numba/core/types/abstract.py
@@ -478,7 +478,7 @@ class TypeRef(Dummy):
     """
     def __init__(self, instance_type):
         self.instance_type = instance_type
-        super(TypeRef, self).__init__('typeref[{}]'.format(self.instance_type))
+        super(TypeRef, self).__init__('types.typeref[{}]'.format(self.instance_type))
 
     @property
     def key(self):


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
post to the Numba forum https://numba.discourse.group/.

Second, please ensure that you have read and understood Numba's AI tool use
policy: https://numba.readthedocs.io/en/stable/reference/ai_tools_policy.html

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
This PR fixed issue #7055 by making the TypeRef string representation more verbose.
Changes:
- Updated super (TypeRef, self)._init_to use 'types. TypeRef ({})',
- Fixed #7055

