### PR TITLE
Optimize no-axis integer sums in memory order

### DIFF
--- a/docs/upcoming_changes/10820.performance.rst
+++ b/docs/upcoming_changes/10820.performance.rst
@@ -1,0 +1,7 @@
+Improve memory traversal for integer sums
+-----------------------------------------
+
+No-axis sums of integer or boolean arrays with integer accumulators now use
+memory-order traversal for contiguous arrays and supported strided layouts.
+This improves performance for several transposed and Fortran-layout cases.
+Floating-point reductions retain their existing execution path.

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -434,6 +434,71 @@ def get_ret_dtype_if_any(aryty, dtype):
     return ret_dtype
 
 
+def _sum_integer_memory_order(context, builder, aryty, ary, ret_dtype):
+    intp = context.get_value_type(types.intp)
+    result = cgutils.alloca_once_value(
+        builder, context.get_constant(ret_dtype, 0))
+
+    def accumulate(ptr):
+        value = load_item(context, builder, aryty, ptr)
+        value = context.cast(builder, value, aryty.dtype, ret_dtype)
+        # Reassociation is valid only with wrapping, not no-overflow, addition.
+        total = builder.add(builder.load(result), value)
+        builder.store(total, result)
+
+    if aryty.layout in ('C', 'F'):
+        with cgutils.for_range(builder, ary.nitems, intp=intp) as loop:
+            accumulate(builder.gep(ary.data, [loop.index]))
+    else:
+        shape = list(cgutils.unpack_tuple(builder, ary.shape))
+        strides = list(cgutils.unpack_tuple(builder, ary.strides))
+        magnitudes = [
+            builder.select(builder.icmp_signed('<', stride, intp(0)),
+                           builder.neg(stride), stride)
+            for stride in strides
+        ]
+        for i in range(1, aryty.ndim):
+            for j in range(i, 0, -1):
+                swap = builder.icmp_unsigned('<', magnitudes[j - 1],
+                                             magnitudes[j])
+                for values in (magnitudes, shape, strides):
+                    left, right = values[j - 1], values[j]
+                    values[j - 1] = builder.select(swap, right, left)
+                    values[j] = builder.select(swap, left, right)
+
+        data = ary.data
+        for size, stride in zip(shape, strides):
+            negative = builder.icmp_signed('<', stride, intp(0))
+            last = builder.select(builder.icmp_signed('>', size, intp(0)),
+                                  builder.sub(size, intp(1)), intp(0))
+            offset = builder.select(negative, builder.mul(last, stride),
+                                    intp(0))
+            data = cgutils.pointer_add(builder, data, offset)
+        strides = magnitudes
+
+        for i in range(1, aryty.ndim):
+            outer_single = builder.icmp_signed('==', shape[i - 1], intp(1))
+            inner_single = builder.icmp_signed('==', shape[i], intp(1))
+            adjacent = builder.icmp_unsigned(
+                '==', strides[i - 1], builder.mul(shape[i], strides[i]))
+            merge = builder.or_(adjacent,
+                                builder.or_(outer_single, inner_single))
+            merged_size = builder.mul(shape[i - 1], shape[i])
+            merged_stride = builder.select(inner_single,
+                                           strides[i - 1], strides[i])
+            shape[i - 1] = builder.select(merge, intp(1), shape[i - 1])
+            shape[i] = builder.select(merge, merged_size, shape[i])
+            strides[i] = builder.select(merge, merged_stride, strides[i])
+
+        with cgutils.loop_nest(builder, shape, intp) as indices:
+            offset = intp(0)
+            for index, stride in zip(indices, strides):
+                offset = builder.add(offset, builder.mul(index, stride))
+            accumulate(cgutils.pointer_add(builder, data, offset))
+
+    return builder.load(result)
+
+
 @intrinsic
 def _numpy_sum(typingctx, aryty, axisty, dtype):
     ret_dtype = get_ret_dtype_if_any(aryty, dtype)
@@ -443,6 +508,15 @@ def _numpy_sum(typingctx, aryty, axisty, dtype):
         ary, _, _ = args
 
         ary = make_array(aryty)(context, builder, ary)
+        if (is_nonelike(axisty)
+                and isinstance(aryty.dtype, (types.Integer, types.Boolean))
+                and isinstance(ret_dtype, types.Integer)
+                # Bound the generated sorting network for arbitrary strides.
+                and (aryty.layout in ('C', 'F') or aryty.ndim <= 4)):
+            result = _sum_integer_memory_order(
+                context, builder, aryty, ary, ret_dtype)
+            return impl_ret_borrowed(context, builder, sig.return_type, result)
+
         if isinstance(ret_dtype, types.NPTimedelta):
             zero = context.get_constant(ret_dtype, ret_dtype(0))
         else:

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -1,4 +1,4 @@
-from itertools import product, combinations_with_replacement
+from itertools import product, combinations_with_replacement, permutations
 
 import numpy as np
 
@@ -1573,6 +1573,156 @@ class TestArrayReductionsExceptions(MemoryLeakMixin, TestCase):
             setattr(cls, test_name, test_fn)
 
 TestArrayReductionsExceptions.install()
+
+
+class TestIntegerSumLayouts(MemoryLeakMixin, TestCase):
+    integer_dtypes = (np.int8, np.uint8, np.int16, np.uint16,
+                      np.int32, np.uint32, np.int64, np.uint64, np.bool_)
+
+    @staticmethod
+    def make_array(dtype):
+        if dtype == np.bool_:
+            values = [False, True, True, False, True]
+        else:
+            info = np.iinfo(dtype)
+            values = [info.max, 1, info.min, 0,
+                      -1 if info.min < 0 else info.max]
+        return np.resize(np.array(values, dtype=dtype), (3, 4, 5))
+
+    @staticmethod
+    def default_dtype(dtype):
+        dtype = np.dtype(dtype)
+        if dtype.kind == 'b' or dtype.itemsize < np.dtype(np.intp).itemsize:
+            return np.dtype(np.intp)
+        return dtype
+
+    @staticmethod
+    def modular_sum(arr, dtype):
+        dtype = np.dtype(dtype)
+        if dtype.kind == 'b':
+            return any(int(value) != 0 for value in arr.flat)
+        modulus = 1 << (8 * dtype.itemsize)
+        total = sum(int(value) for value in arr.flat) % modulus
+        if dtype.kind == 'i' and total >= modulus // 2:
+            total -= modulus
+        return total
+
+    def check_sum(self, cfunc, arr, dtype):
+        before = arr.copy()
+        writable = arr.flags.writeable
+        expected = self.modular_sum(arr, dtype)
+        self.assertEqual(cfunc(arr), expected)
+        signature = cfunc.overloads[(typeof(arr),)].signature
+        self.assertEqual(signature.return_type,
+                         typeof(np.dtype(dtype).type(0)))
+        np.testing.assert_array_equal(arr, before)
+        self.assertEqual(arr.flags.writeable, writable)
+
+    def test_default_dtype_layouts(self):
+        @jit
+        def reduce(arr):
+            return np.sum(arr)
+
+        @jit
+        def reduce_method(arr):
+            return arr.sum()
+
+        for dtype in self.integer_dtypes:
+            base = self.make_array(dtype)
+            arrays = [base.transpose(axes) for axes in permutations(range(3))]
+            arrays.extend([
+                np.asfortranarray(base), base[::-1, :, ::-1],
+                base[::2, ::-2, ::2].transpose(2, 0, 1),
+                np.broadcast_to(base[0, 0, :], (3, 4, 5)),
+                base[:, :1, :].transpose(2, 0, 1),
+                np.lib.stride_tricks.as_strided(
+                    base.ravel(), shape=(4, 3),
+                    strides=(base.itemsize, base.itemsize), writeable=False),
+            ])
+            for arr, cfunc in product(arrays, (reduce, reduce_method)):
+                with self.subTest(dtype=dtype, shape=arr.shape,
+                                  strides=arr.strides, function=cfunc.py_func):
+                    self.check_sum(cfunc, arr, self.default_dtype(arr.dtype))
+
+    def test_explicit_dtype_overflow(self):
+        for out_dtype in (np.int8, np.uint8, np.int64, np.uint64, np.bool_):
+            @jit
+            def reduce(arr):
+                return np.sum(arr, dtype=out_dtype)
+
+            for dtype in self.integer_dtypes:
+                base = self.make_array(dtype)
+                for arr in (base.transpose(2, 0, 1), base[::-1, ::-1, ::-1]):
+                    with self.subTest(dtype=dtype, out_dtype=out_dtype,
+                                      strides=arr.strides):
+                        self.check_sum(reduce, arr, out_dtype)
+
+    def test_empty_scalar_and_unaligned(self):
+        @jit
+        def reduce(arr):
+            return np.sum(arr)
+
+        for dtype in self.integer_dtypes:
+            base = self.make_array(dtype)
+            buffer = np.empty(base.nbytes + 1, dtype=np.uint8)
+            unaligned = np.ndarray(base.shape, dtype=dtype, buffer=buffer,
+                                   offset=1)
+            unaligned[...] = base
+            arrays = [np.array(base[0, 0, 0]), base[:0], base[:, :0],
+                      base[:, :, :0], base[:0].transpose(2, 0, 1),
+                      unaligned.transpose(2, 0, 1)]
+            for arr in arrays:
+                with self.subTest(dtype=dtype, shape=arr.shape,
+                                  strides=arr.strides,
+                                  aligned=arr.flags.aligned):
+                    self.check_sum(reduce, arr, self.default_dtype(arr.dtype))
+
+    def test_floating_accumulator_order(self):
+        @jit
+        def reduce(arr):
+            return np.sum(arr)
+
+        @jit
+        def reduce_float(arr):
+            return np.sum(arr, dtype=np.float64)
+
+        def arrays(dtype, large):
+            return (
+                np.array([[large, 1], [-large, 1]], dtype=dtype).T,
+                np.array([large, 1, 0, 0, -large, 1, 0, 0], dtype=dtype)
+                .reshape(2, 2, 2).transpose(2, 0, 1),
+            )
+
+        for dtype, large in ((np.float32, 2**24), (np.float64, 2**53),
+                             (np.complex128, 2**53)):
+            for arr in arrays(dtype, large):
+                got = np.asarray(reduce(arr), dtype=dtype)
+                expected = np.asarray(2, dtype=dtype)
+                with self.subTest(dtype=dtype, shape=arr.shape):
+                    self.assertEqual(got.tobytes(), expected.tobytes())
+
+        for arr in arrays(np.int64, 2**53):
+            self.assertEqual(np.float64(reduce_float(arr)).tobytes(),
+                             np.float64(2).tobytes())
+
+    def test_explicit_unaligned_signature(self):
+        array_type = types.Array(types.int64, 3, 'A', aligned=False)
+        reduce = jit(types.int64(array_type))(array_sum_global)
+        base = self.make_array(np.int64)
+        buffer = np.empty(base.nbytes + 1, dtype=np.uint8)
+        arr = np.ndarray(base.shape, dtype=np.int64, buffer=buffer, offset=1)
+        arr[...] = base
+        for values in (arr.transpose(2, 0, 1), arr[::-1, :, ::-1]):
+            self.assertEqual(reduce(values), self.modular_sum(values, np.int64))
+
+    def test_higher_rank_fallback(self):
+        reduce = jit(array_sum_global)
+        for ndim in (5, 8):
+            base = np.arange(24, dtype=np.int64).reshape(
+                (2, 3, 4) + (1,) * (ndim - 3))
+            arr = base.swapaxes(0, 1)
+            self.assertFalse(arr.flags.c_contiguous or arr.flags.f_contiguous)
+            self.check_sum(reduce, arr, np.int64)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This changes traversal for no-axis integer and boolean sums with integer
accumulators. Contiguous arrays use a flat physical scan. Arbitrary layouts
up to rank four normalize negative strides, order dimensions by stride magnitude
and coalesce contiguous dimensions. Higher-rank arbitrary layouts retain the
existing iterator. Per-element casts and accumulator selection are preserved;
the optimized path uses wrapping LLVM addition without no-overflow flags.

Floating-point/complex inputs, floating or boolean accumulators and explicit-axis
reductions keep their existing path. This is related to the layout performance
problem in https://github.com/numba/numba/issues/9819, but does not fix its
floating-point reproducer or request closing that issue.

Validation on the final source: 536 tests passed and three skipped across
`numba.tests.test_array_reductions` and `numba.tests.test_array_methods`.
Six added test methods cover 372 combinations. A separately constructed
Python-integer oracle passed 640 additional cases. These are differential
validation results, not an external audit. Repository-config lint reports no
new issues.

On one host, controlled before/after trials measured 13.6× for int64 transposed
and 28.4× for int32 Fortran-layout sums; an ad-hoc public-image processing
pipeline improved 1.49×. One int64 sliced control was 7.8% slower. These compare
patched against unpatched Numba, not NumPy; no multi-machine result is claimed.
All 22 cases, raw trials, exactness checks, earlier failed diagnostics and
reproduction instructions are in the
[evidence branch](https://github.com/JROChub/numba/tree/evidence/integer-sum-memory-order/benchmarks/integer_sum_memory_order).
