### PR TITLE
Update numpy min version to `1.22.3` from `1.22`

### DIFF
--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -32,11 +32,12 @@ def _ensure_critical_deps():
         raise ImportError(msg)
 
     import numpy as np
-    numpy_version = extract_version(np)
+    from numpy.lib import NumpyVersion
+    numpy_version = NumpyVersion(np.__version__)
 
-    if numpy_version < (1, 22):
-        msg = (f"Numba needs NumPy 1.22 or greater. Got NumPy "
-               f"{numpy_version[0]}.{numpy_version[1]}.")
+    if numpy_version < '1.22.3':
+        msg = (f"Numba needs NumPy 1.22.3 or greater. Got NumPy "
+               f"{numpy_version.major}.{numpy_version.minor}.")
         raise ImportError(msg)
 
     try:

--- a/numba/tests/test_import.py
+++ b/numba/tests/test_import.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest import mock
 from numba.tests.support import TestCase, run_in_subprocess
 from numba.core import utils
 import os
@@ -111,6 +112,31 @@ class TestNumbaImport(TestCase):
         # checks that "from numba import *" works.
         code = "from numba import *"
         run_in_subprocess(code)
+
+
+class TestEnsureCriticalDeps(TestCase):
+    def test_numpy_min(self):
+        import numpy as np
+        import numba
+        with mock.patch.object(np, '__version__', '1.22.2'):
+            with self.assertRaises(ImportError):
+                numba._ensure_critical_deps()
+        with mock.patch.object(np, '__version__', '1.22.3'):
+            numba._ensure_critical_deps()
+        with mock.patch.object(np, '__version__', '2.5.0rc1'):
+            numba._ensure_critical_deps()
+
+    def test_scipy_min(self):
+        import numba
+        try:
+            import scipy
+        except ImportError:
+            self.skipTest('scipy')
+        with mock.patch.object(scipy, '__version__', '0.19.1'):
+            with self.assertRaises(ImportError):
+                numba._ensure_critical_deps()
+        with mock.patch.object(scipy, '__version__', '1.0.0rc1'):
+            numba._ensure_critical_deps()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR updates min version gate for NumPy version to `>= 1.22.3`. (from `>=1.22`) to match conda recipe.
Adds test for minor version parsing support on `_ensure_critical_deps()`
This addresses review comment from https://github.com/numba/numba/pull/10827#issuecomment-5625496165
Assisted-by: Kilo