### PR TITLE
Fix uint64_to_unit_float32 rounding up to exactly 1.0

### DIFF
--- a/docs/upcoming_changes/10812.bug_fix.rst
+++ b/docs/upcoming_changes/10812.bug_fix.rst
@@ -1,0 +1,6 @@
+Fix xoroshiro128p_uniform_float32 returning exactly 1.0
+---------------------------------------------------------
+
+``numba.cuda.random.xoroshiro128p_uniform_float32`` could return exactly
+``1.0`` for roughly 1 in 3.4e7 draws, violating its documented
+``[0.0, 1.0)`` contract. This has been fixed.

--- a/numba/cuda/random.py
+++ b/numba/cuda/random.py
@@ -137,7 +137,15 @@ def uint64_to_unit_float64(x):
 def uint64_to_unit_float32(x):
     '''Convert uint64 to float32 value in the range [0.0, 1.0)'''
     x = uint64(x)
-    return float32(uint64_to_unit_float64(x))
+    # Take the top 24 bits directly, matching how uint64_to_unit_float64
+    # takes the top 53 bits, rather than narrowing a 53-bit float64
+    # value into float32's 24-bit significand -- rounding during that
+    # narrowing could push the largest values up to exactly 1.0,
+    # violating the documented [0.0, 1.0) contract (gh-10810). Every
+    # operand is explicitly cast to float32 to avoid NumPy's casting
+    # rule that promotes float32 [op] uint64 to float64 (see the
+    # module-level warning above about verbose casting).
+    return float32(x >> uint32(40)) * float32(1) / float32(uint64(1) << uint32(24))
 
 
 @jit(forceobj=_forceobj, looplift=_looplift, nopython=_nopython)

--- a/numba/cuda/random.py
+++ b/numba/cuda/random.py
@@ -145,7 +145,9 @@ def uint64_to_unit_float32(x):
     # operand is explicitly cast to float32 to avoid NumPy's casting
     # rule that promotes float32 [op] uint64 to float64 (see the
     # module-level warning above about verbose casting).
-    return float32(x >> uint32(40)) * float32(1) / float32(uint64(1) << uint32(24))
+    numerator = float32(x >> uint32(40))
+    denominator = float32(uint64(1) << uint32(24))
+    return numerator * float32(1) / denominator
 
 
 @jit(forceobj=_forceobj, looplift=_looplift, nopython=_nopython)

--- a/numba/cuda/tests/cudapy/test_random.py
+++ b/numba/cuda/tests/cudapy/test_random.py
@@ -90,7 +90,7 @@ class TestCudaRandomXoroshiro128p(CUDATestCase):
         # that triggered xoroshiro128p_uniform_float32 to return 1.0.
         states = np.zeros(1, dtype=xoroshiro128p_dtype)
         init_xoroshiro128p_states_cpu(states, seed=2362621375128073891,
-                                       subsequence_start=0)
+                                      subsequence_start=0)
 
         result = xoroshiro128p_uniform_float32(states, 0)
         self.assertLess(np.float32(result), np.float32(1.0))

--- a/numba/cuda/tests/cudapy/test_random.py
+++ b/numba/cuda/tests/cudapy/test_random.py
@@ -8,7 +8,9 @@ from numba.cuda.testing import skip_on_cudasim, CUDATestCase
 
 from numba.cuda.random import \
     xoroshiro128p_uniform_float32, xoroshiro128p_normal_float32, \
-    xoroshiro128p_uniform_float64, xoroshiro128p_normal_float64
+    xoroshiro128p_uniform_float64, xoroshiro128p_normal_float64, \
+    uint64_to_unit_float32, init_xoroshiro128p_states_cpu, \
+    xoroshiro128p_dtype
 
 
 # Distributions
@@ -65,6 +67,34 @@ class TestCudaRandomXoroshiro128p(CUDATestCase):
                                                          stream=stream)
         s = states.copy_to_host()
         self.assertEqual(len(np.unique(s)), 10)
+
+    def test_uint64_to_unit_float32_stays_below_one(self):
+        # Regression test for gh-10810: uint64_to_unit_float32 narrowed
+        # a 53-bit float64 value into float32's 24-bit significand with
+        # a plain cast, so the largest inputs rounded up to exactly
+        # 1.0, violating the documented [0.0, 1.0) contract. Sweep the
+        # boundary values called out in the issue.
+        boundary_values = np.array(
+            [0, 1, 2 ** 39, 2 ** 63, 2 ** 64 - 2 ** 39, 2 ** 64 - 2049,
+             2 ** 64 - 1], dtype=np.uint64)
+
+        for x in boundary_values:
+            result = uint64_to_unit_float32(x)
+            self.assertGreaterEqual(np.float32(result), np.float32(0.0))
+            self.assertLess(np.float32(result), np.float32(1.0))
+
+    def test_uniform_float32_upper_bound(self):
+        # Regression test for gh-10810. This seed was derived (by
+        # inverting splitmix64, see the issue) to make the first draw
+        # from a fresh state exactly 2**64 - 2**39, the smallest value
+        # that triggered xoroshiro128p_uniform_float32 to return 1.0.
+        states = np.zeros(1, dtype=xoroshiro128p_dtype)
+        init_xoroshiro128p_states_cpu(states, seed=2362621375128073891,
+                                       subsequence_start=0)
+
+        result = xoroshiro128p_uniform_float32(states, 0)
+        self.assertLess(np.float32(result), np.float32(1.0))
+        self.assertGreaterEqual(np.float32(result), np.float32(0.0))
 
     def check_uniform(self, kernel_func, dtype):
         states = cuda.random.create_xoroshiro128p_states(32 * 2, seed=1)


### PR DESCRIPTION
Fixes #10810

## Problem

`numba.cuda.random.xoroshiro128p_uniform_float32` documents a return value in `[0.0, 1.0)`, but `uint64_to_unit_float32` narrows through `uint64_to_unit_float64` (which keeps 53 bits) and then casts down to `float32` (24-bit significand). Every float64 value above the midpoint `1 - 2**-25` rounds up to exactly `1.0` during that cast -- about 1 draw in 3.4e7 -- which breaks callers that use the result as `int(n * u)` (one-past-the-end index) or `log(1 - u)` (infinity).

`uint64_to_unit_float64` itself is correct; only the float32 narrowing path is affected.

## Fix

Take the top 24 bits of the draw directly, the same way `uint64_to_unit_float64` already takes the top 53 bits, instead of routing through a wider intermediate and narrowing it:

```python
numerator = float32(x >> uint32(40))
denominator = float32(uint64(1) << uint32(24))
return numerator * float32(1) / denominator
```

The largest possible result is now `(2**24 - 1) * 2**-24 = 0.99999994`, the largest float32 below 1.0, so the documented range holds by construction. Every operand is explicitly cast to `float32` to avoid NumPy's casting rule that promotes `float32 [op] uint64` to `float64`.

## Testing

Added two tests to `test_random.py`:
- A sweep of the boundary values from the issue directly against `uint64_to_unit_float32`.
- An end-to-end regression using the seed the issue derives (by inverting splitmix64) to make the first draw from a fresh state exactly `2**64 - 2**39`, the smallest input that triggered the bug.

Both new tests fail with the exact reported symptom (`np.float32(1.0) not less than np.float32(1.0)`) when only the fix is reverted, and pass with it restored.

## Tool use

Root-cause diagnosis and this patch were developed with Claude (Anthropic) as an assistant; I reviewed, tested, and take full responsibility for the change per Numba's AI Tool Use Policy.
