### PR TITLE
ILP64 follow-ups: AOT compile + small cleanups

### DIFF
--- a/docs/upcoming_changes/10818.improvement.rst
+++ b/docs/upcoming_changes/10818.improvement.rst
@@ -1,7 +1,7 @@
 Enable ahead-of-time compilation of ILP64 linear algebra.
 ---------------------------------------------------------
 
-Ahead-of-time compilated modules use the same LAPACK ABI as the JIT-compiled modules.
-In other words, if Numba was built with the ``NUMBA_LAPACK_ILP64=1`` environment
-variable, both JIT and AOT compilation uses the ILP64 LAPACK ABI.
+The LAPACK ABI with which Numba was built is now used by Numba produced ahead-of-time
+compiled modules. i.e. if Numba was built with the ILP64 LAPACK ABI then Numba emits AOT
+compiled modules with that ABI.
 

--- a/docs/upcoming_changes/10818.improvement.rst
+++ b/docs/upcoming_changes/10818.improvement.rst
@@ -1,0 +1,7 @@
+Enable ahead-of-time compilation of ILP64 linear algebra.
+---------------------------------------------------------
+
+Ahead-of-time compilated modules use the same LAPACK ABI as the JIT-compiled modules.
+In other words, if Numba was built with the ``NUMBA_LAPACK_ILP64=1`` environment
+variable, both JIT and AOT compilation uses the ILP64 LAPACK ABI.
+

--- a/numba/_lapack.c
+++ b/numba/_lapack.c
@@ -422,7 +422,7 @@ numba_xxgemm(char kind, char transa, char transb,
 
 
 /* L2-norms */
-NUMBA_EXPORT_FUNC(F_INT)
+NUMBA_EXPORT_FUNC(int)
 numba_xxnrm2(char kind, Py_ssize_t n, void * x, Py_ssize_t incx, void * result)
 {
     void *raw_func = NULL;

--- a/numba/np/linalg.py
+++ b/numba/np/linalg.py
@@ -316,7 +316,7 @@ class _LAPACK:
             types.intp,                 # ldb
             types.CPointer(rtype),      # S
             types.float64,              # rcond
-            types.CPointer(types.intc)  # rank
+            types.CPointer(F_INT_nbtype)  # rank
         )
         return types.ExternalFunction("numba_ez_gelsd", sig)
 
@@ -1843,7 +1843,7 @@ def lstsq_impl(a, b, rcond=-1.0):
 
         # Allocate returns
         s = np.empty(minmn, dtype=real_dtype)
-        rank_ptr = np.empty(1, dtype=np.int32)
+        rank_ptr = np.empty(1, dtype=F_INT_nptype)
 
         r = numba_ez_gelsd(
             kind,  # kind

--- a/numba/pycc/cc.py
+++ b/numba/pycc/cc.py
@@ -170,9 +170,19 @@ class CC(object):
 
     def _get_mixin_defines(self):
         # Macro definitions required by modulemixin.c
+        from numba import _helperlib
         return [
             ('PYCC_MODULE_NAME', self._basename),
             ('PYCC_USE_NRT', int(self._use_nrt)),
+            # modulemixin.c #includes _helperlib.c -> _lapack.c, whose Fortran
+            # integer width (LP64 vs ILP64) is fixed at compile time by
+            # NUMBA_LAPACK_BUILD_ILP64.  It must match the numba this AOT module
+            # is built with, otherwise the AOT BLAS/LAPACK wrappers pass
+            # wrong-width integers to scipy at runtime -- silent corruption or a
+            # crash (see e.g. an ILP64 numba: np.dot in an AOT module segfaults
+            # in the BLAS call).  Mirror numba's own build width.
+            ('NUMBA_LAPACK_BUILD_ILP64',
+             int(getattr(_helperlib, "LAPACK_BUILD_ILP64", 0))),
             ]
 
     def _get_extra_cflags(self):


### PR DESCRIPTION
Following up to https://github.com/numba/numba/pull/10784, which added an internal ILP64 build mode for 64-bit integer enabled linear algebra, here are three further fixes, all found by @bessen:

- 96652b445f2f72d6508812990aa58145be7505bb enables AOT compilation in the ILP64 mode. Here's a reproducer, which segfaults on main built with `NUMBA_LAPACK_ILP64=1` and MKL, and passes with the patch:

```
import sys, faulthandler
import numpy as np
faulthandler.enable()

# AOT-compile a function that calls np.dot via numba's pycc CC API.
import tempfile, importlib
from numba.pycc import CC

AOT_MODULE_NAME = "aot_dot_module"
cc = CC(AOT_MODULE_NAME)
cc.output_dir = tempfile.mkdtemp(prefix="numba_aot_build_")  # scratch build dir

@cc.export("vector_dot", "f8(i4)")
def vector_dot(n):
    a = np.linspace(1, n, n)
    return np.dot(a, a)  # BLAS ddot via the AOT path

cc.compile()
sys.path.insert(0, cc.output_dir)  # so the freshly built .so is importable
lib = importlib.import_module("aot_dot_module")  # same name as AOT_MODULE_NAME
print("AOT module compiled and imported:", lib.__file__)

print("calling AOT vector_dot(4) ...")
print("result:", lib.vector_dot(4))
print("OK - no crash (this line is NOT reached on the 3.14 ILP64 build)")
```

- 029b124bd8f781f6e33e190e0d59d86d83cfd371 is probably a small cleanup: it changes the return type of `numba_xxnrm2` to `int`. The latter is currently declared as F_INT, while all other functions are declared with `NUMBA_EXPORT_FUNC(int)`. The difference existed "forever", from the original commit https://github.com/numba/numba/commit/31c1d047e6f692e4b211def2b18e9e02059002d5. AFAICS, the function simply `return 0;`, so there's no issue returning a plain int. And it makes `numba_xxnrm2` consistent with other functions.  

- e1555b9f0672e8fc68dabb2bca91286def945612 is a fix to a potential problem, it fixes the type of the `rank` pointer in `numba_ez_gelsd` : the LAPACK function returns a Fortran integer, so the matching type is `F_INT`, not `int32`. 


EDIT: Per the [review request](https://github.com/numba/numba/pull/10818#issuecomment-5616444397), I hereby confirm that this contribution complies with the AI policy. In particular, the usage of AI tools in preparing this patch was minimal, there is no substantial amount of AI-generated code in this patch, and the submitter (me) is a human who is fully accountable for the contribution.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
post to the Numba forum https://numba.discourse.group/.

Second, please ensure that you have read and understood Numba's AI tool use
policy: https://numba.readthedocs.io/en/stable/reference/ai_tools_policy.html

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
